### PR TITLE
fix(cli): migrate gather BFS depth clamp to a named cap + completeness guard

### DIFF
--- a/src/cli/commands/search/gather.rs
+++ b/src/cli/commands/search/gather.rs
@@ -89,7 +89,7 @@ pub(crate) fn gather_core(
     };
 
     let opts = GatherOptions {
-        expand_depth: args.depth.clamp(0, 5),
+        expand_depth: args.depth.clamp(0, crate::cli::GATHER_DEPTH_CAP),
         direction: args.direction,
         limit: fetch_limit,
         ..GatherOptions::default()

--- a/src/cli/limits.rs
+++ b/src/cli/limits.rs
@@ -71,6 +71,12 @@ pub(crate) const IMPACT_DEPTH_CAP: usize = 10;
 /// because onboard's tour stays shallow by design — a deep tour is noise.
 pub(crate) const ONBOARD_DEPTH_CAP: usize = 5;
 
+/// `--depth` ceiling for `cqs gather`. Bounds the call-graph BFS-expansion
+/// depth around the seed set. Holds the same value as [`ONBOARD_DEPTH_CAP`]
+/// today but is an independent knob — gather and onboard tune separately,
+/// so a future onboard retune must not silently move gather's ceiling.
+pub(crate) const GATHER_DEPTH_CAP: usize = 5;
+
 // ============ reranker pool sizing ============
 
 /// Default over-retrieval multiplier for the cross-encoder reranker.
@@ -321,6 +327,56 @@ mod tests {
         assert_eq!(PLACEMENT_LIMIT_CAP, 10);
         assert_eq!(IMPACT_DEPTH_CAP, 10);
         assert_eq!(ONBOARD_DEPTH_CAP, 5);
+        assert_eq!(GATHER_DEPTH_CAP, 5);
+    }
+
+    /// Structural guard against a half-completed depth-cap sweep: every BFS
+    /// depth clamp in the command layer must take its ceiling from a named
+    /// `*_DEPTH_CAP` constant, not a raw literal. Asserted on source text on
+    /// purpose — gather's literal `5` equals [`ONBOARD_DEPTH_CAP`], so a
+    /// value-only check would stay green while the binding silently drifts.
+    #[test]
+    fn every_bfs_depth_clamp_uses_a_named_cap() {
+        let manifest_dir = env!("CARGO_MANIFEST_DIR");
+        let sites: &[(&str, &str)] = &[
+            ("src/cli/commands/graph/impact.rs", "args.depth.clamp"),
+            ("src/cli/commands/search/onboard.rs", "depth.clamp"),
+            (
+                "src/cli/commands/search/gather.rs",
+                "expand_depth: args.depth.clamp",
+            ),
+        ];
+        let mut offenders: Vec<String> = Vec::new();
+        for (rel, marker) in sites {
+            let path = std::path::Path::new(manifest_dir).join(rel);
+            let src = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+            let mut found_any = false;
+            for (lineno, line) in src.lines().enumerate() {
+                if !line.contains(marker) || !line.contains(".clamp(") {
+                    continue;
+                }
+                found_any = true;
+                let after = line.split(".clamp(").nth(1).unwrap_or("");
+                let inner = after.split(')').next().unwrap_or("");
+                let ceiling = inner.split(',').nth(1).map(str::trim).unwrap_or("");
+                if !ceiling.contains("DEPTH_CAP") {
+                    offenders.push(format!(
+                        "{rel}:{}  depth ceiling `{ceiling}` is a raw literal, not a named *_DEPTH_CAP constant",
+                        lineno + 1
+                    ));
+                }
+            }
+            assert!(
+                found_any,
+                "no depth-clamp line matched marker `{marker}` in {rel} — the site moved; update this guard's marker so the family stays enumerated"
+            );
+        }
+        assert!(
+            offenders.is_empty(),
+            "incomplete depth-cap sweep — these BFS depth clamps still ship a raw literal:\n  {}",
+            offenders.join("\n  ")
+        );
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -33,8 +33,8 @@ pub use dispatch::run_with;
 // Shared clamp ceilings for commands that are dispatched from both
 // CLI and batch paths.
 pub(crate) use limits::{
-    GRAPH_LIMIT_CAP, IMPACT_DEPTH_CAP, ONBOARD_DEPTH_CAP, PLACEMENT_LIMIT_CAP, RELATED_LIMIT_MAX,
-    SCOUT_LIMIT_MAX, SIMILAR_LIMIT_MAX,
+    GATHER_DEPTH_CAP, GRAPH_LIMIT_CAP, IMPACT_DEPTH_CAP, ONBOARD_DEPTH_CAP, PLACEMENT_LIMIT_CAP,
+    RELATED_LIMIT_MAX, SCOUT_LIMIT_MAX, SIMILAR_LIMIT_MAX,
 };
 
 // Re-export for watch.rs and commands


### PR DESCRIPTION
## gather's BFS depth clamp → a named cap (the sweep-auditor's first catch)

The `sweep-auditor` (shipped in #1897) found this on its validation test-fire: `gather_core` clamped BFS expansion depth with a raw literal — `expand_depth: args.depth.clamp(0, 5)` — while every sibling depth-clamp (`impact`, `onboard`) reads a named `*_DEPTH_CAP`. Git-bisect proof it's an incomplete sweep, not a deliberate exception: #1771 ("named caps replace clamp literals") migrated onboard's depth clamp and gather's *limit* clamps in the same file but **skipped gather's depth clamp**. Dormant only because `5 == ONBOARD_DEPTH_CAP` today — a future `ONBOARD_DEPTH_CAP` retune would silently leave gather behind, the exact drift the named-cap module exists to prevent.

### Fix
- New dedicated cap `GATHER_DEPTH_CAP: usize = 5` in `limits.rs` (one cap per command concern — **not** an alias of onboard's; an independent knob), re-exported through `crate::cli`.
- `gather.rs` ceiling `5` → `GATHER_DEPTH_CAP`. **Lower bound `0` kept** — gather's depth-0 seed-only mode is the legitimate difference from onboard's `1`.
- Value-preserving today (`clamp(0, 5)` byte-identical for every input); purely binds the ceiling to a named knob.

### Completeness guard (the durable deliverable)
`every_bfs_depth_clamp_uses_a_named_cap` in `limits.rs` tests — a source-text enumerate-and-assert over the depth-clamp family (source-text on purpose: gather's `5` *equals* a sibling cap, so a value-only test would be green while the binding drift is latent). Carries a "site moved" guard so a refactor can't silently drop a member. Calibrated: **red** with the literal restored (`gather.rs:92 depth ceiling 5 is a raw literal`), **green** with the fix.

### Gates
`cli::limits::tests` 4 pass (guard + value-pin); gather filter 17 pass; fmt + clippy --all-targets + provenance lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
