### PR TITLE
fix(index): eliminate non-deterministic silent chunk loss in full-corpus build (closes #1891, #1886)

### DIFF
--- a/src/cli/pipeline/chunkloss_interleaving_model.rs
+++ b/src/cli/pipeline/chunkloss_interleaving_model.rs
@@ -1,0 +1,676 @@
+//! Loom model of the index-pipeline chunk-loss protocol — the GPU/CPU
+//! work-steal race that fed two producers into one `store_stage` consumer and
+//! lost chunks non-deterministically on a full-corpus build (#1891, the
+//! interleaving-auditor validation lane).
+//!
+//! ## Why this module exists
+//!
+//! `run_index_pipeline` (`pipeline/mod.rs`) runs THREE threads over a file:
+//!
+//!   * a GPU embed stage and a CPU embed stage that BOTH work-steal `parse_rx`
+//!     and BOTH produce to a cloned `embed_tx` (`embedding.rs`);
+//!   * a single `store_stage` consumer that drains `embed_rx`, accumulates each
+//!     file's chunks per-origin, and flushes a file (writing its chunks +
+//!     pruning stale rows + stamping its reconcile fingerprint, one fused tx)
+//!     the moment that file's fingerprint arrives (`upsert.rs`).
+//!
+//! A file's fingerprint rides the batch carrying its LAST chunk. The flush
+//! PRUNES to the file's live id set. So if a file's chunks are scattered across
+//! two embed batches processed by the two stages at different speeds, the
+//! fingerprint-bearing batch (the file's "last" chunk) could reach `store_stage`
+//! BEFORE the file's earlier chunks — firing a flush+prune on a PARTIAL
+//! accumulator, then stranding the late-arriving chunks in a fresh accum that
+//! never flushes. That is the confirmed silent, non-deterministic chunk loss.
+//!
+//! The house unit suite runs single-threaded by construction: it cannot place
+//! the two producers' sends in the adversarial order. The lane's deterministic
+//! `store_stage_out_of_order_*` tests feed ONE channel in a fixed bad order;
+//! they assert the consumer survives that ONE schedule. This module goes
+//! further: it runs the actual two-producer race (GPU + CPU) as loom threads,
+//! captures the order their messages land on `embed_tx`, drains that order
+//! through the real `store_stage` flush logic, and asserts the no-loss invariant
+//! after EVERY interleaving loom explores — the structural null the
+//! deterministic test cannot reach.
+//!
+//! ## The fix under validation (two layers)
+//!
+//!   1. **Parser file-alignment** (`parsing.rs` `file_aligned_take`): a file's
+//!      whole contiguous chunk run rides exactly ONE `ParsedBatch`, so a file is
+//!      processed by exactly ONE embed stage. Its chunks + fingerprint then
+//!      travel together (or, on a GPU-failure split, cached-then-requeued in
+//!      FIFO order on the single `embed_tx`). This makes completion
+//!      order-independent BY CONSTRUCTION.
+//!   2. **store_stage additive-reflush net** (`upsert.rs` `flushed` map): a late
+//!      batch for an already-flushed file triggers an ADDITIVE re-flush whose
+//!      prune live set is the UNION of prior-committed ids and the new chunks —
+//!      so nothing the file produced is pruned away even if a chunk arrives
+//!      after the flush.
+//!
+//! ## The invariant under test
+//!
+//! > **NO-LOSS**: after the pipeline drains for a file, the store holds EXACTLY
+//! > the set of chunk ids the parser produced for that file — none lost, none
+//! > duplicated — AND the file is stamped (its fingerprint committed) iff every
+//! > one of its chunks committed. There is no interleaving of the two producers
+//! > under which a parsed chunk is absent from the store at quiesce.
+//!
+//! ## What the model abstracts (the bounded shape loom needs)
+//!
+//! - A file `F` with three chunk ids `{a, b, c}`. `c` is the file's LAST chunk,
+//!   so the fingerprint rides `c`'s batch (the production stamping rule).
+//! - `embed_tx` / `fail_tx` are modelled as `Mutex<Vec<Msg>>` FIFO queues (the
+//!   reconcile-model house style: all shared state behind `Mutex`, no loom mpsc
+//!   — whose `Receiver::drop` re-enters the runtime and aborts a model that
+//!   panics, masking the real assertion). A `Mutex` push gives the same
+//!   release/acquire happens-before a real channel send does, which is exactly
+//!   the edge the cached-before-requeued ordering rests on.
+//! - The contended thing is the ORDER messages land on `embed_tx`, set by the
+//!   two producer threads + the `fail_tx -> fail_rx` handoff. The two producers
+//!   are loom threads; loom explores their interleaving. The single `store_stage`
+//!   consumer then drains the resulting `embed_tx` order on the main thread (it
+//!   is the SOLE consumer — no consumer/consumer race exists to model), so its
+//!   logic runs against every producer interleaving loom found.
+//! - The GPU-failure split is modelled to the letter of `flush_to_cpu`: the
+//!   cached half goes to `embed_tx` with F's fingerprint DROPPED (F has chunks
+//!   in `to_embed`), then the requeued half goes to `fail_tx` carrying F's
+//!   fingerprint; the CPU stage pops it from `fail_tx` and forwards it to
+//!   `embed_tx`. The cached-before-requeued happens-before is therefore a real
+//!   lock-ordering edge, not an assumption — loom explores a reordering if one
+//!   were possible.
+//!
+//! ## Running
+//!
+//! Loom tests do not run in the normal suite (this module is
+//! `#![cfg(all(cqs_loom, test))]`, absent from a normal build). Run:
+//!
+//! ```bash
+//! RUSTFLAGS="--cfg cqs_loom" CARGO_TARGET_DIR=<private-loom-dir> \
+//!     cargo test --features cuda-index --bin cqs chunkloss_interleaving_model
+//! ```
+//!
+//! All safety models here are GREEN: the protocol upholds NO-LOSS under every
+//! interleaving loom explores. The `#[ignore]`d `..._would_lose_a_chunk` model
+//! is the negative control — it reverts BOTH fix layers (flush+prune on
+//! fingerprint with a partial live set, no additive net) and the FIFO ordering
+//! edge, and loom finds the schedule that drops chunk `c`'s earlier siblings,
+//! proving the test has teeth.
+
+#![cfg(all(cqs_loom, test))]
+
+use std::collections::HashSet;
+
+use loom::sync::{Arc, Mutex};
+use loom::thread;
+
+/// A parsed chunk id. In production this is `{path}:{line}:{byte}:{hash8}`; here
+/// a single char stands for each of file F's three chunks.
+type ChunkId = char;
+
+/// File F's full parsed chunk set, in parse order. `c` is the file's LAST chunk,
+/// so the fingerprint rides `c`'s batch (the production stamping rule).
+const F_CHUNKS: [ChunkId; 3] = ['a', 'b', 'c'];
+const F_LAST: ChunkId = 'c';
+
+/// A message on `embed_tx` / `fail_tx`, the faithful `EmbeddedBatch` /
+/// `ParsedBatch` shape reduced to what the no-loss invariant depends on: the
+/// chunk ids it carries and whether it carries F's fingerprint (the completion
+/// signal). `has_fp` true ⇔ F's last chunk's batch (or the requeued half that
+/// holds the fingerprint across a GPU split).
+#[derive(Clone, Debug)]
+struct Msg {
+    chunks: Vec<ChunkId>,
+    has_fp: bool,
+}
+
+/// A FIFO queue behind a `Mutex` — the house-style stand-in for a crossbeam
+/// channel. A push under the lock and a later pop under the lock are ordered by
+/// the lock's release/acquire, the same happens-before a channel send/recv
+/// gives. Single-consumer (matches `embed_rx` / `fail_rx`).
+#[derive(Default)]
+struct Queue {
+    items: Vec<Msg>,
+}
+
+impl Queue {
+    fn push(q: &Mutex<Queue>, msg: Msg) {
+        q.lock().unwrap().items.push(msg);
+    }
+    /// Pop the front item if present (FIFO). Returns `None` when empty.
+    fn pop(q: &Mutex<Queue>) -> Option<Msg> {
+        let mut g = q.lock().unwrap();
+        if g.items.is_empty() {
+            None
+        } else {
+            Some(g.items.remove(0))
+        }
+    }
+    fn drain(q: &Mutex<Queue>) -> Vec<Msg> {
+        std::mem::take(&mut q.lock().unwrap().items)
+    }
+}
+
+/// The committed store state for file F. `committed` is the set of chunk ids
+/// written; `stamped` is whether F's fingerprint was committed.
+#[derive(Default)]
+struct Store {
+    committed: HashSet<ChunkId>,
+    stamped: bool,
+}
+
+/// The store_stage consumer's per-run scratch: the in-flight accumulator (chunks
+/// arrived for F but not yet flushed) and the "flushed" net (F's fingerprint
+/// arrived once, with the cumulative committed id set — the additive-reflush
+/// safety net).
+#[derive(Default)]
+struct Consumer {
+    accum: Vec<ChunkId>,
+    /// `Some(prior_ids)` once F has been flushed at least once this run. Mirrors
+    /// `store_stage`'s `flushed: HashMap<PathBuf, (fp, HashSet<id>)>`.
+    flushed: Option<HashSet<ChunkId>>,
+}
+
+/// THE FIXED store_stage flush: write the accum's chunks AND prune to the UNION
+/// of (this flush's ids) ∪ (prior-committed ids). The union prune is the
+/// additive net — it never deletes a chunk an earlier (out-of-order) flush
+/// committed. Faithful to `flush_file`'s `live_ids = own_ids ∪ extra_live_ids`.
+fn flush_fixed(store: &mut Store, consumer: &mut Consumer, stamp: bool) {
+    let own: HashSet<ChunkId> = consumer.accum.drain(..).collect();
+    let prior = consumer.flushed.clone().unwrap_or_default();
+    let live: HashSet<ChunkId> = own.union(&prior).copied().collect();
+
+    // Prune: keep only `live` (delete anything for F not in the union).
+    store.committed.retain(|id| live.contains(id));
+    // Write this flush's own chunks.
+    store.committed.extend(own.iter().copied());
+    if stamp {
+        store.stamped = true;
+    }
+
+    // Record the cumulative committed set so a later additive flush unions in.
+    let entry = consumer.flushed.get_or_insert_with(HashSet::new);
+    entry.extend(own);
+}
+
+/// The store_stage consumer body (FIXED). Drains the captured `embed_tx` message
+/// order, accumulating chunks per the production rules and flushing on the
+/// fingerprint signal (plus the additive late-arrival re-flush + residual pass).
+fn store_stage_fixed(store: &mut Store, msgs: Vec<Msg>) {
+    let mut consumer = Consumer::default();
+    for msg in msgs {
+        consumer.accum.extend(msg.chunks.iter().copied());
+        if msg.has_fp {
+            // Fingerprint arrived → flush (complete in the in-order path;
+            // out-of-order it may be partial, but the additive net + the
+            // late/residual passes catch the rest).
+            flush_fixed(store, &mut consumer, true);
+        } else if consumer.flushed.is_some() && !consumer.accum.is_empty() {
+            // LATE-ARRIVAL additive flush: F already flushed, more chunks
+            // arrived. Re-flush additively (no new stamp). Mirrors the per-batch
+            // late pass in `store_stage`.
+            flush_fixed(store, &mut consumer, false);
+        }
+    }
+    // Residual / end-of-stream additive flush: leftover accum for a file that
+    // WAS flushed. Mirrors the belt-and-suspenders residual pass.
+    if consumer.flushed.is_some() && !consumer.accum.is_empty() {
+        flush_fixed(store, &mut consumer, false);
+    }
+    // An accum with chunks but NO prior flush is an incomplete file (fingerprint
+    // never arrived): left unwritten by design. Under file-alignment the
+    // fingerprint always arrives WITH the file's chunks, so this never strands a
+    // chunk the parser produced — the models below confirm it.
+}
+
+/// THE BUGGY store_stage flush (negative control): prune to ONLY this flush's
+/// ids — no union with prior-committed ids, no additive net. This is the
+/// pre-fix shape: a fingerprint flush prunes the file to the partial set it can
+/// see, deleting earlier-arriving chunks, and a fresh accum that fills AFTER the
+/// fingerprint was consumed never flushes.
+fn store_stage_buggy(store: &mut Store, msgs: Vec<Msg>) {
+    let mut accum: Vec<ChunkId> = Vec::new();
+    for msg in msgs {
+        accum.extend(msg.chunks.iter().copied());
+        if msg.has_fp {
+            let own: HashSet<ChunkId> = accum.drain(..).collect();
+            // BUG: prune to ONLY own ids — no union with prior commits.
+            store.committed.retain(|id| own.contains(id));
+            store.committed.extend(own.iter().copied());
+            store.stamped = true;
+            // BUG: no `flushed` record → a later batch for F is treated as a
+            // brand-new file whose accum is never flushed on a non-fp message.
+        }
+        // No additive late-arrival pass — chunks after the fingerprint sit in a
+        // fresh accum that never flushes.
+    }
+    // No residual additive flush.
+}
+
+/// NO-LOSS assertion: the store holds EXACTLY F's parsed chunk set, and F is
+/// stamped (it completed). Run after both producers join and the consumer drains.
+fn assert_no_loss(store: &Store) {
+    for id in F_CHUNKS {
+        assert!(
+            store.committed.contains(&id),
+            "NO-LOSS VIOLATED: chunk {id:?} is absent from the store at quiesce — \
+             a producer interleaving stranded or pruned it (committed = {:?})",
+            store.committed,
+        );
+    }
+    assert_eq!(
+        store.committed.len(),
+        F_CHUNKS.len(),
+        "NO-LOSS VIOLATED: store holds {} ids, expected {} (duplicate or foreign id): {:?}",
+        store.committed.len(),
+        F_CHUNKS.len(),
+        store.committed,
+    );
+    assert!(
+        store.stamped,
+        "NO-LOSS VIOLATED: F completed (all chunks present) but was never stamped — \
+         the next run would needlessly re-index it, and a real partial flush would \
+         have stamped it AHEAD of its data",
+    );
+}
+
+// ===========================================================================
+// MODEL 1 (safety, GREEN): the GPU-failure split under file-alignment.
+//
+// File F rides ONE ParsedBatch (file-alignment). The GPU stage grabs it, splits
+// it into a cached half {a, b} and a to_embed half {c} (the LAST chunk — so the
+// fingerprint would ride c). The GPU embed FAILS, so `flush_to_cpu` runs:
+//   * cached half {a, b} -> embed_tx with F's fingerprint DROPPED (F has chunks
+//     in to_embed);
+//   * requeued half {c}  -> fail_tx carrying F's fingerprint.
+// The CPU stage pops {c}+fp from fail_tx, re-embeds, pushes it to embed_tx.
+//
+// Loom explores every interleaving of the GPU and CPU threads. The load-bearing
+// question: can {c}+fp ever land on embed_tx BEFORE {a, b}? It cannot — the lock
+// edges (GPU pushes cached to embed_tx THEN to fail_tx; CPU pops fail_tx THEN
+// pushes to embed_tx) force cached-before-requeued. The model captures embed_tx's
+// final order, drains it through the FIXED store_stage, and asserts NO-LOSS after
+// every schedule.
+// ===========================================================================
+#[test]
+fn gpu_failure_split_loses_nothing_under_file_alignment() {
+    loom::model(|| {
+        let embed_tx = Arc::new(Mutex::new(Queue::default()));
+        let fail_tx = Arc::new(Mutex::new(Queue::default()));
+
+        // GPU stage: cached half to embed_tx (fp dropped), requeued to fail_tx.
+        let embed_gpu = Arc::clone(&embed_tx);
+        let fail_gpu = Arc::clone(&fail_tx);
+        let gpu = thread::spawn(move || {
+            // cached half {a, b}: F has chunks in to_embed, so its fingerprint is
+            // DROPPED here (faithful to flush_to_cpu's cached_fps filter).
+            Queue::push(
+                &embed_gpu,
+                Msg {
+                    chunks: vec!['a', 'b'],
+                    has_fp: false,
+                },
+            );
+            // requeued half {c}: carries F's fingerprint (lands last).
+            Queue::push(
+                &fail_gpu,
+                Msg {
+                    chunks: vec![F_LAST],
+                    has_fp: true,
+                },
+            );
+        });
+
+        // CPU stage: pop fail_tx, forward to embed_tx. The pop happens-after the
+        // GPU's push to fail_tx; the GPU's push to embed_tx happens-before its
+        // push to fail_tx; so the forwarded msg's embed_tx push is ordered AFTER
+        // the cached half's. (If fail_tx is momentarily empty the CPU yields and
+        // retries — loom bounds this since the GPU push is the only producer.)
+        let embed_cpu = Arc::clone(&embed_tx);
+        let fail_cpu = Arc::clone(&fail_tx);
+        let cpu = thread::spawn(move || loop {
+            match Queue::pop(&fail_cpu) {
+                Some(requeued) => {
+                    Queue::push(&embed_cpu, requeued);
+                    break;
+                }
+                None => thread::yield_now(),
+            }
+        });
+
+        gpu.join().unwrap();
+        cpu.join().unwrap();
+
+        // store_stage is the SOLE consumer; drain embed_tx's final order through
+        // the real flush logic. (No consumer/consumer race exists to model.)
+        let msgs = Queue::drain(&embed_tx);
+        let mut store = Store::default();
+        store_stage_fixed(&mut store, msgs);
+        assert_no_loss(&store);
+    });
+}
+
+// ===========================================================================
+// MODEL 2 (safety, GREEN): two producers racing into the shared embed_tx on
+// DISTINCT in-order files.
+//
+// File-alignment guarantees a file rides one stage in order, but the GPU and CPU
+// stages run CONCURRENTLY on different files. This models F (all chunks + fp in
+// one in-order batch) sent by the GPU stage, racing a wholly independent file
+// 'z' sent by the CPU stage, both into the shared embed_tx. The two producers'
+// pushes interleave arbitrarily (loom explores both orders), yet F's single
+// batch carries its chunks AND fingerprint together, so F flushes atomically
+// regardless of where 'z' lands relative to it. Cross-file independence
+// (store_stage keys accums by origin) is pinned: 'z' never lands in F's set.
+// ===========================================================================
+#[test]
+fn in_order_file_unaffected_by_concurrent_producer() {
+    loom::model(|| {
+        let embed_tx = Arc::new(Mutex::new(Queue::default()));
+
+        // GPU stage: F's whole run + fingerprint in ONE batch (file-aligned,
+        // in-order — the common production path).
+        let embed_gpu = Arc::clone(&embed_tx);
+        let gpu = thread::spawn(move || {
+            Queue::push(
+                &embed_gpu,
+                Msg {
+                    chunks: F_CHUNKS.to_vec(),
+                    has_fp: true,
+                },
+            );
+        });
+
+        // CPU stage: a concurrent, independent batch for a DIFFERENT file ('z').
+        let embed_cpu = Arc::clone(&embed_tx);
+        let cpu = thread::spawn(move || {
+            Queue::push(
+                &embed_cpu,
+                Msg {
+                    chunks: vec!['z'],
+                    has_fp: true,
+                },
+            );
+        });
+
+        gpu.join().unwrap();
+        cpu.join().unwrap();
+
+        // Drain through a consumer scoped to F (a foreign origin has its own
+        // accum/flush path — cross-file independence).
+        let msgs = Queue::drain(&embed_tx);
+        let mut store = Store::default();
+        let mut consumer = Consumer::default();
+        for msg in msgs {
+            let f_chunks: Vec<ChunkId> = msg
+                .chunks
+                .iter()
+                .copied()
+                .filter(|id| F_CHUNKS.contains(id))
+                .collect();
+            let is_f = !f_chunks.is_empty();
+            consumer.accum.extend(f_chunks);
+            if msg.has_fp && is_f {
+                flush_fixed(&mut store, &mut consumer, true);
+            }
+        }
+        assert_no_loss(&store);
+    });
+}
+
+// ===========================================================================
+// MODEL 3 (safety, GREEN): the ADVERSARIAL out-of-order arrival the additive net
+// defends — fingerprint-bearing chunk c lands FIRST, THEN earlier chunks a, b
+// arrive late. This is the schedule a FUTURE regression (re-introducing a file
+// straddle across the work-steal so the two halves race with NO ordering edge)
+// would produce. Two producer threads push the two halves into embed_tx with NO
+// causal edge between them, so loom explores BOTH landing orders. The fix's
+// additive-reflush net must keep a and b regardless of order.
+//
+// This is the loom-generalised form of the lane's deterministic
+// `store_stage_out_of_order_fingerprint_before_chunks_loses_nothing` test: that
+// test pins ONE order; here loom explores the order AND the (single-consumer)
+// drain handles both.
+// ===========================================================================
+#[test]
+fn out_of_order_halves_keep_every_chunk_either_order() {
+    loom::model(|| {
+        let embed_tx = Arc::new(Mutex::new(Queue::default()));
+
+        // Producer 1: the fingerprint-bearing "last chunk" c.
+        let e1 = Arc::clone(&embed_tx);
+        let p1 = thread::spawn(move || {
+            Queue::push(
+                &e1,
+                Msg {
+                    chunks: vec![F_LAST],
+                    has_fp: true,
+                },
+            );
+        });
+        // Producer 2: the earlier chunks a, b (no fingerprint). NO edge to p1,
+        // so loom runs them in either order.
+        let e2 = Arc::clone(&embed_tx);
+        let p2 = thread::spawn(move || {
+            Queue::push(
+                &e2,
+                Msg {
+                    chunks: vec!['a', 'b'],
+                    has_fp: false,
+                },
+            );
+        });
+
+        p1.join().unwrap();
+        p2.join().unwrap();
+
+        let msgs = Queue::drain(&embed_tx);
+        let mut store = Store::default();
+        store_stage_fixed(&mut store, msgs);
+        assert_no_loss(&store);
+    });
+}
+
+// ===========================================================================
+// MODEL 4 (safety, GREEN): the DUPLICATE-FINGERPRINT hazard a multi-file
+// GPU-failure split introduces, and that two individually-correct ops compose
+// into.
+//
+// `flush_to_cpu` (`embedding.rs`) sends the cached half with fingerprints DROPPED
+// for files present in `to_embed`, but sends the requeued half with the FULL
+// `prepared.file_fingerprints` set. So when a batch packs file F (straddling
+// cached+to_embed) AND file G (fully in the cached half), G's fingerprint rides
+// BOTH halves: the cached half (kept, since G ∉ to_embed) AND the requeued half
+// (the full-set send). G's fingerprint therefore reaches `store_stage` TWICE.
+//
+//   * Op 1 — `flush_to_cpu` sending the full fp set on the requeued half: correct
+//     in isolation (the requeued half is the completion signal for the straddling
+//     files, and reusing the full map is the simplest faithful carrier).
+//   * Op 2 — `store_stage` flushing-and-pruning on a fingerprint: correct in
+//     isolation (a fingerprint means the file is complete; prune drops stale
+//     rows).
+//
+// Their COMPOSITION must not let G's SECOND fingerprint re-prune G to nothing.
+// In production the second fp hits the `None` arm (chunk-bearing fingerprint with
+// no accumulated chunks — G's accum was consumed by the first flush): it
+// re-stamps the in-memory fp WITHOUT a prune. The model reproduces both files,
+// both fp arrivals for G, the cached-before-requeued ordering, and asserts BOTH F
+// and G survive intact.
+//
+// The load-bearing safety: the second (empty-accum, already-flushed) flush unions
+// `own={}` with G's prior committed ids, so the prune is a no-op. A regression
+// that made the `None` arm prune to the (empty) accum would wipe G — this model
+// would catch it.
+// ===========================================================================
+#[test]
+fn multi_file_split_duplicate_fingerprint_does_not_reprune() {
+    // G's chunks (fully cached). F is the straddling file (a,b cached; c requeued).
+    const G_CHUNKS: [ChunkId; 2] = ['x', 'y'];
+
+    loom::model(|| {
+        let embed_tx = Arc::new(Mutex::new(Queue::default()));
+        let fail_tx = Arc::new(Mutex::new(Queue::default()));
+
+        // GPU stage on a batch packing F (straddle) + G (fully cached), GPU embed
+        // fails → flush_to_cpu:
+        //   cached half: {a, b} (F) + {x, y} (G); fp KEPT for G (G ∉ to_embed),
+        //               DROPPED for F (F ∈ to_embed).
+        //   requeued half: {c} (F); fp set = FULL {F, G} (the full-map send).
+        let embed_gpu = Arc::clone(&embed_tx);
+        let fail_gpu = Arc::clone(&fail_tx);
+        let gpu = thread::spawn(move || {
+            Queue::push(
+                &embed_gpu,
+                Msg {
+                    // cached half: F's a,b + G's x,y. `has_fp` is F-scoped in the
+                    // shared `Msg`; G's fingerprint on this half is derived in the
+                    // drain below from the presence of G's chunks (`contains('x')`),
+                    // faithful to `cached_fps` keeping G (G ∉ to_embed).
+                    chunks: vec!['a', 'b', 'x', 'y'],
+                    has_fp: false,
+                },
+            );
+            // requeued half: F's c, fp set = FULL {F, G}.
+            Queue::push(
+                &fail_gpu,
+                Msg {
+                    chunks: vec![F_LAST],
+                    has_fp: true,
+                },
+            );
+        });
+
+        let embed_cpu = Arc::clone(&embed_tx);
+        let fail_cpu = Arc::clone(&fail_tx);
+        let cpu = thread::spawn(move || loop {
+            match Queue::pop(&fail_cpu) {
+                Some(requeued) => {
+                    Queue::push(&embed_cpu, requeued);
+                    break;
+                }
+                None => thread::yield_now(),
+            }
+        });
+
+        gpu.join().unwrap();
+        cpu.join().unwrap();
+
+        // Per-file drain, faithful to store_stage's per-origin keying. We model the
+        // fingerprint carriage explicitly per the flush_to_cpu split:
+        //   - cached half (msg 0): carries G's fingerprint (G fully cached).
+        //   - requeued half (msg 1, has_fp): carries F's AND G's fingerprints
+        //     (the full-set send) — G's is the DUPLICATE.
+        let msgs = Queue::drain(&embed_tx);
+        let mut store_f = Store::default();
+        let mut store_g = Store::default();
+        let mut cons_f = Consumer::default();
+        let mut cons_g = Consumer::default();
+
+        for msg in &msgs {
+            // Accumulate per origin.
+            for &id in &msg.chunks {
+                if F_CHUNKS.contains(&id) {
+                    cons_f.accum.push(id);
+                } else if G_CHUNKS.contains(&id) {
+                    cons_g.accum.push(id);
+                }
+            }
+            // Which files' fingerprints does THIS message carry?
+            //   cached half (the !has_fp one that holds G's chunks): G's fp.
+            //   requeued half (has_fp): F's fp + G's fp (full-set DUPLICATE).
+            let carries_g_fp = msg.chunks.contains(&'x') || msg.has_fp;
+            let carries_f_fp = msg.has_fp;
+
+            // G flush: if G's accum has chunks → flush; if G already flushed and
+            // this is the duplicate fp with empty accum → the None-arm no-op
+            // (flush_fixed unions own={} with prior, pruning nothing).
+            if carries_g_fp && (!cons_g.accum.is_empty() || cons_g.flushed.is_some()) {
+                flush_fixed(&mut store_g, &mut cons_g, true);
+            }
+            if carries_f_fp {
+                flush_fixed(&mut store_f, &mut cons_f, true);
+            }
+        }
+
+        // BOTH files intact: G survived the duplicate fingerprint (no re-prune),
+        // F survived the straddle split.
+        assert_no_loss(&store_f);
+        // G's own no-loss check (G_CHUNKS, stamped).
+        for id in G_CHUNKS {
+            assert!(
+                store_g.committed.contains(&id),
+                "NO-LOSS VIOLATED: G's chunk {id:?} was re-pruned by its DUPLICATE \
+                 fingerprint on the requeued half (committed = {:?})",
+                store_g.committed,
+            );
+        }
+        assert_eq!(
+            store_g.committed.len(),
+            G_CHUNKS.len(),
+            "NO-LOSS VIOLATED: G holds {} ids, expected {}: {:?}",
+            store_g.committed.len(),
+            G_CHUNKS.len(),
+            store_g.committed,
+        );
+        assert!(
+            store_g.stamped,
+            "G must remain stamped after the duplicate fp"
+        );
+    });
+}
+
+// ===========================================================================
+// NEGATIVE CONTROL (`#[ignore]`, FAILS by design): proves the model has teeth.
+// Revert BOTH fix layers: (1) the producers straddle F across two batches with
+// NO ordering edge so its fingerprint-bearing chunk c can race ahead, and (2)
+// the consumer flush-prunes on the fingerprint with ONLY the chunks-so-far (no
+// union, no additive net). Loom finds the schedule where c lands first, the
+// consumer flushes and prunes the store to {c}, then a,b land in a fresh accum
+// that never flushes — a and b are LOST.
+//
+// Run with `--ignored` to observe the failure:
+//   RUSTFLAGS="--cfg cqs_loom" cargo test --features cuda-index --bin cqs \
+//       chunkloss_interleaving_model -- --ignored
+// ===========================================================================
+#[test]
+#[ignore = "negative control: reproduces the #1891 chunk-loss schedule with both fix layers \
+            reverted (file straddle + non-additive flush); FAILS by design"]
+fn straddle_with_nonadditive_flush_would_lose_a_chunk() {
+    loom::model(|| {
+        let embed_tx = Arc::new(Mutex::new(Queue::default()));
+
+        // Producer A: the fingerprint-bearing LAST chunk c (the straddle's
+        // second half), able to race ahead of producer B (no ordering edge).
+        let ea = Arc::clone(&embed_tx);
+        let pa = thread::spawn(move || {
+            Queue::push(
+                &ea,
+                Msg {
+                    chunks: vec![F_LAST],
+                    has_fp: true,
+                },
+            );
+        });
+        // Producer B: the earlier chunks a, b (no fingerprint), the straddle's
+        // first half.
+        let eb = Arc::clone(&embed_tx);
+        let pb = thread::spawn(move || {
+            Queue::push(
+                &eb,
+                Msg {
+                    chunks: vec!['a', 'b'],
+                    has_fp: false,
+                },
+            );
+        });
+
+        pa.join().unwrap();
+        pb.join().unwrap();
+
+        let msgs = Queue::drain(&embed_tx);
+        let mut store = Store::default();
+        // BUGGY consumer: non-additive flush, no net.
+        store_stage_buggy(&mut store, msgs);
+        // FAILS on the schedule where A's {c}+fp is consumed and flushed (prune
+        // to {c}) before B's {a, b} arrive — a and b are stranded/pruned.
+        assert_no_loss(&store);
+    });
+}

--- a/src/cli/pipeline/chunkloss_interleaving_model.rs
+++ b/src/cli/pipeline/chunkloss_interleaving_model.rs
@@ -618,6 +618,364 @@ fn multi_file_split_duplicate_fingerprint_does_not_reprune() {
 }
 
 // ===========================================================================
+// CALL-GRAPH DIMENSION — validating the LATE-LANDING P2 FIX (the additive
+// re-flush's wholesale-DELETE call-graph wipe). This fix was committed AFTER the
+// chunk-loss models above; it lives in the SAME additive-net region this lane
+// audits, so the producer-interleaving validation belongs here too.
+//
+// `write_function_calls_in_tx` (`store/calls/crud.rs`) does an UNCONDITIONAL
+// `DELETE FROM function_calls WHERE file = ?` then inserts the supplied set. So a
+// flush that supplies an EMPTY relationship set deletes the file's whole call
+// graph and inserts nothing. The additive re-flush (chunk-loss net layer 2)
+// originally flushed a fresh accumulator whose `function_calls` were empty
+// (relationships ride the first batch, drained into the accum the FIRST flush
+// consumed) — so a late additive flush WIPED the call graph the first flush
+// wrote: chunks survived (union-prune), the call graph silently vanished.
+//
+// The fix: the `flushed` state carries the CUMULATIVE relationships, re-supplied
+// on EVERY flush, so the wholesale DELETE-then-INSERT reconstructs the graph.
+//
+// > **CALL-GRAPH-FIDELITY**: after any producer interleaving, the file's
+// > committed call graph equals the cumulative call set the parser produced —
+// > never wiped to empty by a later additive flush, never orphaned.
+// ===========================================================================
+
+/// A call edge `(caller, callee)` — the `function_calls` row reduced to what the
+/// fidelity invariant depends on.
+type Edge = (char, char);
+
+/// A relationship-aware message: chunk ids + whether it carries the fingerprint
+/// + the call edges riding THIS batch (relationships ride the first batch in
+/// production; the GPU-split requeued half carries the full set).
+#[derive(Clone, Debug)]
+struct RelMsg {
+    chunks: Vec<ChunkId>,
+    has_fp: bool,
+    edges: Vec<Edge>,
+}
+
+/// A relationship FIFO queue behind a `Mutex` (house-style channel stand-in).
+#[derive(Default)]
+struct RelQueue {
+    items: Vec<RelMsg>,
+}
+
+impl RelQueue {
+    fn push(q: &Mutex<RelQueue>, msg: RelMsg) {
+        q.lock().unwrap().items.push(msg);
+    }
+    fn pop(q: &Mutex<RelQueue>) -> Option<RelMsg> {
+        let mut g = q.lock().unwrap();
+        if g.items.is_empty() {
+            None
+        } else {
+            Some(g.items.remove(0))
+        }
+    }
+    fn drain(q: &Mutex<RelQueue>) -> Vec<RelMsg> {
+        std::mem::take(&mut q.lock().unwrap().items)
+    }
+}
+
+/// The store's committed call graph for file F. The wholesale write REPLACES it
+/// with the supplied set (DELETE-then-INSERT), so a flush with an empty supplied
+/// set leaves it empty.
+#[derive(Default)]
+struct CallStore {
+    chunks: HashSet<ChunkId>,
+    edges: HashSet<Edge>,
+    stamped: bool,
+}
+
+/// Consumer scratch for the call-graph dimension: chunk accum + the cumulative
+/// `flushed` state (committed ids AND cumulative edges — the P2-fix carry-forward).
+#[derive(Default)]
+struct CallConsumer {
+    accum: Vec<ChunkId>,
+    accum_edges: Vec<Edge>,
+    flushed: Option<(HashSet<ChunkId>, HashSet<Edge>)>,
+}
+
+/// THE FIXED flush: re-supply the CUMULATIVE edge set on every flush (the
+/// wholesale write replaces the store's edges with it), and union-prune chunks.
+fn call_flush_fixed(store: &mut CallStore, c: &mut CallConsumer, stamp: bool) {
+    let own_ids: HashSet<ChunkId> = c.accum.drain(..).collect();
+    let new_edges: Vec<Edge> = c.accum_edges.drain(..).collect();
+
+    let (prior_ids, mut cum_edges) = c.flushed.take().unwrap_or_default();
+    // Cumulative edges = prior ∪ this batch's edges (the flushed-state merge).
+    cum_edges.extend(new_edges.iter().copied());
+    let live: HashSet<ChunkId> = own_ids.union(&prior_ids).copied().collect();
+
+    // Wholesale call-graph write: REPLACE the store's edges with the cumulative
+    // set (DELETE-then-INSERT). Because cum_edges carries forward, this rebuilds
+    // — never wipes.
+    store.edges = cum_edges.clone();
+    // Union-prune chunks.
+    store.chunks.retain(|id| live.contains(id));
+    store.chunks.extend(own_ids.iter().copied());
+    if stamp {
+        store.stamped = true;
+    }
+
+    let mut next_ids = prior_ids;
+    next_ids.extend(own_ids);
+    c.flushed = Some((next_ids, cum_edges));
+}
+
+/// THE BUGGY flush (negative control): supply ONLY this batch's edges to the
+/// wholesale write (no carry-forward). A late additive flush whose batch carried
+/// NO edges therefore supplies an empty set → the DELETE wipes the graph.
+fn call_flush_buggy(store: &mut CallStore, c: &mut CallConsumer, stamp: bool) {
+    let own_ids: HashSet<ChunkId> = c.accum.drain(..).collect();
+    let new_edges: HashSet<Edge> = c.accum_edges.drain(..).collect();
+    let (prior_ids, _) = c.flushed.take().unwrap_or_default();
+    let live: HashSet<ChunkId> = own_ids.union(&prior_ids).copied().collect();
+
+    // BUG: wholesale write with ONLY this batch's edges (no cumulative). When the
+    // late additive batch has no edges, this DELETE-then-INSERT wipes the graph.
+    store.edges = new_edges;
+    store.chunks.retain(|id| live.contains(id));
+    store.chunks.extend(own_ids.iter().copied());
+    if stamp {
+        store.stamped = true;
+    }
+    let mut next_ids = prior_ids;
+    next_ids.extend(own_ids);
+    // Note: still records ids (so chunks survive) but DROPS edges — the precise
+    // pre-P2-fix shape (chunks ok, call graph wiped).
+    c.flushed = Some((next_ids, HashSet::new()));
+}
+
+/// The expected cumulative call graph the parser produced for F.
+const F_EDGES: [Edge; 1] = [('a', 'v')]; // chunk `a` (caller) calls `v` (victim)
+
+fn assert_call_graph_intact(store: &CallStore) {
+    for &e in &F_EDGES {
+        assert!(
+            store.edges.contains(&e),
+            "CALL-GRAPH-FIDELITY VIOLATED: edge {e:?} absent — an additive re-flush \
+             supplied an empty relationship set and the wholesale DELETE wiped the \
+             call graph (edges = {:?})",
+            store.edges,
+        );
+    }
+    // Chunks must also survive (the union-prune); a wiped graph with surviving
+    // chunks is the exact pre-fix asymmetry.
+    assert!(
+        store.chunks.contains(&'a'),
+        "the caller chunk must survive alongside its edge (chunks = {:?})",
+        store.chunks,
+    );
+}
+
+// MODEL 5 (safety, GREEN): the GPU-failure split carries relationships on the
+// requeued half (the full set), with the cached half carrying NONE (faithful to
+// flush_to_cpu sending `RelationshipData::default()` on the cached half when
+// to_embed is non-empty). The additive interactions must leave F's call graph
+// intact. Loom explores the GPU/CPU producer interleaving; the fixed
+// carry-forward flush keeps the edge under every schedule.
+#[test]
+fn gpu_split_relationships_survive_call_graph_intact() {
+    loom::model(|| {
+        let embed_tx = Arc::new(Mutex::new(RelQueue::default()));
+        let fail_tx = Arc::new(Mutex::new(RelQueue::default()));
+
+        // GPU stage (embed fails → flush_to_cpu):
+        //   cached half: {a} (the caller chunk), NO fp, NO edges (cached half
+        //     sends RelationshipData::default() when to_embed is non-empty).
+        //   requeued half: {c} (F's last chunk), fp, FULL edges {(a,v)}.
+        let embed_gpu = Arc::clone(&embed_tx);
+        let fail_gpu = Arc::clone(&fail_tx);
+        let gpu = thread::spawn(move || {
+            RelQueue::push(
+                &embed_gpu,
+                RelMsg {
+                    chunks: vec!['a'],
+                    has_fp: false,
+                    edges: vec![],
+                },
+            );
+            RelQueue::push(
+                &fail_gpu,
+                RelMsg {
+                    chunks: vec![F_LAST],
+                    has_fp: true,
+                    edges: vec![('a', 'v')],
+                },
+            );
+        });
+
+        let embed_cpu = Arc::clone(&embed_tx);
+        let fail_cpu = Arc::clone(&fail_tx);
+        let cpu = thread::spawn(move || loop {
+            match RelQueue::pop(&fail_cpu) {
+                Some(requeued) => {
+                    RelQueue::push(&embed_cpu, requeued);
+                    break;
+                }
+                None => thread::yield_now(),
+            }
+        });
+
+        gpu.join().unwrap();
+        cpu.join().unwrap();
+
+        let msgs = RelQueue::drain(&embed_tx);
+        let mut store = CallStore::default();
+        let mut c = CallConsumer::default();
+        for msg in msgs {
+            c.accum.extend(msg.chunks.iter().copied());
+            c.accum_edges.extend(msg.edges.iter().copied());
+            if msg.has_fp {
+                call_flush_fixed(&mut store, &mut c, true);
+            } else if c.flushed.is_some() && !c.accum.is_empty() {
+                call_flush_fixed(&mut store, &mut c, false);
+            }
+        }
+        if c.flushed.is_some() && !c.accum.is_empty() {
+            call_flush_fixed(&mut store, &mut c, false);
+        }
+        assert_call_graph_intact(&store);
+    });
+}
+
+// MODEL 6 (safety, GREEN): relationships arrive in a SEPARATE batch AFTER the
+// file's fingerprint+chunks flushed (the relationship-after-fingerprint
+// ordering). Two producers, no edge → loom explores both orders. The fixed
+// carry-forward + relationship-only re-flush must write the edge whichever order
+// lands, and must NOT prune the already-committed caller chunk.
+#[test]
+fn relationships_after_flush_write_edge_either_order() {
+    loom::model(|| {
+        let embed_tx = Arc::new(Mutex::new(RelQueue::default()));
+
+        // Producer 1: fp + the caller chunk {a}, NO edges (file flushes complete).
+        let e1 = Arc::clone(&embed_tx);
+        let p1 = thread::spawn(move || {
+            RelQueue::push(
+                &e1,
+                RelMsg {
+                    chunks: vec!['a'],
+                    has_fp: true,
+                    edges: vec![],
+                },
+            );
+        });
+        // Producer 2: the relationships arrive late, NO new chunks, NO fp.
+        let e2 = Arc::clone(&embed_tx);
+        let p2 = thread::spawn(move || {
+            RelQueue::push(
+                &e2,
+                RelMsg {
+                    chunks: vec![],
+                    has_fp: false,
+                    edges: vec![('a', 'v')],
+                },
+            );
+        });
+
+        p1.join().unwrap();
+        p2.join().unwrap();
+
+        // Faithful consumer: chunk-flush on fp; a NO-chunk NO-fp batch with edges
+        // for an already-flushed file is the RELATIONSHIP-ONLY re-flush (keeps the
+        // committed chunks via the cumulative live ids; re-supplies cumulative
+        // edges). When relationships arrive BEFORE the fingerprint, they buffer in
+        // the accum and ride the flush.
+        let msgs = RelQueue::drain(&embed_tx);
+        let mut store = CallStore::default();
+        let mut c = CallConsumer::default();
+        for msg in msgs {
+            c.accum.extend(msg.chunks.iter().copied());
+            c.accum_edges.extend(msg.edges.iter().copied());
+            if msg.has_fp {
+                call_flush_fixed(&mut store, &mut c, true);
+            } else if c.flushed.is_some() {
+                // already-flushed file got a no-fp batch → late chunk pass and/or
+                // relationship-only re-flush. Either way re-supply cumulative.
+                call_flush_fixed(&mut store, &mut c, false);
+            }
+            // A no-fp batch BEFORE any flush just buffers (accum holds edges).
+        }
+        if c.flushed.is_some() && (!c.accum.is_empty() || !c.accum_edges.is_empty()) {
+            call_flush_fixed(&mut store, &mut c, false);
+        }
+        assert_call_graph_intact(&store);
+    });
+}
+
+// NEGATIVE CONTROL (`#[ignore]`, FAILS by design): the pre-P2-fix shape. The
+// additive re-flush supplies ONLY the late batch's edges (no carry-forward); a
+// late batch with no edges hands an empty set to the wholesale DELETE-then-INSERT
+// and the call graph is WIPED. Loom finds the relationship-after-fingerprint
+// schedule and the fidelity assert fires.
+//
+// Run with `--ignored`:
+//   RUSTFLAGS="--cfg cqs_loom" cargo test --features cuda-index --bin cqs \
+//       call_graph_wiped_by_empty_additive_reflush -- --ignored
+#[test]
+#[ignore = "negative control: reproduces the call-graph wipe with the carry-forward reverted \
+            (additive re-flush supplies an empty relationship set); FAILS by design"]
+fn call_graph_wiped_by_empty_additive_reflush() {
+    loom::model(|| {
+        let embed_tx = Arc::new(Mutex::new(RelQueue::default()));
+
+        // Producer 1: fp + caller chunk {a} + the edge {(a,v)} (the FIRST flush
+        // writes the edge).
+        let e1 = Arc::clone(&embed_tx);
+        let p1 = thread::spawn(move || {
+            RelQueue::push(
+                &e1,
+                RelMsg {
+                    chunks: vec!['a'],
+                    has_fp: true,
+                    edges: vec![('a', 'v')],
+                },
+            );
+        });
+        // Producer 2: a LATE additive batch — a straddling tail chunk {c}, NO
+        // edges. With the buggy (non-cumulative) flush this re-flush supplies an
+        // empty edge set and wipes the graph.
+        let e2 = Arc::clone(&embed_tx);
+        let p2 = thread::spawn(move || {
+            RelQueue::push(
+                &e2,
+                RelMsg {
+                    chunks: vec![F_LAST],
+                    has_fp: false,
+                    edges: vec![],
+                },
+            );
+        });
+
+        p1.join().unwrap();
+        p2.join().unwrap();
+
+        let msgs = RelQueue::drain(&embed_tx);
+        let mut store = CallStore::default();
+        let mut c = CallConsumer::default();
+        for msg in msgs {
+            c.accum.extend(msg.chunks.iter().copied());
+            c.accum_edges.extend(msg.edges.iter().copied());
+            if msg.has_fp {
+                call_flush_buggy(&mut store, &mut c, true);
+            } else if c.flushed.is_some() && !c.accum.is_empty() {
+                // late additive flush with the BUGGY (empty-set) write.
+                call_flush_buggy(&mut store, &mut c, false);
+            }
+        }
+        if c.flushed.is_some() && !c.accum.is_empty() {
+            call_flush_buggy(&mut store, &mut c, false);
+        }
+        // FAILS on the schedule where p1 flushes (edge written), then p2's late
+        // chunk triggers an additive flush that supplies an empty edge set and the
+        // wholesale DELETE wipes the edge.
+        assert_call_graph_intact(&store);
+    });
+}
+
+// ===========================================================================
 // NEGATIVE CONTROL (`#[ignore]`, FAILS by design): proves the model has teeth.
 // Revert BOTH fix layers: (1) the producers straddle F across two batches with
 // NO ordering edge so its fingerprint-bearing chunk c can race ahead, and (2)

--- a/src/cli/pipeline/mod.rs
+++ b/src/cli/pipeline/mod.rs
@@ -5,6 +5,13 @@
 //! 2. Embedder: Embed chunks (GPU with CPU fallback)
 //! 3. Writer: Write to SQLite
 
+// Loom model of the index-pipeline chunk-loss protocol — the GPU/CPU work-steal
+// race that fed two producers into one `store_stage` consumer (#1891, the
+// interleaving-auditor validation lane). Gated to `--cfg cqs_loom` test builds;
+// absent from a normal build. See the module header for the NO-LOSS invariant it
+// pins and the schedules it enumerates.
+#[cfg(all(cqs_loom, test))]
+mod chunkloss_interleaving_model;
 mod embedding;
 mod parsing;
 mod reuse;

--- a/src/cli/pipeline/parsing.rs
+++ b/src/cli/pipeline/parsing.rs
@@ -43,6 +43,50 @@ fn full_disk_fingerprint(abs_path: &std::path::Path) -> FileFingerprint {
     .unwrap_or_default()
 }
 
+/// How many leading chunks of `chunks` form a FILE-ALIGNED batch under the soft
+/// cap `batch_size`.
+///
+/// `chunks` must have each file's chunks in a contiguous run (the parser's rayon
+/// fold/reduce guarantees this). The returned `take` is a sum of whole
+/// contiguous file-runs from the front: it never splits a file's run across the
+/// boundary. The first file's run is ALWAYS included, even when that one file
+/// alone exceeds `batch_size` (so an oversize file rides as its own batch rather
+/// than being split — splitting is exactly the cross-stage race this prevents).
+/// Subsequent file-runs are added only while the running total stays at or below
+/// `batch_size`.
+///
+/// Invariants (held for any non-empty `chunks`, any `batch_size >= 1`):
+///   * `1 <= take <= chunks.len()`
+///   * `chunks[take - 1].file != chunks[take].file` when `take < chunks.len()`
+///     (the cut lands on a file boundary)
+fn file_aligned_take(chunks: &[cqs::Chunk], batch_size: usize) -> usize {
+    debug_assert!(
+        !chunks.is_empty(),
+        "file_aligned_take needs a non-empty slice"
+    );
+    let mut take = 0usize;
+    while take < chunks.len() {
+        // Extent of the contiguous run for the file at `take`.
+        let run_file = &chunks[take].file;
+        let run_len = chunks[take..]
+            .iter()
+            .take_while(|c| &c.file == run_file)
+            .count();
+        // Always include the first run; stop before adding a later run that
+        // would push the batch over the soft cap.
+        if take > 0 && take + run_len > batch_size {
+            break;
+        }
+        take += run_len;
+        // The first run is committed; once we're at/over the cap, stop adding
+        // more files (the next run starts a fresh batch).
+        if take >= batch_size {
+            break;
+        }
+    }
+    take
+}
+
 /// Result of the per-batch staleness pre-filter: which files to parse, and
 /// the disk fingerprint for each of them.
 struct StalenessFilterResult {
@@ -476,17 +520,37 @@ pub(super) fn parser_stage(
             continue;
         }
 
-        // Send in embedding-sized batches. Relationships ride with the first
-        // batch only; per-chunk data (chunk_calls, type_edges) is deferred in
-        // store_stage until all chunks are committed.
+        // Send in embedding-sized batches, FILE-ALIGNED: a single file's chunks
+        // are never split across two `ParsedBatch`es. The two embed stages
+        // (GPU + CPU) work-steal `parse_rx`, so a file split across batches
+        // could have its halves processed by different stages at different
+        // speeds; the fingerprint-bearing half (the file's last chunk) could
+        // then reach `store_stage` BEFORE the file's earlier-batch chunks,
+        // firing a flush+prune on a PARTIAL accumulator and stranding the
+        // late-arriving chunks in an accum that never flushes — silent,
+        // non-deterministic chunk loss. Keeping each file's whole contiguous run
+        // inside one batch makes that file ride exactly one stage in order, so
+        // its chunks and fingerprint arrive together (or, on a GPU-failure
+        // split, cached-then-requeued in FIFO order on the single `embed_tx`).
+        // Completion is then order-independent by construction, not by timing.
         //
-        // A file's fingerprint is stamped ONLY in the batch carrying its last
-        // chunk (`remaining_per_file` hits zero), so the stamp lands strictly
-        // after every one of the file's chunks has been written — a crash
-        // between two of a file's batch commits leaves it unstamped and the
-        // next run's pre-filter reclassifies it STALE. The empty-file prune
-        // set rides with the first batch (it references no chunks, so ordering
-        // against chunk writes is irrelevant).
+        // A file's chunks are contiguous in `chunks` (the rayon fold appends
+        // each file's chunks in one `extend`, and reduce concatenates disjoint
+        // partitions), so a batch is a sum of whole contiguous file-runs.
+        // `batch_size` is a soft cap: a single file larger than `batch_size`
+        // rides alone (its own batch). `embed_documents` re-batches internally
+        // at `embed_batch_size` for GPU memory, so an oversize per-file batch
+        // does not change peak GPU usage — and `store_stage` already buffers a
+        // whole straddling file in its accumulator regardless, so peak host
+        // memory is unchanged too.
+        //
+        // Relationships ride with the first batch only; per-chunk data
+        // (chunk_calls, type_edges) is deferred in store_stage until all chunks
+        // are committed. A file's fingerprint is stamped in the (single) batch
+        // carrying its chunks, so the stamp lands together with — never before —
+        // the file's data. The empty-file prune set rides with the first batch
+        // (it references no chunks, so ordering against chunk writes is
+        // irrelevant).
         //
         // Drain owned chunks into each batch instead of `chunks.chunks(n)` +
         // `.to_vec()`, which would clone every Chunk. We own `chunks` here and
@@ -495,11 +559,14 @@ pub(super) fn parser_stage(
         let mut remaining_empties = Some(empty_file_fingerprints);
         let mut chunks = chunks;
         while !chunks.is_empty() {
-            let take = batch_size.min(chunks.len());
+            let take = file_aligned_take(&chunks, batch_size);
             // Compute the per-batch fingerprint stamp set from a borrow first;
             // `drain` below moves the same chunks out. Decrement each file's
             // remaining count as its chunks leave; a file whose count reaches
             // zero in this window has delivered its last chunk, so stamp it.
+            // With file-aligned batching a file's whole run is in one window, so
+            // its count drops to zero in the same batch as its chunks — the
+            // stamp can never precede the data.
             let mut batch_fps: std::collections::HashMap<PathBuf, FileFingerprint> =
                 std::collections::HashMap::new();
             for c in &chunks[..take] {
@@ -536,18 +603,221 @@ mod tests {
     use crossbeam_channel::unbounded;
     use std::collections::HashSet;
 
-    /// Fixture-driven regression test for the drain-based send loop. Builds a
-    /// small fixture corpus, runs `parser_stage` end-to-end,
-    /// and verifies:
+    /// Build a chunk whose only load-bearing field for `file_aligned_take` is
+    /// its `file` — the function groups by contiguous `file` runs.
+    fn aligned_chunk(file: &str) -> cqs::Chunk {
+        cqs::Chunk {
+            id: format!("{file}:0"),
+            file: PathBuf::from(file),
+            language: cqs::language::Language::Rust,
+            chunk_type: cqs::language::ChunkType::Function,
+            name: "x".to_string(),
+            signature: String::new(),
+            content: String::new(),
+            doc: None,
+            line_start: 1,
+            line_end: 1,
+            byte_start: 0,
+            content_hash: String::new(),
+            canonical_hash: String::new(),
+            parent_id: None,
+            window_idx: None,
+            parent_type_name: None,
+            parser_version: 0,
+        }
+    }
+
+    fn aligned_chunks(files: &[&str]) -> Vec<cqs::Chunk> {
+        files.iter().map(|f| aligned_chunk(f)).collect()
+    }
+
+    /// `file_aligned_take` never splits a single file's contiguous run, and the
+    /// cut always lands on a file boundary. This is the by-construction property
+    /// that kills the GPU/CPU work-steal chunk-loss race: a file that rides one
+    /// `ParsedBatch` rides one embed stage in order, so its fingerprint never
+    /// reaches `store_stage` before its data.
+    #[test]
+    fn file_aligned_take_respects_soft_cap_when_files_split_cleanly() {
+        // Three files of 2 chunks each, cap 3: take only file a (2 <= 3, then
+        // adding b's run would be 4 > 3 → stop). Cut lands between a and b.
+        let chunks = aligned_chunks(&["a", "a", "b", "b", "c", "c"]);
+        let take = file_aligned_take(&chunks, 3);
+        assert_eq!(take, 2, "take only the first whole file-run under the cap");
+        assert_ne!(
+            chunks[take - 1].file,
+            chunks[take].file,
+            "cut must land on a file boundary"
+        );
+    }
+
+    #[test]
+    fn file_aligned_take_packs_multiple_small_files_up_to_cap() {
+        // Files of 1 chunk each, cap 3: pack a, b, c (3 == cap → stop).
+        let chunks = aligned_chunks(&["a", "b", "c", "d"]);
+        let take = file_aligned_take(&chunks, 3);
+        assert_eq!(take, 3, "pack whole small files until the cap is reached");
+        assert_ne!(chunks[take - 1].file, chunks[take].file);
+    }
+
+    #[test]
+    fn file_aligned_take_oversize_file_rides_alone() {
+        // First file alone exceeds the cap: it must STILL be taken whole (never
+        // split — splitting is the race). The next file starts a fresh batch.
+        let chunks = aligned_chunks(&["big", "big", "big", "big", "small"]);
+        let take = file_aligned_take(&chunks, 2);
+        assert_eq!(
+            take, 4,
+            "an oversize first file rides alone, whole — never split"
+        );
+        assert_eq!(chunks[take - 1].file, PathBuf::from("big"));
+        assert_eq!(chunks[take].file, PathBuf::from("small"));
+    }
+
+    #[test]
+    fn file_aligned_take_single_file_takes_all() {
+        let chunks = aligned_chunks(&["a", "a", "a"]);
+        assert_eq!(file_aligned_take(&chunks, 2), 3, "lone file: take its run");
+    }
+
+    /// Driving `file_aligned_take` to exhaustion (as the drain loop does) must
+    /// (1) deliver every chunk exactly once, (2) never split a file across two
+    /// batches. Property-style sweep over a fixed corpus and several caps.
+    #[test]
+    fn file_aligned_take_full_drain_never_splits_a_file() {
+        let layouts: &[&[&str]] = &[
+            &["a", "a", "b", "c", "c", "c", "d"],
+            &["x", "x", "x", "x", "y"],
+            &["p", "q", "r", "s"],
+            &["solo", "solo", "solo"],
+        ];
+        for layout in layouts {
+            for cap in 1..=6 {
+                let mut chunks = aligned_chunks(layout);
+                let mut delivered: Vec<PathBuf> = Vec::new();
+                while !chunks.is_empty() {
+                    let take = file_aligned_take(&chunks, cap);
+                    assert!(take >= 1 && take <= chunks.len(), "take in bounds");
+                    // Boundary: the chunk just before the cut and just after must
+                    // belong to different files (no split).
+                    if take < chunks.len() {
+                        assert_ne!(
+                            chunks[take - 1].file,
+                            chunks[take].file,
+                            "layout {layout:?} cap {cap}: cut split a file run"
+                        );
+                    }
+                    delivered.extend(chunks.drain(..take).map(|c| c.file));
+                }
+                // Every chunk delivered exactly once, in original order.
+                let expected: Vec<PathBuf> =
+                    aligned_chunks(layout).into_iter().map(|c| c.file).collect();
+                assert_eq!(
+                    delivered, expected,
+                    "layout {layout:?} cap {cap}: drain lost or reordered chunks"
+                );
+            }
+        }
+    }
+
+    /// End-to-end: a file whose chunks exceed `embed_batch_size` must ride
+    /// EXACTLY ONE `ParsedBatch` — never straddle two. This is the parser-side
+    /// guarantee that makes the GPU/CPU work-steal chunk-loss bug impossible by
+    /// construction: a file confined to one batch is processed by one embed
+    /// stage in order, so its fingerprint-bearing data can never overtake its
+    /// earlier chunks in the cross-stage race.
+    #[test]
+    fn parser_stage_never_straddles_a_file_across_batches() {
+        let _lock = super::super::types::TEST_ENV_MUTEX
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+
+        // `big.rs` has > embed_batch_size functions; `a.rs`/`b.rs` are small.
+        let mut big = String::new();
+        for i in 0..200 {
+            use std::fmt::Write as _;
+            writeln!(&mut big, "pub fn big_{i}() {{}}").unwrap();
+        }
+        std::fs::write(root.join("big.rs"), &big).unwrap();
+        std::fs::write(root.join("a.rs"), "pub fn a_one() {}\npub fn a_two() {}\n").unwrap();
+        std::fs::write(root.join("b.rs"), "pub fn b_one() {}\n").unwrap();
+
+        let rel_paths = vec![
+            PathBuf::from("big.rs"),
+            PathBuf::from("a.rs"),
+            PathBuf::from("b.rs"),
+        ];
+
+        let db_path = root.join("index.db");
+        let store = Arc::new(Store::open(&db_path).unwrap());
+        store.init(&cqs::store::ModelInfo::default()).unwrap();
+
+        let (tx, rx) = unbounded::<ParsedBatch>();
+        let ctx = ParserStageContext {
+            root: root.clone(),
+            force: true,
+            parser: Arc::new(CqParser::new().unwrap()),
+            store: Arc::clone(&store),
+            parsed_count: Arc::new(AtomicUsize::new(0)),
+            parse_errors: Arc::new(AtomicUsize::new(0)),
+            model_config: cqs::embedder::ModelConfig::resolve(None, None),
+        };
+        parser_stage(rel_paths, ctx, tx).unwrap();
+
+        let batches: Vec<ParsedBatch> = rx.try_iter().collect();
+        assert!(
+            batches.len() >= 2,
+            "big.rs should force multiple batches, got {}",
+            batches.len()
+        );
+
+        // No file appears in more than one batch (the no-straddle invariant).
+        let mut file_to_batch: std::collections::HashMap<PathBuf, usize> =
+            std::collections::HashMap::new();
+        for (bi, b) in batches.iter().enumerate() {
+            let files_in_batch: HashSet<PathBuf> =
+                b.chunks.iter().map(|c| c.file.clone()).collect();
+            for f in files_in_batch {
+                if let Some(prev) = file_to_batch.insert(f.clone(), bi) {
+                    assert_eq!(
+                        prev, bi,
+                        "file {f:?} straddled parse batches {prev} and {bi} — \
+                         the no-straddle invariant is broken"
+                    );
+                }
+            }
+        }
+        // big.rs really did produce more than one batch's worth of chunks, so
+        // the no-straddle property was non-trivially exercised.
+        let big = PathBuf::from("big.rs");
+        let big_chunks: usize = batches
+            .iter()
+            .flat_map(|b| b.chunks.iter())
+            .filter(|c| c.file == big)
+            .count();
+        assert!(
+            big_chunks > embed_batch_size(),
+            "big.rs must exceed embed_batch_size to exercise the no-straddle path; got {big_chunks}"
+        );
+    }
+
+    /// Fixture-driven regression test for the file-aligned send loop. Builds a
+    /// many-file fixture corpus, runs `parser_stage` end-to-end, and verifies:
     ///
     /// * every chunk the parser produced is delivered (no loss)
     /// * chunk IDs are unique across batches (drain did not alias data)
-    /// * each batch respects `embed_batch_size()`
+    /// * NO file straddles two batches (the no-straddle invariant that kills the
+    ///   GPU/CPU work-steal chunk-loss race)
+    /// * each batch is at or below `embed_batch_size()` (soft cap; a lone file
+    ///   larger than the cap is the only exception, absent from this fixture)
     /// * at least two batches are emitted (so the loop actually iterates)
     /// * relationships ride with exactly one batch
     ///
-    /// The fixture produces >64 chunks so the default `embed_batch_size()`
-    /// of 64 forces multiple iterations — avoids mutating the shared
+    /// Uses many SMALL files (each well under the cap) so the file-aligned packer
+    /// must group several files per batch and roll to a second batch — exercising
+    /// the multi-file packing path. Avoids mutating the shared
     /// `CQS_EMBED_BATCH_SIZE` env var, which would race with
     /// `pipeline::tests::test_embed_batch_size`.
     #[test]
@@ -562,23 +832,21 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let root = tmp.path().to_path_buf();
 
-        // Three fixture files. File `big.rs` has 70 trivial functions so the
-        // total chunk count exceeds the default embed_batch_size (64),
-        // guaranteeing at least two batches without touching env vars.
-        let mut big = String::new();
-        for i in 0..70 {
-            use std::fmt::Write as _;
-            writeln!(&mut big, "pub fn big_{i}() {{}}").unwrap();
+        // 50 files of 2 functions each = 100 chunks. With the default
+        // embed_batch_size (64) the file-aligned packer fills a first batch with
+        // ~32 files (64 chunks), then rolls the rest into a second batch —
+        // forcing multiple iterations and exercising multi-file packing, all
+        // with files far smaller than the cap (so none rides alone/oversize).
+        let mut rel_paths: Vec<PathBuf> = Vec::new();
+        for i in 0..50 {
+            let name = format!("f{i}.rs");
+            std::fs::write(
+                root.join(&name),
+                format!("pub fn f{i}_a() {{}}\npub fn f{i}_b() {{}}\n"),
+            )
+            .unwrap();
+            rel_paths.push(PathBuf::from(name));
         }
-        std::fs::write(root.join("big.rs"), &big).unwrap();
-        std::fs::write(root.join("a.rs"), "pub fn a_one() {}\npub fn a_two() {}\n").unwrap();
-        std::fs::write(root.join("b.rs"), "pub fn b_one() {}\n").unwrap();
-
-        let rel_paths: Vec<PathBuf> = vec![
-            PathBuf::from("big.rs"),
-            PathBuf::from("a.rs"),
-            PathBuf::from("b.rs"),
-        ];
 
         // Store + parser — same flavour as the real pipeline.
         let db_path = root.join("index.db");
@@ -624,16 +892,28 @@ mod tests {
         let mut ids: HashSet<String> = HashSet::new();
         let mut total = 0usize;
         let mut rels_seen = 0usize;
-        for b in &batches {
+        // Every file appears in at most one batch (no straddle).
+        let mut file_to_batch: std::collections::HashMap<PathBuf, usize> =
+            std::collections::HashMap::new();
+        for (bi, b) in batches.iter().enumerate() {
             assert!(!b.chunks.is_empty(), "empty batch should not be sent");
+            // Soft cap: every fixture file is 2 chunks (< cap), so no batch may
+            // exceed the cap (only a lone oversize file could, and there is none).
             assert!(
                 b.chunks.len() <= max_batch,
-                "batch must respect embed_batch_size={max_batch}, got {}",
+                "batch must respect the soft cap embed_batch_size={max_batch}, got {}",
                 b.chunks.len()
             );
             total += b.chunks.len();
             for c in &b.chunks {
                 assert!(ids.insert(c.id.clone()), "duplicated chunk id: {}", c.id);
+                if let Some(prev) = file_to_batch.insert(c.file.clone(), bi) {
+                    assert_eq!(
+                        prev, bi,
+                        "file {:?} straddled batches {prev} and {bi}",
+                        c.file
+                    );
+                }
             }
             let has_rels = !b.relationships.type_refs.is_empty()
                 || !b.relationships.function_calls.is_empty()
@@ -1002,12 +1282,14 @@ mod tests {
         );
     }
 
-    /// File-complete fingerprint stamping: a file whose chunks straddle two
-    /// embed batches has its fingerprint stamped ONLY in the batch carrying
-    /// its last chunk — never the earlier batch. Pins the crash-safety
-    /// invariant: the fingerprint lands strictly after all of the file's
-    /// chunks, so a crash between the two batch commits leaves the file
-    /// unstamped (and therefore STALE on the next run) rather than current.
+    /// File-complete fingerprint stamping under file-aligned batching: a large
+    /// file (>64 functions) rides EXACTLY ONE `ParsedBatch` — its chunks are
+    /// never split across batches — and its fingerprint is stamped exactly once,
+    /// on that single batch. This is the post-fix shape of the crash-safety +
+    /// no-loss invariant: because the file is confined to one batch (and thus
+    /// one embed stage, in order), the fingerprint physically rides with the
+    /// file's data, so it can NEVER reach `store_stage` before the file's chunks
+    /// (the GPU/CPU work-steal race the no-straddle rule eliminates).
     #[test]
     fn parser_stage_stamps_fingerprint_only_on_last_chunk_batch() {
         let _lock = super::super::types::TEST_ENV_MUTEX
@@ -1017,8 +1299,8 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let root = tmp.path().to_path_buf();
 
-        // One file with >64 functions so its chunks span at least two
-        // `embed_batch_size`-bounded batches.
+        // One file with >64 functions: pre-fix this straddled two batches; with
+        // file-aligned batching it rides ONE (oversize-rides-alone) batch.
         let mut big = String::new();
         for i in 0..70 {
             use std::fmt::Write as _;
@@ -1044,36 +1326,35 @@ mod tests {
         parser_stage(vec![PathBuf::from("straddle.rs")], ctx, tx).unwrap();
 
         let batches: Vec<ParsedBatch> = rx.try_iter().collect();
-        assert!(
-            batches.len() >= 2,
-            "fixture must straddle batches, got {}",
-            batches.len()
-        );
         let straddle = PathBuf::from("straddle.rs");
 
-        // Fingerprint absent from every batch BEFORE the last, present in the
-        // final batch — and stamped exactly once overall.
-        let (last_idx, _) = batches
+        // The file's chunks all ride a SINGLE batch (no straddle).
+        let chunk_bearing: Vec<usize> = batches
             .iter()
             .enumerate()
-            .rev()
-            .find(|(_, b)| !b.chunks.is_empty())
-            .expect("at least one non-empty batch");
+            .filter(|(_, b)| b.chunks.iter().any(|c| c.file == straddle))
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(
+            chunk_bearing.len(),
+            1,
+            "a single file must ride exactly one batch (no straddle), got batches {chunk_bearing:?}"
+        );
+
+        // Its fingerprint is stamped exactly once, on that same batch — never
+        // ahead of the data.
         let mut stamp_count = 0;
         for (i, b) in batches.iter().enumerate() {
             if b.file_fingerprints.contains_key(&straddle) {
                 stamp_count += 1;
                 assert_eq!(
-                    i, last_idx,
-                    "fingerprint stamped on batch {i}, expected only the last batch {last_idx}"
+                    i, chunk_bearing[0],
+                    "fingerprint stamped on batch {i}, expected the file's only batch {}",
+                    chunk_bearing[0]
                 );
             }
         }
         assert_eq!(stamp_count, 1, "fingerprint must be stamped exactly once");
-        assert!(
-            batches[last_idx].file_fingerprints.contains_key(&straddle),
-            "last batch must carry the fingerprint"
-        );
     }
 
     /// A previously-indexed file that now parses to ZERO chunks rides the

--- a/src/cli/pipeline/upsert.rs
+++ b/src/cli/pipeline/upsert.rs
@@ -117,29 +117,60 @@ pub(super) fn store_stage(
     // straggler — flushes FK-checked at the end via `upsert_calls_batch`.
     let mut pending_chunk_calls: HashMap<String, Vec<cqs::parser::CallSite>> = HashMap::new();
 
-    // Flush one COMPLETE file in a single fused transaction: real + sentinel
-    // chunks + FTS + per-chunk calls + file-level function_calls + phantom prune
-    // + fingerprint stamp, all-or-nothing. On Err the tx rolled back → the file
-    // is left in its prior coherent state, UNstamped, so the next reconcile
+    // Files already flushed this run, with their fingerprint and the cumulative
+    // set of chunk ids committed so far. This is the order-independence safety
+    // net: the upstream parser stage keeps each file's chunks inside ONE embed
+    // stage (file-aligned parse batches) so a file's chunks and fingerprint
+    // arrive together — but if a future change ever let a file's chunks straddle
+    // the GPU/CPU work-steal again, a fingerprint-bearing batch could arrive
+    // before some of the file's chunks. Without this map those late chunks would
+    // land in a fresh, never-flushed accumulator and be silently dropped (and
+    // the fingerprint flush's prune would delete any earlier-arriving ones). With
+    // it, a late batch for an already-flushed file triggers an ADDITIVE re-flush
+    // whose prune live set is the UNION of the prior committed ids and the new
+    // chunks — so nothing the file produced is ever pruned away. Dormant in the
+    // in-order production path; the deterministic out-of-order regression test
+    // exercises it directly.
+    let mut flushed: HashMap<PathBuf, (cqs::store::FileFingerprint, HashSet<String>)> =
+        HashMap::new();
+
+    // Flush one file in a single fused transaction: real + sentinel chunks +
+    // FTS + per-chunk calls + file-level function_calls + phantom prune +
+    // fingerprint stamp, all-or-nothing. On Err the tx rolled back → the file is
+    // left in its prior coherent state, UNstamped, so the next reconcile
     // re-selects it (orphan-impossible in either direction). Type edges are
-    // written right after, against the now-committed chunks. Returns
-    // `(embedded, calls, type_edges)` credited (only on success).
+    // written right after, against the now-committed chunks.
+    //
+    // `extra_live_ids` are chunk ids ALREADY committed for this file in a prior
+    // flush this run (an additive re-flush after out-of-order arrival); they are
+    // added to the prune live set so the prior flush's chunks survive. Empty for
+    // the normal single-flush path. Returns `(embedded, calls, type_edges,
+    // committed_live_ids)` — the live ids are returned (only on success) so the
+    // caller can track the cumulative set for any further additive re-flush.
     let flush_file = |store: &Store,
                       pending_chunk_calls: &mut HashMap<String, Vec<cqs::parser::CallSite>>,
                       origin: &PathBuf,
                       accum: FileAccum,
-                      fp: &cqs::store::FileFingerprint|
-     -> (usize, usize, usize) {
-        // Complete live-id set for the prune (every chunk this file produced).
-        let live_ids: Vec<String> = accum
+                      fp: &cqs::store::FileFingerprint,
+                      extra_live_ids: &HashSet<String>|
+     -> (usize, usize, usize, Option<Vec<String>>) {
+        // This flush's own chunk ids.
+        let own_ids: Vec<String> = accum
             .real
             .iter()
             .map(|(c, _)| c.id.clone())
             .chain(accum.sentinel.iter().map(|c| c.id.clone()))
             .collect();
-        // Drain this file's own per-chunk calls (caller present in this tx).
+        // Complete live-id set for the prune: this flush's chunks PLUS any chunks
+        // already committed for this file in a prior (out-of-order) flush, so the
+        // prune never deletes the file's earlier-committed chunks.
+        let mut live_ids: Vec<String> = own_ids.clone();
+        live_ids.extend(extra_live_ids.iter().cloned());
+        // Drain this file's own per-chunk calls (caller present in this tx). Only
+        // for ids written in THIS tx (`own_ids`); a prior flush already drained
+        // its own ids' calls.
         let mut file_calls: Vec<(String, cqs::parser::CallSite)> = Vec::new();
-        for id in &live_ids {
+        for id in &own_ids {
             if let Some(sites) = pending_chunk_calls.remove(id) {
                 for site in sites {
                     file_calls.push((id.clone(), site));
@@ -183,13 +214,19 @@ pub(super) fn store_stage(
                             error = %e,
                             "Failed to store type edges after fused write"
                         );
-                        return (accum.real.len() + accum.sentinel.len(), calls_count, 0);
+                        return (
+                            accum.real.len() + accum.sentinel.len(),
+                            calls_count,
+                            0,
+                            Some(live_ids),
+                        );
                     }
                 }
                 (
                     accum.real.len() + accum.sentinel.len(),
                     calls_count,
                     type_edge_count,
+                    Some(live_ids),
                 )
             }
             Err(e) => {
@@ -199,7 +236,7 @@ pub(super) fn store_stage(
                     "Fused per-file write failed; file left in its prior coherent state \
                      (chunks/calls/stamp all rolled back) — re-indexes next run"
                 );
-                (0, 0, 0)
+                (0, 0, 0, None)
             }
         }
     };
@@ -249,32 +286,99 @@ pub(super) fn store_stage(
         }
 
         // FLUSH completed files. A file's fingerprint rides the batch carrying
-        // its LAST chunk, so its presence here means the file is COMPLETE.
-        // Track which origins flushed WITH chunks this batch so the zero-chunk
-        // pass below skips a stray empty-set entry for the same origin (which
-        // would otherwise prune the chunk we just wrote).
+        // its LAST chunk, so (in the in-order production path) its presence here
+        // means the file is COMPLETE. Track which origins flushed WITH chunks
+        // this batch so the zero-chunk pass below skips a stray empty-set entry
+        // for the same origin (which would otherwise prune the chunk we just
+        // wrote).
         let mut flushed_with_chunks: HashSet<PathBuf> = HashSet::new();
+        let empty_live: HashSet<String> = HashSet::new();
         for (file, fp) in std::mem::take(&mut batch.file_fingerprints) {
             match accums.remove(&file) {
                 Some(accum) => {
                     flushed_with_chunks.insert(file.clone());
-                    let (embedded, calls, type_edges) =
-                        flush_file(store, &mut pending_chunk_calls, &file, accum, &fp);
+                    let (embedded, calls, type_edges, committed) = flush_file(
+                        store,
+                        &mut pending_chunk_calls,
+                        &file,
+                        accum,
+                        &fp,
+                        &empty_live,
+                    );
                     total_embedded += embedded;
                     total_calls += calls;
                     total_type_edges += type_edges;
+                    // Record the flush so a late (out-of-order) batch for this
+                    // file triggers an ADDITIVE re-flush instead of stranding its
+                    // chunks. On a failed flush (`None`) record an empty live set
+                    // with the fingerprint so a later additive flush still stamps.
+                    let entry = flushed
+                        .entry(file.clone())
+                        .or_insert_with(|| (fp.clone(), HashSet::new()));
+                    entry.0 = fp.clone();
+                    if let Some(ids) = committed {
+                        entry.1.extend(ids);
+                    }
                 }
                 None => {
-                    // A chunk-bearing fingerprint with no accumulated chunks is
-                    // not an expected shape (the stamp rides the last-chunk
-                    // batch). Skip it rather than route to the zero-chunk flush —
-                    // that would prune any prior chunks for the origin. The file
-                    // stays unstamped and re-indexes next run.
+                    // A chunk-bearing fingerprint with no accumulated chunks: in
+                    // the in-order path this is unexpected (the stamp rides the
+                    // last-chunk batch). With out-of-order arrival it means the
+                    // fingerprint preceded ALL of the file's chunks. Record the
+                    // fingerprint with an empty live set so when the chunks arrive
+                    // later the additive-flush pass writes + stamps them; the file
+                    // is left unstamped for now (no chunks to stamp against yet).
+                    flushed
+                        .entry(file.clone())
+                        .or_insert_with(|| (fp.clone(), HashSet::new()))
+                        .0 = fp.clone();
                     tracing::warn!(
                         file = %file.display(),
                         "Chunk-bearing fingerprint arrived with no accumulated chunks; \
-                         skipping (file re-indexes next run)"
+                         deferring stamp until the file's chunks arrive"
                     );
+                }
+            }
+        }
+
+        // LATE-ARRIVAL additive flush: any file that was already flushed this run
+        // but has since accumulated MORE chunks (its fingerprint arrived before
+        // some of its chunks, out of order). Re-flush the new chunks additively —
+        // the prune live set is the UNION of prior-committed ids and the new
+        // chunks, so nothing the file produced is pruned away. This cannot fire
+        // in the in-order production path (a flushed file's accum is empty); it
+        // is the safety net the deterministic out-of-order test exercises.
+        let late_files: Vec<PathBuf> = accums
+            .iter()
+            .filter(|(file, a)| {
+                flushed.contains_key(*file) && (!a.real.is_empty() || !a.sentinel.is_empty())
+            })
+            .map(|(file, _)| file.clone())
+            .collect();
+        for file in late_files {
+            let Some(accum) = accums.remove(&file) else {
+                continue;
+            };
+            // Snapshot the prior live set + fingerprint, then flush additively.
+            let (fp, prior_ids) = match flushed.get(&file) {
+                Some((fp, ids)) => (fp.clone(), ids.clone()),
+                None => continue,
+            };
+            flushed_with_chunks.insert(file.clone());
+            let (embedded, calls, type_edges, committed) = flush_file(
+                store,
+                &mut pending_chunk_calls,
+                &file,
+                accum,
+                &fp,
+                &prior_ids,
+            );
+            total_embedded += embedded;
+            total_calls += calls;
+            total_type_edges += type_edges;
+            if let Some(ids) = committed {
+                if let Some(entry) = flushed.get_mut(&file) {
+                    entry.1.extend(ids);
                 }
             }
         }
@@ -300,8 +404,14 @@ pub(super) fn store_stage(
                 function_calls: accum.function_calls,
                 ..Default::default()
             };
-            let (embedded, calls, type_edges) =
-                flush_file(store, &mut pending_chunk_calls, &file, zero_chunk, &fp);
+            let (embedded, calls, type_edges, _committed) = flush_file(
+                store,
+                &mut pending_chunk_calls,
+                &file,
+                zero_chunk,
+                &fp,
+                &empty_live,
+            );
             total_embedded += embedded;
             total_calls += calls;
             total_type_edges += type_edges;
@@ -314,6 +424,44 @@ pub(super) fn store_stage(
             "parsed:{} embedded:{} written:{}",
             parsed, embedded, total_embedded
         ));
+    }
+
+    // Belt-and-suspenders: additively flush any residual accum for a file that
+    // WAS flushed this run (its fingerprint arrived, then more of its chunks
+    // arrived out of order in the final batch). The per-batch late pass handles
+    // these as they arrive, so this normally finds nothing; it guarantees no
+    // already-fingerprinted file's late chunks are stranded at shutdown.
+    let residual_flushed: Vec<PathBuf> = accums
+        .iter()
+        .filter(|(file, a)| {
+            flushed.contains_key(*file) && (!a.real.is_empty() || !a.sentinel.is_empty())
+        })
+        .map(|(file, _)| file.clone())
+        .collect();
+    for file in residual_flushed {
+        let Some(accum) = accums.remove(&file) else {
+            continue;
+        };
+        let (fp, prior_ids) = match flushed.get(&file) {
+            Some((fp, ids)) => (fp.clone(), ids.clone()),
+            None => continue,
+        };
+        let (embedded, calls, type_edges, committed) = flush_file(
+            store,
+            &mut pending_chunk_calls,
+            &file,
+            accum,
+            &fp,
+            &prior_ids,
+        );
+        total_embedded += embedded;
+        total_calls += calls;
+        total_type_edges += type_edges;
+        if let Some(ids) = committed {
+            if let Some(entry) = flushed.get_mut(&file) {
+                entry.1.extend(ids);
+            }
+        }
     }
 
     // Any accum still holding chunks at end-of-stream is an INCOMPLETE file
@@ -1174,6 +1322,256 @@ mod tests {
             users.iter().any(|u| u.name == "user_fn"),
             "type edge must resolve at the file's fused flush; got {:?}",
             users.iter().map(|u| &u.name).collect::<Vec<_>>()
+        );
+    }
+
+    /// THE HEADLINE REGRESSION TEST. A file straddling two embed batches whose
+    /// fingerprint-bearing batch (the file's "last" chunk) arrives at
+    /// `store_stage` BEFORE the file's earlier-batch chunks — exactly the effect
+    /// of the GPU/CPU `parse_rx` work-steal race when a file's halves are
+    /// processed by stages running at different speeds. EVERY one of the file's
+    /// chunks must end up in the store: ZERO loss.
+    ///
+    /// Pre-fix (revert both the parser file-alignment AND the `store_stage`
+    /// additive-reflush net): the fingerprint flush prunes the file to the
+    /// partial live set {c} the moment it arrives, then [a, b] land in a fresh
+    /// accumulator that never flushes (its fingerprint was already consumed) and
+    /// are silently dropped at end-of-stream — only `c` survives. That is the
+    /// confirmed, non-deterministic full-corpus chunk loss, made deterministic
+    /// here by feeding the batches in the adversarial order directly.
+    #[test]
+    fn store_stage_out_of_order_fingerprint_before_chunks_loses_nothing() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = Store::open(&tmp.path().join("index.db")).unwrap();
+        store.init(&ModelInfo::default()).unwrap();
+
+        let content = b"fn a() {}\nfn b() {}\nfn c() {}";
+        let mut last_fp = HashMap::new();
+        last_fp.insert(PathBuf::from("straddle.rs"), full_fp(content));
+
+        // ADVERSARIAL ORDER: the fingerprint-bearing batch (the file's last
+        // chunk `c`) arrives FIRST, before the earlier chunks `a` and `b`.
+        run_store_stage(
+            &store,
+            vec![
+                embedded_batch(
+                    vec![chunk("straddle.rs", "cccc", "fn c() {}")],
+                    last_fp,
+                    HashMap::new(),
+                ),
+                embedded_batch(
+                    vec![
+                        chunk("straddle.rs", "aaaa", "fn a() {}"),
+                        chunk("straddle.rs", "bbbb", "fn b() {}"),
+                    ],
+                    HashMap::new(),
+                    HashMap::new(),
+                ),
+            ],
+        );
+
+        // All three chunks present — none pruned, none stranded.
+        let stored = store.get_chunks_by_origin("straddle.rs").unwrap();
+        assert_eq!(
+            stored.len(),
+            3,
+            "out-of-order arrival must lose NO chunks; got {:?}",
+            stored.iter().map(|c| &c.id).collect::<Vec<_>>()
+        );
+        let ids: HashSet<String> = stored.iter().map(|c| c.id.clone()).collect();
+        for suffix in ["aaaa", "bbbb", "cccc"] {
+            assert!(
+                ids.contains(&format!("straddle.rs:1:{suffix}")),
+                "chunk {suffix} missing from the store after out-of-order arrival; got {ids:?}"
+            );
+        }
+
+        // And the file is stamped (its fingerprint landed with the flush).
+        let fps = store.fingerprints_for_origins(&["straddle.rs"]).unwrap();
+        assert!(
+            fps.get("straddle.rs")
+                .is_some_and(|fp| fp.content_hash.is_some()),
+            "the completed file must be stamped after the additive flush"
+        );
+    }
+
+    /// Extreme out-of-order: the fingerprint arrives in a batch with NONE of the
+    /// file's chunks (all of them follow in a LATER batch). The chunk-bearing
+    /// fingerprint's empty-accum arm defers the stamp; the later chunks then
+    /// trigger the additive flush that writes + stamps them. ZERO loss.
+    #[test]
+    fn store_stage_out_of_order_fingerprint_with_no_chunks_then_chunks_later() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = Store::open(&tmp.path().join("index.db")).unwrap();
+        store.init(&ModelInfo::default()).unwrap();
+
+        let content = b"fn a() {}\nfn b() {}";
+        let mut fp_only = HashMap::new();
+        fp_only.insert(PathBuf::from("late.rs"), full_fp(content));
+
+        run_store_stage(
+            &store,
+            vec![
+                // Fingerprint, but no chunks for late.rs in this batch.
+                embedded_batch(Vec::new(), fp_only, HashMap::new()),
+                // The file's chunks arrive afterward.
+                embedded_batch(
+                    vec![
+                        chunk("late.rs", "aaaa", "fn a() {}"),
+                        chunk("late.rs", "bbbb", "fn b() {}"),
+                    ],
+                    HashMap::new(),
+                    HashMap::new(),
+                ),
+            ],
+        );
+
+        let stored = store.get_chunks_by_origin("late.rs").unwrap();
+        assert_eq!(
+            stored.len(),
+            2,
+            "fingerprint-before-all-chunks must still write every chunk; got {:?}",
+            stored.iter().map(|c| &c.id).collect::<Vec<_>>()
+        );
+        let fps = store.fingerprints_for_origins(&["late.rs"]).unwrap();
+        assert!(
+            fps.get("late.rs")
+                .is_some_and(|fp| fp.content_hash.is_some()),
+            "the file must be stamped once its chunks arrive and flush"
+        );
+    }
+
+    /// Out-of-order arrival must NOT clobber a prior run's chunks for a DIFFERENT
+    /// file, nor leave the re-indexed file's prior chunks behind. Seed the file
+    /// with stale chunks, then re-index it out-of-order; the prune live set is
+    /// the UNION of all this-run chunks, so the stale chunk is removed and all
+    /// new chunks survive (no over-prune, no under-prune).
+    #[test]
+    fn store_stage_out_of_order_prunes_stale_keeps_all_new() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = Store::open(&tmp.path().join("index.db")).unwrap();
+        store.init(&ModelInfo::default()).unwrap();
+
+        // Seed two STALE chunks (different ids than the new run will produce).
+        let emb = Embedding::new(vec![0.25_f32; cqs::EMBEDDING_DIM]);
+        let mut seed_fp = HashMap::new();
+        seed_fp.insert(PathBuf::from("reidx.rs"), full_fp(b"old"));
+        store
+            .upsert_embedded_batch(
+                &[
+                    (chunk("reidx.rs", "old1", "fn old1() {}"), emb.clone()),
+                    (chunk("reidx.rs", "old2", "fn old2() {}"), emb.clone()),
+                ],
+                &[],
+                &seed_fp,
+            )
+            .unwrap();
+        assert_eq!(store.get_chunks_by_origin("reidx.rs").unwrap().len(), 2);
+
+        // Re-index out-of-order with three NEW chunks; fingerprint rides the
+        // batch with the "last" new chunk, which arrives first.
+        let content = b"fn n1() {}\nfn n2() {}\nfn n3() {}";
+        let mut new_fp = HashMap::new();
+        new_fp.insert(PathBuf::from("reidx.rs"), full_fp(content));
+        run_store_stage(
+            &store,
+            vec![
+                embedded_batch(
+                    vec![chunk("reidx.rs", "new3", "fn n3() {}")],
+                    new_fp,
+                    HashMap::new(),
+                ),
+                embedded_batch(
+                    vec![
+                        chunk("reidx.rs", "new1", "fn n1() {}"),
+                        chunk("reidx.rs", "new2", "fn n2() {}"),
+                    ],
+                    HashMap::new(),
+                    HashMap::new(),
+                ),
+            ],
+        );
+
+        let ids: HashSet<String> = store
+            .get_chunks_by_origin("reidx.rs")
+            .unwrap()
+            .into_iter()
+            .map(|c| c.id)
+            .collect();
+        // All three new chunks present.
+        for suffix in ["new1", "new2", "new3"] {
+            assert!(
+                ids.contains(&format!("reidx.rs:1:{suffix}")),
+                "new chunk {suffix} missing after out-of-order reindex; got {ids:?}"
+            );
+        }
+        // Neither stale chunk survives (the union prune removed prior-run rows).
+        for suffix in ["old1", "old2"] {
+            assert!(
+                !ids.contains(&format!("reidx.rs:1:{suffix}")),
+                "stale chunk {suffix} must be pruned by the out-of-order reindex; got {ids:?}"
+            );
+        }
+        assert_eq!(
+            ids.len(),
+            3,
+            "exactly the three new chunks remain; got {ids:?}"
+        );
+    }
+
+    /// Out-of-order arrival must preserve the fused-write orphan-coherence:
+    /// every surviving chunk's call edges are present, and there are NO orphaned
+    /// `function_calls` (calls-without-chunks). The file's call set rides the
+    /// FIRST (relationships-bearing) batch; with the fingerprint-before-chunks
+    /// ordering the additive flush must still wire the calls to their now-present
+    /// caller chunks without leaving an orphan.
+    #[test]
+    fn store_stage_out_of_order_preserves_orphan_coherence() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = Store::open(&tmp.path().join("index.db")).unwrap();
+        store.init(&ModelInfo::default()).unwrap();
+
+        let content = b"fn caller() { victim(); }\nfn other() {}";
+        let mut last_fp = HashMap::new();
+        last_fp.insert(PathBuf::from("calls.rs"), full_fp(content));
+
+        // Fingerprint-bearing batch (with the file's relationships) arrives
+        // first; the caller chunk arrives later. The function_calls ride the
+        // first batch (matching the real pipeline, where relationships ride the
+        // first parse batch).
+        let mut first = embedded_batch(
+            vec![chunk("calls.rs", "other", "fn other() {}")],
+            last_fp,
+            HashMap::new(),
+        );
+        first
+            .relationships
+            .function_calls
+            .insert(PathBuf::from("calls.rs"), one_call("caller", "victim"));
+
+        run_store_stage(
+            &store,
+            vec![
+                first,
+                embedded_batch(
+                    vec![chunk("calls.rs", "caller", "fn caller() { victim(); }")],
+                    HashMap::new(),
+                    HashMap::new(),
+                ),
+            ],
+        );
+
+        // Both chunks present.
+        assert_eq!(
+            store.get_chunks_by_origin("calls.rs").unwrap().len(),
+            2,
+            "out-of-order arrival with relationships must keep all chunks"
+        );
+        // No calls-without-chunks orphan: the fused-write coherence holds across
+        // the additive flush.
+        assert!(
+            store.find_orphaned_function_calls().unwrap().is_empty(),
+            "out-of-order arrival must not leave an orphaned function_calls row"
         );
     }
 }

--- a/src/cli/pipeline/upsert.rs
+++ b/src/cli/pipeline/upsert.rs
@@ -85,6 +85,29 @@ struct FileAccum {
     type_refs: Vec<cqs::parser::ChunkTypeRefs>,
 }
 
+/// State retained for a file AFTER its first flush this run, so a late
+/// (out-of-order) batch can ADDITIVELY re-flush without losing anything.
+///
+/// `live_ids` is the cumulative set of chunk ids committed so far — the additive
+/// re-flush unions it into the prune set so the earlier flush's chunks survive.
+///
+/// `function_calls` / `type_refs` are the cumulative relationships seen for the
+/// file across ALL its batches. They are CARRIED FORWARD here because the
+/// file-level call-graph write (`write_function_calls_in_tx`) is a wholesale
+/// DELETE-then-INSERT of the supplied set: an additive re-flush that supplied an
+/// EMPTY set would wipe the call edges the first flush wrote and insert nothing
+/// (silently deleting the file's whole call graph). Supplying the cumulative set
+/// on EVERY flush makes the last write reconstruct the file's complete call
+/// graph + type edges, robust to relationships arriving in any batch (early with
+/// the fingerprint, or late with a straddling tail).
+#[derive(Default)]
+struct FlushedFile {
+    fp: cqs::store::FileFingerprint,
+    live_ids: HashSet<String>,
+    function_calls: Vec<cqs::parser::FunctionCalls>,
+    type_refs: Vec<cqs::parser::ChunkTypeRefs>,
+}
+
 /// Stage 3: per-file fused write of embedded chunks + call graph + function
 /// calls + fingerprint stamp; type edges deferred to the end. #1835: each file
 /// is written in ONE all-or-nothing transaction (`upsert_file_fused`) when it
@@ -117,22 +140,25 @@ pub(super) fn store_stage(
     // straggler — flushes FK-checked at the end via `upsert_calls_batch`.
     let mut pending_chunk_calls: HashMap<String, Vec<cqs::parser::CallSite>> = HashMap::new();
 
-    // Files already flushed this run, with their fingerprint and the cumulative
-    // set of chunk ids committed so far. This is the order-independence safety
-    // net: the upstream parser stage keeps each file's chunks inside ONE embed
-    // stage (file-aligned parse batches) so a file's chunks and fingerprint
-    // arrive together — but if a future change ever let a file's chunks straddle
-    // the GPU/CPU work-steal again, a fingerprint-bearing batch could arrive
-    // before some of the file's chunks. Without this map those late chunks would
-    // land in a fresh, never-flushed accumulator and be silently dropped (and
-    // the fingerprint flush's prune would delete any earlier-arriving ones). With
-    // it, a late batch for an already-flushed file triggers an ADDITIVE re-flush
-    // whose prune live set is the UNION of the prior committed ids and the new
-    // chunks — so nothing the file produced is ever pruned away. Dormant in the
-    // in-order production path; the deterministic out-of-order regression test
-    // exercises it directly.
-    let mut flushed: HashMap<PathBuf, (cqs::store::FileFingerprint, HashSet<String>)> =
-        HashMap::new();
+    // Files already flushed this run, keyed by origin. This is the
+    // order-independence safety net: the upstream parser stage keeps each file's
+    // chunks inside ONE embed stage (file-aligned parse batches) so a file's
+    // chunks, relationships, and fingerprint arrive together — but if a future
+    // change ever let a file's chunks straddle the GPU/CPU work-steal again, a
+    // fingerprint-bearing batch could arrive before (or after) some of the
+    // file's chunks/relationships. Without this map those late chunks would land
+    // in a fresh, never-flushed accumulator and be silently dropped (and the
+    // fingerprint flush's prune would delete any earlier-arriving ones). With it,
+    // a late batch for an already-flushed file triggers an ADDITIVE re-flush:
+    //   * the prune live set is the UNION of prior-committed ids and new chunks,
+    //     so no chunk the file produced is pruned away; and
+    //   * the cumulative relationships (function_calls + type_refs) are supplied
+    //     on EVERY flush, so the wholesale DELETE-then-INSERT call-graph write
+    //     reconstructs the file's complete call graph + type edges instead of
+    //     wiping them with an empty late set.
+    // Dormant in the in-order production path; the deterministic out-of-order
+    // regression tests exercise it directly.
+    let mut flushed: HashMap<PathBuf, FlushedFile> = HashMap::new();
 
     // Flush one file in a single fused transaction: real + sentinel chunks +
     // FTS + per-chunk calls + file-level function_calls + phantom prune +
@@ -141,16 +167,22 @@ pub(super) fn store_stage(
     // re-selects it (orphan-impossible in either direction). Type edges are
     // written right after, against the now-committed chunks.
     //
-    // `extra_live_ids` are chunk ids ALREADY committed for this file in a prior
-    // flush this run (an additive re-flush after out-of-order arrival); they are
-    // added to the prune live set so the prior flush's chunks survive. Empty for
-    // the normal single-flush path. Returns `(embedded, calls, type_edges,
-    // committed_live_ids)` — the live ids are returned (only on success) so the
-    // caller can track the cumulative set for any further additive re-flush.
+    // `function_calls` / `type_refs` are the CUMULATIVE relationship sets for the
+    // file (not just this batch's), supplied explicitly so an additive re-flush
+    // re-writes the file's whole call graph + type edges rather than wiping them
+    // (the call-graph write is a wholesale DELETE-then-INSERT of the supplied
+    // set). `extra_live_ids` are chunk ids ALREADY committed for this file in a
+    // prior flush this run; they are unioned into the prune live set so the prior
+    // flush's chunks survive. Both are empty for the normal single-flush path.
+    // Returns `(embedded, calls, type_edges, committed_live_ids)` — the live ids
+    // are returned (only on success) so the caller can track the cumulative set
+    // for any further additive re-flush.
     let flush_file = |store: &Store,
                       pending_chunk_calls: &mut HashMap<String, Vec<cqs::parser::CallSite>>,
                       origin: &PathBuf,
-                      accum: FileAccum,
+                      accum: &FileAccum,
+                      function_calls: &[cqs::parser::FunctionCalls],
+                      type_refs: &[cqs::parser::ChunkTypeRefs],
                       fp: &cqs::store::FileFingerprint,
                       extra_live_ids: &HashSet<String>|
      -> (usize, usize, usize, Option<Vec<String>>) {
@@ -182,12 +214,11 @@ pub(super) fn store_stage(
         // `total_calls` semantics, which summed both). Credited only on a
         // successful flush below.
         let calls_count: usize = file_calls.len()
-            + accum
-                .function_calls
+            + function_calls
                 .iter()
                 .map(|fc| fc.calls.len())
                 .sum::<usize>();
-        let type_edge_count: usize = accum.type_refs.iter().map(|t| t.type_refs.len()).sum();
+        let type_edge_count: usize = type_refs.iter().map(|t| t.type_refs.len()).sum();
         let live_refs: Vec<&str> = live_ids.iter().map(|s| s.as_str()).collect();
         match store.upsert_file_fused(
             &accum.real,
@@ -196,18 +227,22 @@ pub(super) fn store_stage(
             &file_calls,
             origin.as_path(),
             &live_refs,
-            &accum.function_calls,
+            function_calls,
             fp,
         ) {
             Ok(_) => {
                 // Type edges resolve against THIS file's chunks (by name+line),
                 // which are now committed by the fused write above — so they
-                // never silently skip a not-yet-committed target. Best-effort:
-                // a failure here only loses this file's type edges (re-resolved
-                // next reindex), it does not roll back the coherent fused write.
-                if !accum.type_refs.is_empty() {
-                    if let Err(e) = store
-                        .upsert_type_edges_for_files(&[(origin.clone(), accum.type_refs.clone())])
+                // never silently skip a not-yet-committed target. The CUMULATIVE
+                // set is re-supplied on every flush, and the per-chunk-id
+                // DELETE-then-INSERT in `upsert_type_edges_one_file` is
+                // idempotent — so an additive re-flush rebuilds the file's type
+                // edges rather than dropping them. Best-effort: a failure here
+                // only loses this file's type edges (re-resolved next reindex),
+                // it does not roll back the coherent fused write.
+                if !type_refs.is_empty() {
+                    if let Err(e) =
+                        store.upsert_type_edges_for_files(&[(origin.clone(), type_refs.to_vec())])
                     {
                         tracing::warn!(
                             file = %origin.display(),
@@ -254,20 +289,44 @@ pub(super) fn store_stage(
             pending_chunk_calls.entry(caller_id).or_default().push(site);
         }
 
+        // Files that ALREADY flushed this run but received NEW relationships this
+        // batch (out-of-order: relationships rode a batch AFTER the file's
+        // fingerprint+chunks). Their cumulative `flushed` copy grew but no new
+        // chunks arrived, so the late-arrival chunk pass below won't pick them
+        // up; a dedicated relationship-only re-flush writes the new edges.
+        let mut rels_dirty: HashSet<PathBuf> = HashSet::new();
+
         // File-level function_calls also ride the first batch; buffer per origin
         // until the file completes (its fingerprint arrives in a later batch).
+        // If the file ALREADY flushed this run (out-of-order: its fingerprint
+        // preceded this relationship batch), merge into the cumulative `flushed`
+        // copy instead — an additive re-flush below rewrites the call graph with
+        // the complete set.
         for (file, fcs) in std::mem::take(&mut batch.relationships.function_calls) {
-            accums.entry(file).or_default().function_calls.extend(fcs);
+            match flushed.get_mut(&file) {
+                Some(state) => {
+                    state.function_calls.extend(fcs);
+                    rels_dirty.insert(file);
+                }
+                None => accums.entry(file).or_default().function_calls.extend(fcs),
+            }
         }
 
         // Type edges also ride the first batch; buffer per origin and write them
         // with the file's flush (after its chunks commit, so they always resolve).
+        // Same already-flushed routing as function_calls.
         for (file, chunk_type_refs) in std::mem::take(&mut batch.relationships.type_refs) {
-            accums
-                .entry(file)
-                .or_default()
-                .type_refs
-                .extend(chunk_type_refs);
+            match flushed.get_mut(&file) {
+                Some(state) => {
+                    state.type_refs.extend(chunk_type_refs);
+                    rels_dirty.insert(file);
+                }
+                None => accums
+                    .entry(file)
+                    .or_default()
+                    .type_refs
+                    .extend(chunk_type_refs),
+            }
         }
 
         // Accumulate this batch's chunks into their per-file buffers, routing
@@ -301,7 +360,9 @@ pub(super) fn store_stage(
                         store,
                         &mut pending_chunk_calls,
                         &file,
-                        accum,
+                        &accum,
+                        &accum.function_calls,
+                        &accum.type_refs,
                         &fp,
                         &empty_live,
                     );
@@ -310,14 +371,16 @@ pub(super) fn store_stage(
                     total_type_edges += type_edges;
                     // Record the flush so a late (out-of-order) batch for this
                     // file triggers an ADDITIVE re-flush instead of stranding its
-                    // chunks. On a failed flush (`None`) record an empty live set
-                    // with the fingerprint so a later additive flush still stamps.
-                    let entry = flushed
-                        .entry(file.clone())
-                        .or_insert_with(|| (fp.clone(), HashSet::new()));
-                    entry.0 = fp.clone();
+                    // chunks — carrying forward the cumulative relationships so the
+                    // re-flush rewrites (not wipes) the call graph + type edges.
+                    // On a failed flush (`None`) record an empty live set with the
+                    // fingerprint so a later additive flush still stamps.
+                    let entry = flushed.entry(file.clone()).or_default();
+                    entry.fp = fp.clone();
+                    entry.function_calls = accum.function_calls;
+                    entry.type_refs = accum.type_refs;
                     if let Some(ids) = committed {
-                        entry.1.extend(ids);
+                        entry.live_ids.extend(ids);
                     }
                 }
                 None => {
@@ -328,10 +391,7 @@ pub(super) fn store_stage(
                     // fingerprint with an empty live set so when the chunks arrive
                     // later the additive-flush pass writes + stamps them; the file
                     // is left unstamped for now (no chunks to stamp against yet).
-                    flushed
-                        .entry(file.clone())
-                        .or_insert_with(|| (fp.clone(), HashSet::new()))
-                        .0 = fp.clone();
+                    flushed.entry(file.clone()).or_default().fp = fp.clone();
                     tracing::warn!(
                         file = %file.display(),
                         "Chunk-bearing fingerprint arrived with no accumulated chunks; \
@@ -359,17 +419,35 @@ pub(super) fn store_stage(
             let Some(accum) = accums.remove(&file) else {
                 continue;
             };
-            // Snapshot the prior live set + fingerprint, then flush additively.
-            let (fp, prior_ids) = match flushed.get(&file) {
-                Some((fp, ids)) => (fp.clone(), ids.clone()),
-                None => continue,
+            // Fold any relationships the late chunk batch carried into the
+            // cumulative `flushed` copy (normally none — relationships route
+            // straight to `flushed` once a file is flushed — but defensive), then
+            // snapshot fp + cumulative live ids + relationships and flush
+            // additively. Cumulative relationships are re-supplied so the call
+            // graph is reconstructed, not wiped.
+            let (fp, prior_ids, function_calls, type_refs) = {
+                let Some(state) = flushed.get_mut(&file) else {
+                    continue;
+                };
+                state
+                    .function_calls
+                    .extend(accum.function_calls.iter().cloned());
+                state.type_refs.extend(accum.type_refs.iter().cloned());
+                (
+                    state.fp.clone(),
+                    state.live_ids.clone(),
+                    state.function_calls.clone(),
+                    state.type_refs.clone(),
+                )
             };
             flushed_with_chunks.insert(file.clone());
             let (embedded, calls, type_edges, committed) = flush_file(
                 store,
                 &mut pending_chunk_calls,
                 &file,
-                accum,
+                &accum,
+                &function_calls,
+                &type_refs,
                 &fp,
                 &prior_ids,
             );
@@ -378,9 +456,53 @@ pub(super) fn store_stage(
             total_type_edges += type_edges;
             if let Some(ids) = committed {
                 if let Some(entry) = flushed.get_mut(&file) {
-                    entry.1.extend(ids);
+                    entry.live_ids.extend(ids);
                 }
             }
+        }
+
+        // RELATIONSHIP-ONLY re-flush: a file that already flushed this run and
+        // received NEW relationships this batch but NO new chunks (relationships
+        // rode a batch after the file's fingerprint+chunks). The late-arrival
+        // chunk pass above already covers files that also got new chunks (it
+        // re-supplies the cumulative relationships), so skip those here. The
+        // accum is empty (no new chunks); `extra_live_ids` = the file's already-
+        // committed ids so the prune KEEPS them (an empty accum + empty live set
+        // would delete the whole file). The cumulative relationships are
+        // re-supplied so the call graph + type edges are rewritten complete.
+        let rels_only: Vec<PathBuf> = rels_dirty
+            .into_iter()
+            .filter(|f| !flushed_with_chunks.contains(f))
+            .collect();
+        let empty_accum = FileAccum::default();
+        for file in rels_only {
+            let (fp, prior_ids, function_calls, type_refs) = match flushed.get(&file) {
+                Some(state) => (
+                    state.fp.clone(),
+                    state.live_ids.clone(),
+                    state.function_calls.clone(),
+                    state.type_refs.clone(),
+                ),
+                None => continue,
+            };
+            // No committed chunks yet (fingerprint-with-no-chunks deferral) → the
+            // file isn't on disk; relationships have no caller chunks to wire to.
+            // Defer until its chunks arrive (the chunk pass will re-supply rels).
+            if prior_ids.is_empty() {
+                continue;
+            }
+            let (_embedded, calls, type_edges, _committed) = flush_file(
+                store,
+                &mut pending_chunk_calls,
+                &file,
+                &empty_accum,
+                &function_calls,
+                &type_refs,
+                &fp,
+                &prior_ids,
+            );
+            total_calls += calls;
+            total_type_edges += type_edges;
         }
 
         // FLUSH zero-chunk files (parsed to nothing this run): same fused
@@ -400,15 +522,14 @@ pub(super) fn store_stage(
             // the first batch); a zero-chunk file carries no chunks, so any stray
             // chunk in the accum is dropped — empties never carry chunks.
             let accum = accums.remove(&file).unwrap_or_default();
-            let zero_chunk = FileAccum {
-                function_calls: accum.function_calls,
-                ..Default::default()
-            };
+            let zero_chunk = FileAccum::default();
             let (embedded, calls, type_edges, _committed) = flush_file(
                 store,
                 &mut pending_chunk_calls,
                 &file,
-                zero_chunk,
+                &zero_chunk,
+                &accum.function_calls,
+                &accum.type_refs,
                 &fp,
                 &empty_live,
             );
@@ -442,15 +563,28 @@ pub(super) fn store_stage(
         let Some(accum) = accums.remove(&file) else {
             continue;
         };
-        let (fp, prior_ids) = match flushed.get(&file) {
-            Some((fp, ids)) => (fp.clone(), ids.clone()),
-            None => continue,
+        let (fp, prior_ids, function_calls, type_refs) = {
+            let Some(state) = flushed.get_mut(&file) else {
+                continue;
+            };
+            state
+                .function_calls
+                .extend(accum.function_calls.iter().cloned());
+            state.type_refs.extend(accum.type_refs.iter().cloned());
+            (
+                state.fp.clone(),
+                state.live_ids.clone(),
+                state.function_calls.clone(),
+                state.type_refs.clone(),
+            )
         };
         let (embedded, calls, type_edges, committed) = flush_file(
             store,
             &mut pending_chunk_calls,
             &file,
-            accum,
+            &accum,
+            &function_calls,
+            &type_refs,
             &fp,
             &prior_ids,
         );
@@ -459,7 +593,7 @@ pub(super) fn store_stage(
         total_type_edges += type_edges;
         if let Some(ids) = committed {
             if let Some(entry) = flushed.get_mut(&file) {
-                entry.1.extend(ids);
+                entry.live_ids.extend(ids);
             }
         }
     }
@@ -1519,14 +1653,38 @@ mod tests {
         );
     }
 
-    /// Out-of-order arrival must preserve the fused-write orphan-coherence:
-    /// every surviving chunk's call edges are present, and there are NO orphaned
-    /// `function_calls` (calls-without-chunks). The file's call set rides the
-    /// FIRST (relationships-bearing) batch; with the fingerprint-before-chunks
-    /// ordering the additive flush must still wire the calls to their now-present
-    /// caller chunks without leaving an orphan.
+    /// Build an `EmbeddedBatch` carrying a type-edge set for `file` — chunk
+    /// `caller` (line 1) references type `Config`. Mirrors the real pipeline,
+    /// where type_refs ride the first parse batch.
+    fn one_type_ref() -> Vec<cqs::parser::ChunkTypeRefs> {
+        vec![cqs::parser::ChunkTypeRefs {
+            name: "caller".to_string(),
+            line_start: 1,
+            type_refs: vec![cqs::parser::TypeRef {
+                type_name: "Config".to_string(),
+                line_number: 1,
+                kind: Some(cqs::parser::TypeEdgeKind::Param),
+            }],
+        }]
+    }
+
+    /// THE EDGE-SURVIVAL REGRESSION TEST (relationships-with-fingerprint, chunks
+    /// late). Out-of-order arrival must preserve the file's CALL GRAPH and TYPE
+    /// EDGES, not just its chunks. The relationships ride the FIRST batch (with
+    /// the fingerprint); the caller chunk arrives LATER. The additive re-flush
+    /// for the late chunk must re-supply the cumulative relationships so the
+    /// call-graph write (a wholesale DELETE-then-INSERT) rebuilds the edge rather
+    /// than wiping it.
+    ///
+    /// Pre-fix (additive re-flush supplies an EMPTY relationship set): the
+    /// re-flush's `DELETE FROM function_calls WHERE file = ?` wipes the
+    /// `caller→victim` edge the first flush wrote and inserts nothing — chunks
+    /// survive (union-prune) but `get_callers_full("victim")` returns `[]`. The
+    /// load-bearing assertion is EDGE SURVIVAL; the no-orphan check is kept as a
+    /// secondary assertion (it is vacuously satisfied by a fully-deleted edge
+    /// set, which is exactly why it alone was an insufficient guard).
     #[test]
-    fn store_stage_out_of_order_preserves_orphan_coherence() {
+    fn store_stage_out_of_order_preserves_call_graph() {
         let tmp = tempfile::TempDir::new().unwrap();
         let store = Store::open(&tmp.path().join("index.db")).unwrap();
         store.init(&ModelInfo::default()).unwrap();
@@ -1535,10 +1693,9 @@ mod tests {
         let mut last_fp = HashMap::new();
         last_fp.insert(PathBuf::from("calls.rs"), full_fp(content));
 
-        // Fingerprint-bearing batch (with the file's relationships) arrives
-        // first; the caller chunk arrives later. The function_calls ride the
-        // first batch (matching the real pipeline, where relationships ride the
-        // first parse batch).
+        // Fingerprint-bearing batch carries the file's relationships (call edge
+        // caller→victim + a type edge caller→Config) and chunk `other`; the
+        // `caller` chunk arrives in the LATER batch.
         let mut first = embedded_batch(
             vec![chunk("calls.rs", "other", "fn other() {}")],
             last_fp,
@@ -1548,6 +1705,10 @@ mod tests {
             .relationships
             .function_calls
             .insert(PathBuf::from("calls.rs"), one_call("caller", "victim"));
+        first
+            .relationships
+            .type_refs
+            .insert(PathBuf::from("calls.rs"), one_type_ref());
 
         run_store_stage(
             &store,
@@ -1567,11 +1728,85 @@ mod tests {
             2,
             "out-of-order arrival with relationships must keep all chunks"
         );
-        // No calls-without-chunks orphan: the fused-write coherence holds across
-        // the additive flush.
+        // LOAD-BEARING: the call edge survives the additive re-flush.
+        let callers = store.get_callers_full("victim").unwrap();
+        assert!(
+            callers.iter().any(|c| c.name == "caller"),
+            "the caller→victim call edge must survive the out-of-order re-flush; got {:?}",
+            callers.iter().map(|c| &c.name).collect::<Vec<_>>()
+        );
+        // LOAD-BEARING: the type edge survives too.
+        let users = store.get_type_users("Config", 10).unwrap();
+        assert!(
+            users.iter().any(|u| u.name == "caller"),
+            "the caller→Config type edge must survive the out-of-order re-flush; got {:?}",
+            users.iter().map(|u| &u.name).collect::<Vec<_>>()
+        );
+        // Secondary: no calls-without-chunks orphan (vacuous if the edge set were
+        // wiped — kept only as a complement to the edge-survival checks above).
         assert!(
             store.find_orphaned_function_calls().unwrap().is_empty(),
             "out-of-order arrival must not leave an orphaned function_calls row"
+        );
+    }
+
+    /// EDGE-SURVIVAL, the OTHER ordering (fingerprint+chunks first, relationships
+    /// LATE). The relationship batch arrives AFTER the file already flushed, so
+    /// it lands in the cumulative `flushed` copy and must trigger a
+    /// relationship-only re-flush that writes the edge against the now-present
+    /// caller chunk — without re-pruning the file's already-committed chunks.
+    #[test]
+    fn store_stage_out_of_order_relationships_after_flush_write_edge() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = Store::open(&tmp.path().join("index.db")).unwrap();
+        store.init(&ModelInfo::default()).unwrap();
+
+        let content = b"fn caller() { victim(); }";
+        let mut fp = HashMap::new();
+        fp.insert(PathBuf::from("calls.rs"), full_fp(content));
+
+        // Batch 1: fingerprint + the caller chunk, NO relationships (the file
+        // flushes complete-on-chunks). Batch 2: the relationships arrive late.
+        let mut rel_batch = embedded_batch(Vec::new(), HashMap::new(), HashMap::new());
+        rel_batch
+            .relationships
+            .function_calls
+            .insert(PathBuf::from("calls.rs"), one_call("caller", "victim"));
+        rel_batch
+            .relationships
+            .type_refs
+            .insert(PathBuf::from("calls.rs"), one_type_ref());
+
+        run_store_stage(
+            &store,
+            vec![
+                embedded_batch(
+                    vec![chunk("calls.rs", "caller", "fn caller() { victim(); }")],
+                    fp,
+                    HashMap::new(),
+                ),
+                rel_batch,
+            ],
+        );
+
+        // The chunk survived (not re-pruned by the relationship-only re-flush).
+        assert_eq!(
+            store.get_chunks_by_origin("calls.rs").unwrap().len(),
+            1,
+            "the relationship-only re-flush must not prune the file's chunks"
+        );
+        // The late edge was written.
+        let callers = store.get_callers_full("victim").unwrap();
+        assert!(
+            callers.iter().any(|c| c.name == "caller"),
+            "a late relationship batch must write its call edge; got {:?}",
+            callers.iter().map(|c| &c.name).collect::<Vec<_>>()
+        );
+        let users = store.get_type_users("Config", 10).unwrap();
+        assert!(
+            users.iter().any(|u| u.name == "caller"),
+            "a late relationship batch must write its type edge; got {:?}",
+            users.iter().map(|u| &u.name).collect::<Vec<_>>()
         );
     }
 }


### PR DESCRIPTION
## Eliminate non-deterministic silent chunk loss in the full-corpus index build

closes #1891, closes #1886

**Serious correctness bug: real code was silently missing from the index after `cqs index`.** A file's `SearchFilter` struct / `cmd_watch` / `ReviewResult` / markdown fns parsed fine in isolation but vanished from the full-corpus index (only their tests survived). Non-deterministic — the dropped set varied per reindex; chunk totals drifted 15943/15975/16018.

### Root cause
The embed→store pipeline: parse batches chunks by COUNT across files → files **straddle** parse-batch boundaries; the GPU and CPU embed stages **work-steal a cloned `parse_rx`** and both produce to a cloned `embed_tx` with **no cross-stage ordering**; `store_stage` (the #1835 fused write) flushes+prunes a file the instant its fingerprint arrives, assuming in-order delivery. A straddling file's fingerprint-bearing batch (one stage) could reach the store before its earlier-batch chunks (the other stage) → partial flush + prune → late chunks silently lost. Non-deterministic by GPU/CPU race timing + embedding-cache state (recently-edited → uncached → vulnerable). Pre-existing race; #1835's per-file prune-flush turned it into a hard loss. (#1879 neither caused nor fixed it; it was a symptom that the eval-refresh surfaced.)

### Fix — two layers
1. **Parser file-alignment** (`parsing.rs` `file_aligned_take` + drain) — a file's contiguous chunk run is **never split across `ParsedBatch`es**, so a file rides exactly one embed stage in order; its fingerprint physically cannot overtake its data. `batch_size` becomes a soft cap (an oversize file rides alone; the embedder re-batches internally, so GPU peak is unchanged). **The race is structurally impossible.**
2. **`store_stage` order-independence net** (`upsert.rs` `FlushedFile` map + additive re-flush, union-prune) — a defense-in-depth backstop: a late batch for an already-flushed file additively re-flushes with a UNION prune (no chunk lost/stranded) and **re-supplies the file's cumulative `function_calls` + `type_refs`** so the call graph survives. Dormant in the file-aligned production path; load-bearing against any future straddle regression.

### Review (magnet area — four independent gates)
- **Opus code-review:** APPROVE. Verified file-alignment contiguity at the rayon fold/reduce, union-prune soundness, residual-flush completeness. Found the layer-2 P2 below.
- **Seam-audit:** found a P2 — the additive re-flush originally handed an *empty* relationship set to the wholesale `DELETE FROM function_calls WHERE file=?`, silently wiping the call graph (chunks survived, edges vanished; the orphan-coherence test was vacuous). **Fixed** (carry-forward). **Re-seam-audit of the fix: CLEAN, no mirror seam** (no duplicate edges, chunk half intact, no stale resurrection, orphan-coherence holds).
- **Interleaving-audit:** **loom-proven** — `chunkloss_interleaving_model.rs` (cqs_loom-gated): 6 safety models green (NO-LOSS chunk dimension + CALL-GRAPH-FIDELITY relationship dimension) + 2 negative controls that fail-by-design, reproducing both the literal #1891 chunk loss and the P2 call-graph wipe when the fix is reverted.

### Tests
`store_stage_out_of_order_preserves_call_graph` (edge-survival, **red-without proven**: revert → `get_callers_full` returns `[]`) replaces the vacuous orphan-only test; `store_stage_out_of_order_relationships_after_flush_write_edge` (the other ordering); `parser_stage_never_straddles_a_file_across_batches` (red-without under the old hard-cap); union-prune + orphan-coherence + oversize-rides-alone tests; the loom suite.

### Scope
- **Worktree-overlay build is structurally immune** — `overlay_reindex_files` is a separate single-threaded per-file path, no race; no change needed.
- **PARSER_VERSION NOT bumped** — parsing output is byte-identical; pipeline-only change. **A full reindex IS needed on deploy to recover the chunks the bug dropped** (content recovery, not a parser migration).
- Gates: fmt / clippy --all-targets cuda clean; full `--tests` sweep 4563/0/67; loom 6 pass; provenance clean.

### Follow-up
The loom call-graph model uses a `HashSet` so it can't express a *duplicate*-edge regression (production is dup-free — verified 4 ways; it's a model coverage gap). Sub-threshold; filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
