### PR TITLE
feat(overlay): #1858 Part A — scout/gather/task seed search through worktree overlay

### DIFF
--- a/docs/plans/2026-06-12-worktree-overlay-implementation.md
+++ b/docs/plans/2026-06-12-worktree-overlay-implementation.md
@@ -419,30 +419,40 @@ All inside the shared core so CLI==daemon parity is by construction:
   hybrid, `--name-only`, all filters;
 - the project half of `--include-refs` (it flows through
   `retrieve_project`).
+- **`scout` / `gather` / `task` SEED retrieval (#1858 Part A).** Their seed
+  `search_filtered` now routes through `WorktreeOverlay::merge_seed_results`
+  on the daemon path, so from a worktree a worktree-added/edited file
+  surfaces as a seed. The cores take an `Option<&WorktreeOverlay>` threaded
+  from the daemon dispatchers (`scout_with_overlay` / `gather_with_overlay` /
+  `task_with_resources_overlay`); CLI-direct passes `None`. The downstream
+  BFS / call-graph expansion stays parent-truth — the payload carries an
+  honest `_meta.overlay_graph = "seed-only"` marker (skip-when-absent) so a
+  consumer knows the seeds are overlaid while the graph is not.
 
 **Explicitly excluded (and how exclusion is enforced):**
 - `--ref`-scoped search: `ProjectSurface::Skip` (`query.rs:984`) — searches
   an external store; worktree state is irrelevant; `retrieve_ref_scoped`
-  never calls `apply_overlay`.
-- `scout` / `gather` / `task`: their seed retrieval bypasses `query_core`
-  entirely (`scout_core` calls `store.search_filtered` directly,
-  `src/scout.rs:204`; gather at `src/gather.rs:650`) — no code change needed
-  to exclude; one test pins that `cqs scout` from a worktree emits no
-  `worktree_overlay` meta.
-- `similar` / `related` / `neighbors` / `where` / `onboard`: same — not
-  routed through `retrieve_project`.
+  never calls `apply_overlay`. Cross-index `gather --ref` also stays
+  parent-truth (it seeds from the reference, not the project store).
+- `scout` / `gather` / `task` **graph phases** (BFS expansion, caller/test
+  counts, staleness): parent-truth in Part A — only the seed is overlaid.
+  Phase-2/Part B extends the overlay to the call-graph add/subtract layer.
+- `similar` / `related` / `neighbors` / `where` / `onboard`: not routed
+  through `retrieve_project` or the seed overlay — parent-truth.
 - **All graph commands** (`callers`, `callees`, `impact`, `test-map`,
   `trace`, `explain`, `dead`, `review`, `ci`, `diff`, `drift`): stay
   parent-truth with the existing `worktree_stale` hint
   (`json_envelope.rs:65`). The overlay's call tables (written by
   `reindex_files` as a side effect) are deliberately **not** merged — call
   graph shadowing has subtraction semantics (a deleted caller must reduce
-  parent counts) that phase 2 owns. No partial overlay: a graph answer that
+  parent counts) that Part B owns. No partial overlay: a graph answer that
   is half-worktree would be a new calibration lie.
 
-Because the hook is `retrieve_project` + the FTS short-circuits, the
-exclusion list is enforced by architecture, not by per-command flags — the
-only commands that *can* see an overlay are the ones in the include list.
+The search overlay is enforced by the `retrieve_project` + FTS short-circuit
+hook; the seed overlay (Part A) is enforced by the explicit
+`Option<&WorktreeOverlay>` threaded into the three seed cores. Both surfaces
+share `set_overlay_meta` so the `_meta.worktree_overlay` outcome rides every
+overlaid answer.
 
 ---
 
@@ -509,7 +519,13 @@ Tests (names from §4's table plus the program-doc gates):
     None, max_connections=1) + roundtrip; `-z` name-status parser (R/C/D/M/T
     records, embedded-rename two-entry expansion); fingerprint determinism +
     order-independence.
-19. `overlay_scout_not_overlaid` — scope-guard pin (§9).
+19. ~~`overlay_scout_not_overlaid` — scope-guard pin (§9).~~ **INVERTED by
+    #1858 Part A**: scout's seed IS overlaid now (daemon path). The pin became
+    `overlay_scout_cli_direct_serves_parent` (CLI-direct still serves parent —
+    no daemon, no build), with the active seed-overlay covered daemon-side by
+    `overlay_scout_seed_overlaid` / `overlay_gather_seed_overlaid` /
+    `overlay_task_seed_overlaid_marker` in `handlers/search.rs` plus the
+    `merge_seed_results` unit tests in `worktree_overlay.rs`.
 20. Run `/recall-gate` after the query-path PR merges (retrieval-adjacent by
     the house rule, even though `overlay_no_worktree_no_overlay` says it
     cannot move).

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -94,6 +94,40 @@ pub(crate) struct LimitArg {
     pub limit: usize,
 }
 
+/// The worktree-overlay tri-state flags, flattened into the commands whose SEED
+/// retrieval the overlay shadows (Part A): `scout`, `gather`, `task`. The
+/// `search` command carries the same three flags inline ([`SearchArgs`]); this
+/// is the shared subset for the seed-overlaid graph-adjacent commands. Each
+/// resolves activation through the same `resolve_overlay_active` precedence the
+/// search surface uses, so no two surfaces can diverge.
+#[derive(Args, Debug, Clone, Default)]
+pub(crate) struct OverlayArgs {
+    /// Overlay the worktree's uncommitted/committed delta on top of the parent
+    /// index so the SEED search reflects this checkout's edits, not main's.
+    /// Default-on when run from a worktree; off in the main checkout. Tri-state
+    /// env `CQS_WORKTREE_OVERLAY`: `1` forces on, `0` forces off, unset =
+    /// default. `--overlay` forces on; `--no-overlay` forces off (opt-out wins).
+    /// Phase 1 builds overlays on the daemon path only. The call-graph
+    /// expansion stays on parent-truth — a `_meta.overlay_graph = "seed-only"`
+    /// marker says so. Requires `--json` to forward to the daemon.
+    #[arg(long, conflicts_with = "no_overlay")]
+    pub overlay: bool,
+
+    /// Opt out of the worktree seed overlay even when run from a worktree
+    /// (where it is default-on). The explicit-off counterpart of `--overlay`;
+    /// equivalent to `CQS_WORKTREE_OVERLAY=0`. Opt-out wins over every opt-in.
+    #[arg(long, conflicts_with = "overlay")]
+    pub no_overlay: bool,
+
+    /// Wire-only: the absolute worktree root to build the overlay for. Hidden
+    /// from `--help` — computed by the CLI (`cqs::worktree::overlay_root`) and
+    /// appended to the daemon-forwarded args, never set by a human. The daemon
+    /// VALIDATES it (canonicalize + `resolve_main_project_dir == served root`)
+    /// before reading any of its files.
+    #[arg(long, hide = true)]
+    pub overlay_root: Option<std::path::PathBuf>,
+}
+
 /// Arguments for semantic search: the flagship command. Shared between CLI
 /// `search` (top-level + `cqs search …`) and batch `search`.
 ///
@@ -285,6 +319,9 @@ pub(crate) struct GatherArgs {
     /// Cross-index gather: seed from reference, bridge into project code
     #[arg(long = "ref")]
     pub ref_name: Option<String>,
+    /// Worktree-overlay tri-state for the seed search (Part A).
+    #[command(flatten)]
+    pub overlay: OverlayArgs,
 }
 
 /// Arguments shared between CLI `impact` and batch `impact`.
@@ -334,6 +371,9 @@ pub(crate) struct ScoutArgs {
     /// Dependency (default: 0.10). Lower yields more ModifyTargets.
     #[arg(long, value_parser = parse_finite_f32)]
     pub min_gap_ratio: Option<f32>,
+    /// Worktree-overlay tri-state for the seed search (Part A).
+    #[command(flatten)]
+    pub overlay: OverlayArgs,
 }
 
 /// Arguments shared between CLI `context` and batch `context`.
@@ -595,6 +635,9 @@ pub(crate) struct TaskArgs {
     /// Compact output (~200 tokens): files, at-risk functions, test coverage
     #[arg(long)]
     pub brief: bool,
+    /// Worktree-overlay tri-state for the scout-seed search (Part A).
+    #[command(flatten)]
+    pub overlay: OverlayArgs,
 }
 
 /// Arguments shared between CLI `read` and batch `read`.

--- a/src/cli/batch/commands.rs
+++ b/src/cli/batch/commands.rs
@@ -672,6 +672,44 @@ mod tests {
         );
     }
 
+    /// Part A: scout/gather/task accept the same overlay tri-state via the
+    /// flattened `OverlayArgs` — `--overlay` / `--no-overlay` parse and conflict,
+    /// and the hidden `--overlay-root` rides the wire.
+    #[test]
+    fn test_parse_seed_overlay_flags() {
+        for cmd in ["scout", "gather", "task"] {
+            let on = BatchInput::try_parse_from([cmd, "q", "--overlay", "--overlay-root", "/wt"])
+                .unwrap();
+            let (overlay, no_overlay, root) = match on.cmd {
+                BatchCmd::Scout { ref args, .. } => (
+                    args.overlay.overlay,
+                    args.overlay.no_overlay,
+                    args.overlay.overlay_root.clone(),
+                ),
+                BatchCmd::Gather { ref args, .. } => (
+                    args.overlay.overlay,
+                    args.overlay.no_overlay,
+                    args.overlay.overlay_root.clone(),
+                ),
+                BatchCmd::Task { ref args, .. } => (
+                    args.overlay.overlay,
+                    args.overlay.no_overlay,
+                    args.overlay.overlay_root.clone(),
+                ),
+                _ => panic!("unexpected command for {cmd}"),
+            };
+            assert!(overlay, "{cmd} --overlay sets the flag");
+            assert!(!no_overlay);
+            assert_eq!(root.as_deref(), Some(std::path::Path::new("/wt")));
+
+            let conflict = BatchInput::try_parse_from([cmd, "q", "--overlay", "--no-overlay"]);
+            assert!(
+                conflict.is_err(),
+                "{cmd} --overlay and --no-overlay must conflict"
+            );
+        }
+    }
+
     #[test]
     fn test_parse_callers() {
         let input = BatchInput::try_parse_from(["callers", "my_func"]).unwrap();
@@ -987,6 +1025,7 @@ mod tests {
                 search_limit: None,
                 search_threshold: None,
                 min_gap_ratio: None,
+                overlay: crate::cli::args::OverlayArgs::default(),
             },
             output: TextJsonArgs { json: false },
         };

--- a/src/cli/batch/handlers/misc.rs
+++ b/src/cli/batch/handlers/misc.rs
@@ -220,9 +220,11 @@ pub(in crate::cli::batch) fn dispatch_task(
         .clamp(1, crate::cli::PLACEMENT_LIMIT_CAP);
     let graph = ctx.call_graph()?;
     let test_chunks = ctx.test_chunks()?;
-    // Overlay the task SCOUT seed from an eligible worktree (Part A); the
-    // gather/impact/placement phases fetch by name from the parent store and so
-    // stay on parent-truth.
+    // Overlay the task SCOUT seed from an eligible worktree (Part A). The gather
+    // phase also surfaces overlay-origin SEED chunks (a worktree-added/modified
+    // target shows its worktree content in `code`, matching the overlaid scout);
+    // BFS expansion and the impact/placement phases stay on parent-truth (the
+    // `seed-only` marker).
     let overlay = resolve_seed_overlay(ctx, &args.overlay)?;
     let result = cqs::task_with_resources_overlay(
         &ctx.store(),

--- a/src/cli/batch/handlers/misc.rs
+++ b/src/cli/batch/handlers/misc.rs
@@ -8,10 +8,35 @@ use anyhow::Result;
 use super::super::commands::BatchInput;
 use super::super::BatchView;
 use crate::cli::args::{
-    DiffArgs, DriftArgs, GatherArgs, NotesListArgs, PlanArgs, ReconcileArgs, ScoutArgs, TaskArgs,
-    WaitFreshArgs, WhereArgs,
+    DiffArgs, DriftArgs, GatherArgs, NotesListArgs, OverlayArgs, PlanArgs, ReconcileArgs,
+    ScoutArgs, TaskArgs, WaitFreshArgs, WhereArgs,
 };
+// `SearchCtx` brings `BatchView::overlay()` into scope — the seam that resolves
+// + builds the per-worktree overlay from the request `prepare_overlay_request_*`
+// stamped (Part A).
+use crate::cli::commands::search::search_ctx::SearchCtx;
 use crate::cli::validate_finite_f32;
+
+/// Prepare + resolve the worktree seed overlay for an overlay-capable dispatcher
+/// (Part A). Stamps the validated request from the tri-state flags (a
+/// foreign `--overlay-root` is rejected as a wire error), then resolves it
+/// through the daemon overlay LRU. Returns `Some(Arc<WorktreeOverlay>)` when the
+/// overlay is active for this query (eligible worktree, non-clean delta, under
+/// the file cap), else `None` (serve the parent index). The caller threads the
+/// `Some` into the lib `*_overlay` seed path and injects the `seed-only`
+/// `_meta.overlay_graph` marker.
+fn resolve_seed_overlay(
+    ctx: &BatchView,
+    overlay: &OverlayArgs,
+) -> Result<Option<std::sync::Arc<cqs::worktree_overlay::WorktreeOverlay>>> {
+    super::prepare_overlay_request_fields(
+        ctx,
+        overlay.overlay,
+        overlay.no_overlay,
+        overlay.overlay_root.as_deref(),
+    )?;
+    Ok(ctx.overlay())
+}
 
 /// Performs a semantic search gather operation with optional cross-index querying and token budget constraints.
 ///
@@ -25,6 +50,14 @@ pub(in crate::cli::batch) fn dispatch_gather(
     let query = args.query.as_str();
     let ref_name = args.ref_name.as_deref();
     let _span = tracing::info_span!("batch_gather", query, ?ref_name).entered();
+
+    // Clear leftover per-thread overlay meta BEFORE any branch can return — a
+    // reused worker thread must not leak a prior query's
+    // `_meta.worktree_overlay` onto this response (mirrors `dispatch_search`'s
+    // clear-before-branch discipline). The non-`--ref` branch re-clears via
+    // `resolve_seed_overlay`; the `--ref` branch skips that path, so the
+    // unconditional clear here is what guards it. Idempotent.
+    cqs::worktree_overlay::clear_overlay_meta();
 
     let embedder = ctx.embedder()?;
 
@@ -41,33 +74,46 @@ pub(in crate::cli::batch) fn dispatch_gather(
         json_overhead: crate::cli::commands::JSON_OVERHEAD_PER_RESULT,
     };
 
-    let (result, token_info) = if let Some(rn) = ref_name {
+    let (result, token_info, overlaid) = if let Some(rn) = ref_name {
+        // Cross-index gather seeds from the reference, not the project store, so
+        // the overlay does not apply (Part A). Resolve no overlay here.
         ctx.get_ref(rn)?;
         let ref_idx = ctx
             .borrow_ref(rn)
             .ok_or_else(|| anyhow::anyhow!("Reference '{}' not loaded", rn))?;
         let index = ctx.vector_index()?;
-        crate::cli::commands::gather::gather_core(
+        let (result, token_info) = crate::cli::commands::gather::gather_core(
             &ctx.store(),
             embedder,
             &ctx.root,
             &core_args,
             Some(ref_idx.as_ref()),
             index.as_deref(),
-        )?
+            None,
+        )?;
+        (result, token_info, false)
     } else {
-        crate::cli::commands::gather::gather_core(
+        // Project gather: overlay the seed search from an eligible worktree.
+        let overlay = resolve_seed_overlay(ctx, &args.overlay)?;
+        let (result, token_info) = crate::cli::commands::gather::gather_core(
             &ctx.store(),
             embedder,
             &ctx.root,
             &core_args,
             None,
             None,
-        )?
+            overlay.as_deref(),
+        )?;
+        (result, token_info, overlay.is_some())
     };
 
     let output = crate::cli::commands::build_gather_output(&result, query, token_info);
-    Ok(serde_json::to_value(&output)?)
+    let mut value = serde_json::to_value(&output)?;
+    if overlaid {
+        // Seeds are overlaid; BFS expansion still reflects parent-truth.
+        super::attach_overlay_graph_meta(&mut value);
+    }
+    Ok(value)
 }
 
 /// Dispatches filtered notes from the batch context as a JSON response.
@@ -174,7 +220,11 @@ pub(in crate::cli::batch) fn dispatch_task(
         .clamp(1, crate::cli::PLACEMENT_LIMIT_CAP);
     let graph = ctx.call_graph()?;
     let test_chunks = ctx.test_chunks()?;
-    let result = cqs::task_with_resources(
+    // Overlay the task SCOUT seed from an eligible worktree (Part A); the
+    // gather/impact/placement phases fetch by name from the parent store and so
+    // stay on parent-truth.
+    let overlay = resolve_seed_overlay(ctx, &args.overlay)?;
+    let result = cqs::task_with_resources_overlay(
         &ctx.store(),
         embedder,
         description,
@@ -182,11 +232,16 @@ pub(in crate::cli::batch) fn dispatch_task(
         limit,
         &graph,
         &test_chunks,
+        overlay.as_deref(),
     )?;
 
     // Shared projection: waterfall budgeting when `--tokens` is set, else full
     // serialization. Identical to the CLI's non-brief JSON path.
-    crate::cli::commands::task::task_json_core(&result, embedder, tokens)
+    let mut value = crate::cli::commands::task::task_json_core(&result, embedder, tokens)?;
+    if overlay.is_some() {
+        super::attach_overlay_graph_meta(&mut value);
+    }
+    Ok(value)
 }
 
 /// Performs a scout search query with optional token budget packing.
@@ -217,8 +272,19 @@ pub(in crate::cli::batch) fn dispatch_scout(
         search_threshold: args.search_threshold,
         min_gap_ratio: args.min_gap_ratio,
     };
-    let (output, _token_info) =
-        crate::cli::commands::scout::scout_core(&ctx.store(), embedder, &ctx.root, &core_args)?;
+    // Overlay the scout SEED search from an eligible worktree (Part A);
+    // the caller/staleness/BFS-hint phases stay on parent-truth.
+    let overlay = resolve_seed_overlay(ctx, &args.overlay)?;
+    let (mut output, _token_info) = crate::cli::commands::scout::scout_core(
+        &ctx.store(),
+        embedder,
+        &ctx.root,
+        &core_args,
+        overlay.as_deref(),
+    )?;
+    if overlay.is_some() {
+        super::attach_overlay_graph_meta(&mut output);
+    }
     Ok(output)
 }
 

--- a/src/cli/batch/handlers/mod.rs
+++ b/src/cli/batch/handlers/mod.rs
@@ -35,3 +35,73 @@ pub(super) use misc::{
     dispatch_status, dispatch_task, dispatch_wait_fresh, dispatch_where,
 };
 pub(super) use search::dispatch_search;
+
+use super::BatchView;
+use anyhow::Result;
+use std::path::Path;
+
+/// Reset per-thread overlay state and (when requested) validate + stamp the
+/// worktree overlay request for this dispatch, from the raw tri-state fields.
+///
+/// The surface-agnostic core of the search handler's `prepare_overlay_request`,
+/// shared so the seed-overlaid graph-adjacent commands (`scout` / `gather` /
+/// `task`) honor the same activation precedence and the same
+/// security validation as `search`. Called at the TOP of each overlay-capable
+/// dispatcher, BEFORE the core runs, on the daemon worker thread that serves
+/// the query:
+///
+/// 1. **`clear_overlay_meta()` unconditionally** — a reused worker thread must
+///    not leak the previous query's `_meta.worktree_overlay` into this one.
+/// 2. **Validate + stamp `--overlay-root`** when overlay is active (wire flag
+///    OR the daemon's own env; `overlay_eligible = false` because default-on is
+///    a client-side decision the daemon never makes — it only ever sees an
+///    overlay the client forwarded). With no `--overlay-root` the request stays
+///    `None` (no-op for this query). A foreign root is rejected as a wire error.
+pub(super) fn prepare_overlay_request_fields(
+    ctx: &BatchView,
+    overlay: bool,
+    no_overlay: bool,
+    overlay_root: Option<&Path>,
+) -> Result<()> {
+    cqs::worktree_overlay::clear_overlay_meta();
+    let active =
+        crate::cli::commands::search::query::resolve_overlay_active(overlay, no_overlay, false);
+    if !active {
+        return Ok(());
+    }
+    if let Some(root) = overlay_root {
+        // Reject (wire error) if the path is not a worktree of this project.
+        ctx.set_validated_overlay_request(root)?;
+    } else {
+        tracing::debug!(
+            "overlay requested but no --overlay-root on the wire — serving parent index"
+        );
+    }
+    Ok(())
+}
+
+/// Inject the `_meta.overlay_graph = "seed-only"` marker into a dispatcher's
+/// serialized payload (Part A). Called by `scout` / `gather` / `task`
+/// when the worktree overlay shadowed the SEED search but the downstream call-
+/// graph expansion still reflects parent-truth — the marker makes that honest
+/// so a consumer knows the seeds are overlaid while the graph is not.
+///
+/// Skip-when-absent: only call this when an overlay was actually applied; with
+/// no overlay the payload carries no marker. Writes into a reserved top-level
+/// `_meta` object the daemon envelope lifts onto the wire `_meta` (sibling of
+/// `data`), the same channel `worktree_overlay` and `stale_origins` use; the
+/// two coexist (`merged_meta_value` merges the per-response entry with the
+/// process-level `worktree_overlay`).
+pub(super) fn attach_overlay_graph_meta(value: &mut serde_json::Value) {
+    if let Some(obj) = value.as_object_mut() {
+        let meta = obj
+            .entry("_meta")
+            .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+        if let Some(meta_obj) = meta.as_object_mut() {
+            meta_obj.insert(
+                "overlay_graph".to_string(),
+                serde_json::Value::String("seed-only".to_string()),
+            );
+        }
+    }
+}

--- a/src/cli/batch/handlers/search.rs
+++ b/src/cli/batch/handlers/search.rs
@@ -1720,9 +1720,17 @@ mod tests {
         );
     }
 
-    /// Sibling pin: the task pipeline (scout → gather → impact → placement) also
-    /// overlays its scout SEED and carries the `seed-only` marker. Asserts the
-    /// marker; the scout-phase symbol surfacing is covered by the scout test.
+    /// Part A invariant: the task pipeline (scout → gather → impact →
+    /// placement) overlays its scout SEED AND surfaces the overlay-added
+    /// function's chunk in its `code` section — the two halves of the response
+    /// must AGREE. `task_core` extracts the modify-target name from the overlaid
+    /// scout; if `fetch_and_assemble` re-fetches it by name from the PARENT store
+    /// (which has no chunk for a worktree-added function) the function shows in
+    /// `scout.file_groups` but is absent from the `code` section — an internally
+    /// inconsistent single response, while the `seed-only` marker keeps
+    /// promising the seed is present. Asserting only the marker cannot catch
+    /// that; this asserts the chunk is in `json["code"]` with its worktree
+    /// content, and is present in `scout` too.
     #[cfg(feature = "slow-tests")]
     #[test]
     fn overlay_task_seed_overlaid_marker() {
@@ -1752,17 +1760,49 @@ mod tests {
             json["_meta"]["overlay_graph"], "seed-only",
             "task must carry _meta.overlay_graph = seed-only when overlaid; got {json}"
         );
+
+        // The scout phase surfaces the overlay-added symbol (the honest half).
+        let in_scout = json["scout"]["file_groups"]
+            .as_array()
+            .map(|groups| {
+                groups.iter().any(|g| {
+                    g["chunks"].as_array().is_some_and(|chunks| {
+                        chunks.iter().any(|c| c["name"] == "lane_new_widget_total")
+                    })
+                })
+            })
+            .unwrap_or(false);
+        assert!(
+            in_scout,
+            "task scout phase must surface the overlay-added symbol; got {json}"
+        );
+
+        // …and the `code` section must carry its CHUNK with worktree content.
+        // The scout and code halves agreeing is the internal-consistency
+        // invariant: a target surfaced by the overlaid scout must materialize in
+        // the code section with its overlay content, not be dropped by a
+        // parent-only re-fetch.
+        let code_chunk = json["code"]
+            .as_array()
+            .and_then(|code| code.iter().find(|c| c["name"] == "lane_new_widget_total"));
+        let code_chunk = code_chunk.unwrap_or_else(|| {
+            panic!("task `code` section must include the overlay-added function; got {json}")
+        });
+        let content = code_chunk["content"].as_str().unwrap_or("");
+        assert!(
+            content.contains("widget_total"),
+            "task code chunk must carry worktree content; got content={content:?}"
+        );
     }
 
-    /// Sibling pin: `gather`'s SEED is overlay-wired. The payload carries the
-    /// `seed-only` marker (proof the overlay engaged through `gather_core` →
-    /// `gather_with_overlay` → `merge_seed_results`). Symbol-surfacing through
-    /// `merge_seed_results` itself is asserted by `overlay_scout_seed_overlaid`
-    /// (the IDENTICAL lib codepath) and by the `merge_seed_results` unit tests
-    /// in `worktree_overlay.rs`; gather's seed search applies its own dense
-    /// `seed_threshold` (0.3) on top, so whether a given synthetic symbol clears
-    /// it is an embedder-scoring concern, not a wiring one — pinning a specific
-    /// score here would be flaky.
+    /// Part A invariant: `gather`'s SEED is overlay-wired AND its overlay-origin
+    /// chunk SURFACES with worktree content. `merge_seed_results` surfaces the
+    /// overlay-only seed as a `SearchResult`; if `fetch_and_assemble` then
+    /// re-fetches every chunk by name from the PARENT store (where a worktree-
+    /// added name does not exist) the chunk is silently dropped while the
+    /// `seed-only` marker keeps promising the seed is present — the marker would
+    /// lie. Asserting only the marker cannot catch that; this asserts the chunk
+    /// is in `json["chunks"]` with its worktree content.
     #[cfg(feature = "slow-tests")]
     #[test]
     fn overlay_gather_seed_overlaid() {
@@ -1791,6 +1831,165 @@ mod tests {
         assert_eq!(
             json["_meta"]["overlay_graph"], "seed-only",
             "gather must carry _meta.overlay_graph = seed-only when overlaid; got {json}"
+        );
+
+        // The overlay-added seed's CHUNK must be present in the output (not just
+        // the marker). Pre-fix this `chunks` entry was dropped by the parent
+        // by-name re-fetch.
+        let chunk = json["chunks"]
+            .as_array()
+            .and_then(|chunks| chunks.iter().find(|c| c["name"] == "lane_new_widget_total"));
+        let chunk = chunk.unwrap_or_else(|| {
+            panic!("gather must surface the overlay-added seed chunk; got {json}")
+        });
+        // And it must carry the WORKTREE content (the overlay store's chunk),
+        // not a stale/empty parent body. `widget_total` is unique to the
+        // worktree-added body.
+        let content = chunk["content"].as_str().unwrap_or("");
+        assert!(
+            content.contains("widget_total"),
+            "gather overlay seed chunk must carry worktree content; got content={content:?}"
+        );
+    }
+
+    /// Build a parent index (real pipeline) + linked worktree that RENAMES an
+    /// indexed symbol (old name → new name in a tracked, committed file).
+    /// Returns `(dir, ctx, worktree_root)` ready for an overlaid dispatch, or
+    /// `None` when the embedder can't init (CI-without-model → skip).
+    ///
+    /// Parent indexes `renamed_old_token`; the worktree renames it to
+    /// `renamed_new_token`. The overlay must mask the parent origin (so the OLD
+    /// name disappears) and surface the NEW name with its worktree content.
+    #[cfg(feature = "slow-tests")]
+    fn seed_overlay_ctx_with_rename() -> Option<(TempDir, BatchContext, PathBuf)> {
+        let dir = TempDir::new().expect("tempdir");
+        let parent = dir.path().join("parent");
+        std::fs::create_dir_all(parent.join("src")).expect("mkdir");
+        std::fs::write(
+            parent.join("src/widget.rs"),
+            "/// Compute the renamed widget total.\n\
+             pub fn renamed_old_token() -> i32 {\n    \
+             let widget_total = 7;\n    \
+             widget_total\n\
+             }\n",
+        )
+        .expect("write widget.rs");
+        git(&parent, &["init", "-q", "-b", "main"]);
+        git(&parent, &["config", "user.email", "t@e.com"]);
+        git(&parent, &["config", "user.name", "T"]);
+        git(&parent, &["add", "-A"]);
+        git(&parent, &["commit", "-q", "-m", "init"]);
+
+        let embedder = match cqs::Embedder::new_cpu(cqs::embedder::ModelConfig::resolve(None, None))
+        {
+            Ok(e) => e,
+            Err(e) => {
+                eprintln!("skipping rename seed-overlay e2e: embedder init failed: {e}");
+                return None;
+            }
+        };
+        let parser = cqs::parser::Parser::new().expect("parser");
+
+        let cqs_dir = parent.join(".cqs");
+        std::fs::create_dir_all(&cqs_dir).expect("mkdir .cqs");
+        let index_path = cqs_dir.join("index.db");
+        {
+            let store = Store::open(&index_path).expect("open store");
+            let model_info =
+                ModelInfo::new(&embedder.model_config().repo, embedder.embedding_dim());
+            store.init(&model_info).expect("init store");
+            let mut store = store;
+            store.set_dim(model_info.dimensions);
+            crate::cli::watch::overlay_reindex_files(
+                &parent,
+                &store,
+                &[PathBuf::from("src/widget.rs")],
+                &parser,
+                &embedder,
+                None,
+                true,
+            )
+            .expect("index parent");
+        }
+
+        // Linked worktree that RENAMES the symbol (committed, so it shows as a
+        // tracked diff vs the parent HEAD — git records it as a modify on the
+        // file's origin; the overlay masks that origin and re-indexes the new
+        // body).
+        let wt = dir.path().join("wt");
+        git(
+            &parent,
+            &["worktree", "add", "-q", "-b", "lane", wt.to_str().unwrap()],
+        );
+        std::fs::write(
+            wt.join("src/widget.rs"),
+            "/// Compute the renamed widget total.\n\
+             pub fn renamed_new_token() -> i32 {\n    \
+             let widget_total = 7;\n    \
+             widget_total\n\
+             }\n",
+        )
+        .expect("write renamed widget.rs");
+        git(&wt, &["add", "-A"]);
+        git(&wt, &["commit", "-q", "-m", "rename"]);
+        let wt = dunce::canonicalize(&wt).unwrap_or(wt);
+
+        let ctx = create_test_context(&cqs_dir).expect("create_test_context");
+        assert!(
+            ctx.adopt_embedder(std::sync::Arc::new(embedder)),
+            "embedder slot empty"
+        );
+        Some((dir, ctx, wt))
+    }
+
+    /// Part A calibration pin (RENAME case): the overlay masks the parent origin
+    /// so the OLD symbol name is ABSENT from gather, and surfaces the NEW name
+    /// with its worktree content. The old name leaking through would mean the
+    /// mask half of the overlay was bypassed by the by-name re-fetch; the new
+    /// name missing would mean the surface half was (the bug). Both halves are
+    /// asserted in one response.
+    #[cfg(feature = "slow-tests")]
+    #[test]
+    fn overlay_gather_seed_rename() {
+        let Some((_dir, ctx, wt)) = seed_overlay_ctx_with_rename() else {
+            return;
+        };
+        let view = ctx.build_view(None);
+        view.set_validated_overlay_request(&wt)
+            .expect("validate wt");
+
+        let input = BatchInput::try_parse_from([
+            "gather",
+            "Compute the renamed widget total",
+            "--overlay",
+            "--overlay-root",
+            wt.to_str().unwrap(),
+        ])
+        .expect("clap parse");
+        let args = match input.cmd {
+            BatchCmd::Gather { args, .. } => args,
+            other => panic!("Expected Gather, got {other:?}"),
+        };
+        let json = crate::cli::batch::handlers::misc::dispatch_gather(&view, &args)
+            .expect("dispatch_gather");
+
+        let names: Vec<String> = json["chunks"]
+            .as_array()
+            .map(|chunks| {
+                chunks
+                    .iter()
+                    .filter_map(|c| c["name"].as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        assert!(
+            names.iter().any(|n| n == "renamed_new_token"),
+            "gather must surface the worktree-renamed (NEW) symbol; got names={names:?} json={json}"
+        );
+        assert!(
+            !names.iter().any(|n| n == "renamed_old_token"),
+            "gather must NOT surface the parent (OLD) symbol — overlay masks its origin; got names={names:?} json={json}"
         );
     }
 }

--- a/src/cli/batch/handlers/search.rs
+++ b/src/cli/batch/handlers/search.rs
@@ -77,24 +77,17 @@ fn validate_filter_args(args: &SearchArgs) -> Result<ParsedFilters> {
 ///    `--overlay-root`, the request stays `None` (the overlay is a no-op for
 ///    this query — e.g. a daemon search from the project root itself).
 fn prepare_overlay_request(ctx: &BatchView, args: &SearchArgs) -> Result<()> {
-    cqs::worktree_overlay::clear_overlay_meta();
-    // The default-on flip is decided CLIENT-side: the client applies the
-    // tri-state resolution and forwards a `--overlay` flag (+ `--overlay-root`)
-    // whenever it activates. The daemon has no client cwd, so it never does
-    // default-on itself — `overlay_eligible = false` — but it still honors an
-    // explicit `--no-overlay` / `=0` opt-out that rode the wire (opt-out wins).
-    if !daemon_overlay_active(args) {
-        return Ok(());
-    }
-    if let Some(root) = &args.overlay_root {
-        // Reject (wire error) if the path is not a worktree of this project.
-        ctx.set_validated_overlay_request(root)?;
-    } else {
-        tracing::debug!(
-            "overlay requested but no --overlay-root on the wire — serving parent index"
-        );
-    }
-    Ok(())
+    // Delegate to the surface-agnostic core shared with the seed-overlaid
+    // graph-adjacent commands. `SearchArgs` carries the overlay tri-
+    // state inline; the helper applies the same activation precedence
+    // (`resolve_overlay_active(.., overlay_eligible = false)`) and the same
+    // `--overlay-root` validation.
+    super::prepare_overlay_request_fields(
+        ctx,
+        args.overlay,
+        args.no_overlay,
+        args.overlay_root.as_deref(),
+    )
 }
 
 /// Translate the daemon's [`SearchArgs`] into the surface-agnostic
@@ -1581,6 +1574,223 @@ mod tests {
             !overlaid_has_dead_alpha,
             "the overlay must mask the parent's dead src/lib.rs:alpha_unique_token \
              (origin-level mask over REAL producer paths); got {overlaid}"
+        );
+    }
+
+    // ── Part A: seed-overlaid scout / gather end-to-end ────────────────
+    //
+    // The seed-overlay counterpart of the search e2e above, driven through
+    // `dispatch_scout` / `dispatch_task`. Parent index has `alpha`; the worktree
+    // ADDS a new file with a new symbol. The scout/gather/task SEED retrieval
+    // must surface the worktree's new symbol (which the parent index never had),
+    // and the payload must carry the honest `_meta.overlay_graph = "seed-only"`
+    // marker (the BFS/graph phases still reflect parent-truth). Gated behind
+    // `slow-tests` (real embedder for the dense seed search).
+
+    #[cfg(feature = "slow-tests")]
+    fn parse_scout_args(cli_args: &[&str]) -> crate::cli::args::ScoutArgs {
+        let mut full = vec!["scout"];
+        full.extend_from_slice(cli_args);
+        let input = BatchInput::try_parse_from(&full).expect("clap parse failed");
+        match input.cmd {
+            BatchCmd::Scout { args, .. } => args,
+            other => panic!("Expected Scout, got {:?}", other),
+        }
+    }
+
+    /// Build a parent index (real pipeline) + linked worktree that ADDS a new
+    /// file, then adopt a real embedder onto a fresh context. Returns
+    /// `(dir, ctx, worktree_root)` ready for an overlaid dispatch, or `None`
+    /// when the embedder can't init (CI-without-model → skip).
+    #[cfg(feature = "slow-tests")]
+    fn seed_overlay_ctx_with_added_file() -> Option<(TempDir, BatchContext, PathBuf)> {
+        let dir = TempDir::new().expect("tempdir");
+        let parent = dir.path().join("parent");
+        std::fs::create_dir_all(parent.join("src")).expect("mkdir");
+        std::fs::write(
+            parent.join("src/lib.rs"),
+            "pub fn parent_only_token() -> i32 { 1 }\n",
+        )
+        .expect("write lib.rs");
+        git(&parent, &["init", "-q", "-b", "main"]);
+        git(&parent, &["config", "user.email", "t@e.com"]);
+        git(&parent, &["config", "user.name", "T"]);
+        git(&parent, &["add", "-A"]);
+        git(&parent, &["commit", "-q", "-m", "init"]);
+
+        let embedder = match cqs::Embedder::new_cpu(cqs::embedder::ModelConfig::resolve(None, None))
+        {
+            Ok(e) => e,
+            Err(e) => {
+                eprintln!("skipping seed-overlay e2e: embedder init failed: {e}");
+                return None;
+            }
+        };
+        let parser = cqs::parser::Parser::new().expect("parser");
+
+        let cqs_dir = parent.join(".cqs");
+        std::fs::create_dir_all(&cqs_dir).expect("mkdir .cqs");
+        let index_path = cqs_dir.join("index.db");
+        {
+            let store = Store::open(&index_path).expect("open store");
+            let model_info =
+                ModelInfo::new(&embedder.model_config().repo, embedder.embedding_dim());
+            store.init(&model_info).expect("init store");
+            let mut store = store;
+            store.set_dim(model_info.dimensions);
+            crate::cli::watch::overlay_reindex_files(
+                &parent,
+                &store,
+                &[PathBuf::from("src/lib.rs")],
+                &parser,
+                &embedder,
+                None,
+                true,
+            )
+            .expect("index parent");
+        }
+
+        // Linked worktree that ADDS a brand-new file the parent never indexed.
+        let wt = dir.path().join("wt");
+        git(
+            &parent,
+            &["worktree", "add", "-q", "-b", "lane", wt.to_str().unwrap()],
+        );
+        std::fs::write(
+            wt.join("src/feature.rs"),
+            "/// Compute the new widget total for this lane.\n\
+             pub fn lane_new_widget_total() -> i32 {\n    \
+             let widget_total = 42;\n    \
+             widget_total\n\
+             }\n",
+        )
+        .expect("write feature.rs");
+        let wt = dunce::canonicalize(&wt).unwrap_or(wt);
+
+        let ctx = create_test_context(&cqs_dir).expect("create_test_context");
+        assert!(
+            ctx.adopt_embedder(std::sync::Arc::new(embedder)),
+            "embedder slot empty"
+        );
+        Some((dir, ctx, wt))
+    }
+
+    /// Part A headline (inverts the old `overlay_scout_not_overlaid` scope
+    /// guard): the scout SEED is overlaid. A worktree-added file's symbol
+    /// surfaces as a scout seed, and the payload carries the `seed-only`
+    /// `_meta.overlay_graph` marker.
+    #[cfg(feature = "slow-tests")]
+    #[test]
+    fn overlay_scout_seed_overlaid() {
+        let Some((_dir, ctx, wt)) = seed_overlay_ctx_with_added_file() else {
+            return;
+        };
+        let view = ctx.build_view(None);
+        view.set_validated_overlay_request(&wt)
+            .expect("validate wt");
+
+        let args = parse_scout_args(&[
+            "lane new widget total",
+            "--overlay",
+            "--overlay-root",
+            wt.to_str().unwrap(),
+        ]);
+        let json = crate::cli::batch::handlers::misc::dispatch_scout(&view, &args)
+            .expect("dispatch_scout");
+
+        // The worktree-added symbol surfaces as a scout seed (file group).
+        let surfaced = json["file_groups"]
+            .as_array()
+            .map(|groups| {
+                groups.iter().any(|g| {
+                    g["chunks"].as_array().is_some_and(|chunks| {
+                        chunks.iter().any(|c| c["name"] == "lane_new_widget_total")
+                    })
+                })
+            })
+            .unwrap_or(false);
+        assert!(
+            surfaced,
+            "scout seed must surface the worktree-added symbol (overlaid seed); got {json}"
+        );
+        // The honest seed-only marker rides the payload `_meta`.
+        assert_eq!(
+            json["_meta"]["overlay_graph"], "seed-only",
+            "scout must carry _meta.overlay_graph = seed-only when overlaid; got {json}"
+        );
+    }
+
+    /// Sibling pin: the task pipeline (scout → gather → impact → placement) also
+    /// overlays its scout SEED and carries the `seed-only` marker. Asserts the
+    /// marker; the scout-phase symbol surfacing is covered by the scout test.
+    #[cfg(feature = "slow-tests")]
+    #[test]
+    fn overlay_task_seed_overlaid_marker() {
+        let Some((_dir, ctx, wt)) = seed_overlay_ctx_with_added_file() else {
+            return;
+        };
+        let view = ctx.build_view(None);
+        view.set_validated_overlay_request(&wt)
+            .expect("validate wt");
+
+        let mut full = vec![
+            "task",
+            "lane new widget total",
+            "--overlay",
+            "--overlay-root",
+            wt.to_str().unwrap(),
+        ];
+        let input = BatchInput::try_parse_from(&full).expect("clap parse");
+        let args = match input.cmd {
+            BatchCmd::Task { args, .. } => args,
+            other => panic!("Expected Task, got {other:?}"),
+        };
+        full.clear();
+        let json =
+            crate::cli::batch::handlers::misc::dispatch_task(&view, &args).expect("dispatch_task");
+        assert_eq!(
+            json["_meta"]["overlay_graph"], "seed-only",
+            "task must carry _meta.overlay_graph = seed-only when overlaid; got {json}"
+        );
+    }
+
+    /// Sibling pin: `gather`'s SEED is overlay-wired. The payload carries the
+    /// `seed-only` marker (proof the overlay engaged through `gather_core` →
+    /// `gather_with_overlay` → `merge_seed_results`). Symbol-surfacing through
+    /// `merge_seed_results` itself is asserted by `overlay_scout_seed_overlaid`
+    /// (the IDENTICAL lib codepath) and by the `merge_seed_results` unit tests
+    /// in `worktree_overlay.rs`; gather's seed search applies its own dense
+    /// `seed_threshold` (0.3) on top, so whether a given synthetic symbol clears
+    /// it is an embedder-scoring concern, not a wiring one — pinning a specific
+    /// score here would be flaky.
+    #[cfg(feature = "slow-tests")]
+    #[test]
+    fn overlay_gather_seed_overlaid() {
+        let Some((_dir, ctx, wt)) = seed_overlay_ctx_with_added_file() else {
+            return;
+        };
+        let view = ctx.build_view(None);
+        view.set_validated_overlay_request(&wt)
+            .expect("validate wt");
+
+        let input = BatchInput::try_parse_from([
+            "gather",
+            "Compute the new widget total for this lane",
+            "--overlay",
+            "--overlay-root",
+            wt.to_str().unwrap(),
+        ])
+        .expect("clap parse");
+        let args = match input.cmd {
+            BatchCmd::Gather { args, .. } => args,
+            other => panic!("Expected Gather, got {other:?}"),
+        };
+        let json = crate::cli::batch::handlers::misc::dispatch_gather(&view, &args)
+            .expect("dispatch_gather");
+
+        assert_eq!(
+            json["_meta"]["overlay_graph"], "seed-only",
+            "gather must carry _meta.overlay_graph = seed-only when overlaid; got {json}"
         );
     }
 }

--- a/src/cli/commands/search/gather.rs
+++ b/src/cli/commands/search/gather.rs
@@ -10,8 +10,8 @@ use cqs::reference::ReferenceIndex;
 use cqs::store::{ReadOnly, Store};
 use cqs::Embedder;
 use cqs::{
-    gather, gather_cross_index_with_index, normalize_path, GatherDirection, GatherOptions,
-    GatherResult,
+    gather_cross_index_with_index, gather_with_overlay, normalize_path, GatherDirection,
+    GatherOptions, GatherResult,
 };
 
 use crate::cli::staleness;
@@ -70,6 +70,7 @@ impl Default for GatherArgs {
 ///
 /// Unifying the packing here gives the daemon the same reading-order re-sort
 /// the CLI always had (previously the daemon left packed chunks in score order).
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn gather_core(
     store: &Store<ReadOnly>,
     embedder: &Embedder,
@@ -77,6 +78,7 @@ pub(crate) fn gather_core(
     args: &GatherArgs,
     ref_idx: Option<&ReferenceIndex>,
     project_index: Option<&dyn VectorIndex>,
+    overlay: Option<&cqs::worktree_overlay::WorktreeOverlay>,
 ) -> Result<(GatherResult, Option<(usize, usize)>)> {
     let _span = tracing::info_span!("gather_core", query_len = args.query.len()).entered();
 
@@ -96,6 +98,9 @@ pub(crate) fn gather_core(
     };
 
     let mut result = if let Some(ref_idx) = ref_idx {
+        // Cross-index gather seeds from the REFERENCE, not the project store, so
+        // the worktree overlay (a project-delta shadow) does not apply to the
+        // seed — it stays parent-truth in Part A.
         let query_embedding = embedder.embed_query(&args.query)?;
         gather_cross_index_with_index(
             store,
@@ -107,7 +112,8 @@ pub(crate) fn gather_core(
             project_index,
         )?
     } else {
-        gather(store, embedder, &args.query, &opts, root)?
+        // Project gather: overlay the seed search (Part A).
+        gather_with_overlay(store, embedder, &args.query, &opts, root, overlay)?
     };
 
     let token_info = if let Some(budget) = args.tokens {
@@ -273,9 +279,11 @@ pub(crate) fn cmd_gather(gctx: &GatherContext<'_>) -> Result<()> {
             &args,
             Some(&ref_idx),
             index.as_deref(),
+            // CLI surface serves the parent index (overlay is daemon-only, ).
+            None,
         )?
     } else {
-        gather_core(store, embedder, root, &args, None, None)?
+        gather_core(store, embedder, root, &args, None, None, None)?
     };
     let token_count_used = token_info.map(|(used, _)| used);
 

--- a/src/cli/commands/search/scout.rs
+++ b/src/cli/commands/search/scout.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use colored::Colorize;
 
 use cqs::store::{ReadOnly, Store};
-use cqs::{scout_with_options, Embedder, ScoutOptions};
+use cqs::{scout_with_options, scout_with_overlay, Embedder, ScoutOptions};
 
 // ─── Args (surface-agnostic, MCP-ready) ─────────────────────────────────────
 
@@ -65,11 +65,12 @@ pub(crate) fn scout_core(
     embedder: &Embedder,
     root: &std::path::Path,
     args: &ScoutArgs,
+    overlay: Option<&cqs::worktree_overlay::WorktreeOverlay>,
 ) -> Result<(serde_json::Value, Option<(usize, usize)>)> {
     let _span = tracing::info_span!("scout_core", query = %args.query).entered();
     let limit = args.limit.clamp(1, crate::cli::SCOUT_LIMIT_MAX);
     let opts = scout_options_from_args(args);
-    let result = scout_with_options(store, embedder, &args.query, root, limit, &opts)?;
+    let result = scout_with_overlay(store, embedder, &args.query, root, limit, &opts, overlay)?;
 
     let (content_map, token_info) = if let Some(budget) = args.tokens {
         let named_items = crate::cli::commands::scout_scored_names(&result);
@@ -155,7 +156,8 @@ pub(crate) fn cmd_scout(
             search_threshold,
             min_gap_ratio,
         };
-        let (output, _token_info) = scout_core(store, embedder, root, &args)?;
+        // CLI surface serves the parent index (overlay is daemon-only, ).
+        let (output, _token_info) = scout_core(store, embedder, root, &args, None)?;
         crate::cli::json_envelope::emit_json(&output)?;
         return Ok(());
     }

--- a/src/cli/definitions.rs
+++ b/src/cli/definitions.rs
@@ -1142,6 +1142,22 @@ impl Commands {
         }
     }
 
+    /// The worktree-overlay tri-state `(overlay, no_overlay)` for the seed-
+    /// overlaid graph-adjacent commands (`scout` / `gather` / `task`,
+    /// Part A), or `None` for every other command. The `search` overlay flags
+    /// live on the top-level `Cli` (the default `cqs "query"` form), so the
+    /// dispatch-forward path reads those directly; this accessor covers only the
+    /// subcommand-bound seed overlays. Returns the raw flags — the caller folds
+    /// them through `resolve_overlay_active` with worktree eligibility.
+    pub(crate) fn overlay_tristate(&self) -> Option<(bool, bool)> {
+        match self {
+            Commands::Scout { args, .. } => Some((args.overlay.overlay, args.overlay.no_overlay)),
+            Commands::Gather { args, .. } => Some((args.overlay.overlay, args.overlay.no_overlay)),
+            Commands::Task { args, .. } => Some((args.overlay.overlay, args.overlay.no_overlay)),
+            _ => None,
+        }
+    }
+
     /// `true` when this invocation mutates the resolved `.cqs/` index
     /// (or its slots / cache / refs) — the set the parent-index write
     /// guard gates. Pure reads and daemon-forwarded queries return
@@ -1425,6 +1441,32 @@ mod tests {
 
         let cli = Cli::try_parse_from(["cqs", "stale"]).unwrap();
         assert_eq!(cli.command.unwrap().batch_support(), BatchSupport::Daemon);
+    }
+
+    /// Part A: `cqs scout|gather|task <q> --overlay` binds the overlay
+    /// flag to the SUBCOMMAND (the flattened `OverlayArgs`), not the top-level
+    /// `Cli.overlay`, and `overlay_tristate()` reads it back. Non-overlay
+    /// commands return `None`.
+    #[test]
+    fn overlay_tristate_reads_subcommand_flags() {
+        use clap::Parser;
+        for cmd in ["scout", "gather", "task"] {
+            let cli = Cli::try_parse_from(["cqs", cmd, "q", "--overlay"])
+                .unwrap_or_else(|e| panic!("{cmd} --overlay must parse: {e}"));
+            // The flag bound to the subcommand, NOT the top-level default.
+            assert!(
+                !cli.overlay,
+                "{cmd}: --overlay must bind to the subcommand, not top-level Cli.overlay"
+            );
+            assert_eq!(
+                cli.command.as_ref().unwrap().overlay_tristate(),
+                Some((true, false)),
+                "{cmd}: overlay_tristate must report the subcommand flags"
+            );
+        }
+        // A non-overlay command has no tri-state.
+        let cli = Cli::try_parse_from(["cqs", "impact", "foo"]).unwrap();
+        assert_eq!(cli.command.unwrap().overlay_tristate(), None);
     }
 
     /// `mutates_index()` gates the parent-index write guard. Pin the

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -472,19 +472,26 @@ fn cli_arg_spec() -> cqs::daemon_translate::CliArgSpec {
 }
 
 /// `true` when the worktree overlay should be forwarded to the daemon for this
-/// invocation. Uses the SAME shared resolution as the CLI `QueryArgs::from_cli`
-/// adapter ([`resolve_overlay_active`]) so the two surfaces cannot diverge: a
-/// `--no-overlay` / `CQS_WORKTREE_OVERLAY=0` opt-out wins; else `--overlay` /
+/// invocation, from the resolved overlay tri-state flags. Uses the SAME shared
+/// resolution as the CLI `QueryArgs::from_cli` adapter ([`resolve_overlay_active`])
+/// so the two surfaces cannot diverge: a `--no-overlay` /
+/// `CQS_WORKTREE_OVERLAY=0` opt-out wins; else `--overlay` /
 /// `CQS_WORKTREE_OVERLAY=1` opt-in; else default-on iff in an eligible worktree
 /// (`overlay_eligible`). The forward block already gates on `overlay_root`, so
 /// `overlay_eligible` here is that same `overlay_root(cwd, root).is_some()`.
+///
+/// Takes the flags directly (not `&Cli`) because the seed-overlaid graph
+/// commands (`scout` / `gather` / `task`) carry their overlay flags on the
+/// subcommand's flattened `OverlayArgs`, while the default search carries them
+/// on the top-level `Cli` — the caller resolves which applies and passes the
+/// effective pair.
 #[cfg(unix)]
-fn overlay_requested_for_forward(cli: &Cli, overlay_eligible: bool) -> bool {
-    crate::cli::commands::search::query::resolve_overlay_active(
-        cli.overlay,
-        cli.no_overlay,
-        overlay_eligible,
-    )
+fn overlay_requested_for_forward_flags(
+    flag_on: bool,
+    flag_off: bool,
+    overlay_eligible: bool,
+) -> bool {
+    crate::cli::commands::search::query::resolve_overlay_active(flag_on, flag_off, overlay_eligible)
 }
 
 /// `true` when the overlay is explicitly forced OFF for this invocation
@@ -492,8 +499,8 @@ fn overlay_requested_for_forward(cli: &Cli, overlay_eligible: bool) -> bool {
 /// short-circuits the worktree probe in that case. Thin wrapper over the shared
 /// [`query::overlay_force_off`] so the opt-out spelling lives in one place.
 #[cfg(unix)]
-fn overlay_force_off(cli: &Cli) -> bool {
-    crate::cli::commands::search::query::overlay_force_off(cli.no_overlay)
+fn overlay_force_off_flags(flag_off: bool) -> bool {
+    crate::cli::commands::search::query::overlay_force_off(flag_off)
 }
 
 /// Try to forward the current command to a running daemon.
@@ -625,49 +632,67 @@ fn try_daemon_query(cqs_dir: &std::path::Path, cli: &Cli) -> Result<Option<Strin
         &cli_arg_spec(),
     );
 
-    // Worktree-overlay daemon forward (result-trust §3, plan §8). The daemon's
-    // cwd is the parent project and the wire request carries no cwd, so when an
-    // overlay is requested the client must say WHICH worktree. We resolve the
-    // overlay root here (CLI-side `cqs::worktree::overlay_root` over the real
-    // cwd + resolved root) and append the hidden `--overlay-root <abs>` flag
-    // post-translate; the daemon re-validates it (canonicalize +
-    // `resolve_main_project_dir == served root`) before reading any files.
+    // Worktree-overlay daemon forward (result-trust §3, plan §8). Part A
+    // extended it from `search`-only to the seed-overlaid graph-adjacent
+    // commands. The daemon's cwd is the parent project and the wire request
+    // carries no cwd, so when an overlay is requested the client must say WHICH
+    // worktree. We resolve the overlay root here (CLI-side
+    // `cqs::worktree::overlay_root` over the real cwd + resolved root) and append
+    // the hidden `--overlay-root <abs>` flag post-translate; the daemon
+    // re-validates it (canonicalize + `resolve_main_project_dir == served root`)
+    // before reading any files.
     //
-    // Forwards only for the `search` command (the only daemon command the
-    // overlay applies to) and only from an eligible worktree. Activation is the
-    // shared tri-state resolution (the default-on flip): default-on requires
-    // eligibility (`overlay_root.is_some()`), so we resolve the root FIRST and
-    // feed `root.is_some()` to the resolver — a non-worktree CWD short-circuits
-    // before any decision. Env-only / default activations still append the
-    // forwardable `--overlay` flag (the daemon is a separate long-lived process
-    // that does not see the client's env, and the wire `--overlay` is what its
-    // `prepare_overlay_request` consults), and a `--no-overlay` / `=0` opt-out
-    // resolves to `false` so nothing is forwarded.
+    // Forwards for `search` (whole-result overlay) plus `scout` / `gather` /
+    // `task` (seed-only overlay), and only from an eligible worktree. The
+    // overlay flags live in two places: top-level `Cli.overlay`/`no_overlay`
+    // for the default `cqs "query"` search form, and on the subcommand's
+    // flattened `OverlayArgs` for `scout`/`gather`/`task` (so `cqs scout q
+    // --overlay` binds to the subcommand, not the top-level flag). We read the
+    // effective tri-state from whichever applies.
+    //
+    // Activation is the shared tri-state resolution (the default-on flip):
+    // default-on requires eligibility (`overlay_root.is_some()`), so we resolve
+    // the root FIRST and feed `root.is_some()` to the resolver — a non-worktree
+    // CWD short-circuits before any decision. Env-only / default activations
+    // still append the forwardable `--overlay` flag (the daemon is a separate
+    // long-lived process that does not see the client's env, and the wire
+    // `--overlay` is what its `prepare_overlay_request` consults), and a
+    // `--no-overlay` / `=0` opt-out resolves to `false` so nothing is forwarded.
     //
     // An explicit opt-out short-circuits BEFORE the worktree probe: when the
     // overlay can never activate (`--no-overlay` / `CQS_WORKTREE_OVERLAY=0`),
     // there is no reason to resolve the project root or read `.git` on every
-    // search, so the default-on probe stays off the opted-out hot path.
-    if command == "search" && !overlay_force_off(cli) {
-        let resolved_root = find_project_root();
-        let overlay_root = std::env::current_dir()
-            .ok()
-            .and_then(|cwd| cqs::worktree::overlay_root(&cwd, &resolved_root));
-        if overlay_requested_for_forward(cli, overlay_root.is_some()) {
-            if let Some(root) = overlay_root {
-                if !cmd_args.iter().any(|a| a == "--overlay") {
-                    cmd_args.push("--overlay".to_string());
+    // query, so the default-on probe stays off the opted-out hot path.
+    if matches!(command.as_str(), "search" | "scout" | "gather" | "task") {
+        // Effective overlay tri-state: the subcommand's flattened flags for
+        // scout/gather/task, else the top-level Cli flags (default search).
+        let (flag_on, flag_off) = cli
+            .command
+            .as_ref()
+            .and_then(|c| c.overlay_tristate())
+            .unwrap_or((cli.overlay, cli.no_overlay));
+        if !overlay_force_off_flags(flag_off) {
+            let resolved_root = find_project_root();
+            let overlay_root = std::env::current_dir()
+                .ok()
+                .and_then(|cwd| cqs::worktree::overlay_root(&cwd, &resolved_root));
+            if overlay_requested_for_forward_flags(flag_on, flag_off, overlay_root.is_some()) {
+                if let Some(root) = overlay_root {
+                    if !cmd_args.iter().any(|a| a == "--overlay") {
+                        cmd_args.push("--overlay".to_string());
+                    }
+                    cmd_args.push("--overlay-root".to_string());
+                    cmd_args.push(root.to_string_lossy().into_owned());
+                    tracing::debug!(
+                        command = %command,
+                        overlay_root = %root.display(),
+                        "forwarding worktree overlay to daemon"
+                    );
+                } else {
+                    tracing::debug!(
+                        "overlay explicitly requested but cwd is not an eligible worktree — not forwarding overlay-root"
+                    );
                 }
-                cmd_args.push("--overlay-root".to_string());
-                cmd_args.push(root.to_string_lossy().into_owned());
-                tracing::debug!(
-                    overlay_root = %root.display(),
-                    "forwarding worktree overlay to daemon"
-                );
-            } else {
-                tracing::debug!(
-                    "overlay explicitly requested but cwd is not an eligible worktree — not forwarding overlay-root"
-                );
             }
         }
     }

--- a/src/gather.rs
+++ b/src/gather.rs
@@ -394,13 +394,36 @@ pub(crate) fn bfs_expand(
 
 /// Batch-fetch chunks for expanded names, deduplicate by id, assemble `GatheredChunk`s.
 ///
+/// `overlay_seeds`, when `Some`, maps an overlay-origin SEED name to its overlay
+/// `SearchResult` (built by `WorktreeOverlay::overlay_origin_seeds` /
+/// `overlay_seed_chunks_for_names`). A depth-0 name present there is assembled
+/// from the OVERLAY chunk and EXCLUDED from the parent by-name batch, so a
+/// worktree-added seed surfaces (the parent store has no chunk for it) and a
+/// worktree-modified seed shows its worktree content (not the parent's stale
+/// copy). Expansion (depth > 0) always re-fetches from the parent store —
+/// graph expansion stays parent-truth in Part A. `None` (the no-overlay path
+/// and the cross-index / onboard callers) is byte-identical to the prior
+/// parent-only behavior.
+///
 /// Returns `(chunks, search_degraded)`.
 pub(crate) fn fetch_and_assemble<Mode>(
     store: &Store<Mode>,
     name_scores: &HashMap<String, (f32, usize)>,
     root: &Path,
+    overlay_seeds: Option<&HashMap<String, crate::store::SearchResult>>,
 ) -> (Vec<GatheredChunk>, bool) {
-    let all_names: Vec<&str> = name_scores.keys().map(|s| s.as_str()).collect();
+    // A name is served from the overlay only at depth 0. Exclude those names
+    // from the parent batch so we never spend an FTS probe re-fetching a chunk
+    // we're about to override (and so a parent name-collision can't sneak in).
+    let is_overlay_seed = |name: &str, depth: usize| -> bool {
+        depth == 0 && overlay_seeds.is_some_and(|seeds| seeds.contains_key(name))
+    };
+
+    let all_names: Vec<&str> = name_scores
+        .iter()
+        .filter(|(name, (_, depth))| !is_overlay_seed(name, *depth))
+        .map(|(name, _)| name.as_str())
+        .collect();
     let (batch_results, search_degraded) = match store.search_by_names_batch(&all_names, 1) {
         Ok(r) => (r, false),
         Err(e) => {
@@ -413,6 +436,18 @@ pub(crate) fn fetch_and_assemble<Mode>(
     let mut chunks: Vec<GatheredChunk> = Vec::new();
 
     for (name, (score, depth)) in name_scores {
+        // Prefer the overlay seed for an overlay-origin depth-0 name: the
+        // parent store either has no chunk for it (worktree-added) or a stale
+        // one (worktree-modified). This is the gather/task analogue of scout
+        // consuming the merged `SearchResult`s directly.
+        if is_overlay_seed(name, *depth) {
+            if let Some(r) = overlay_seeds.and_then(|seeds| seeds.get(name)) {
+                if seen_ids.insert(r.chunk.id.clone()) {
+                    chunks.push(GatheredChunk::from_search(r, root, *score, *depth, None));
+                }
+                continue;
+            }
+        }
         if let Some(results) = batch_results.get(name) {
             if let Some(r) = results.first() {
                 // HashSet::insert returns false if the key was already
@@ -612,6 +647,14 @@ pub fn gather_with_graph_overlay<Mode>(
         }
     }
 
+    // Overlay-origin seeds: assemble these depth-0 chunks from the OVERLAY
+    // store, not the parent. The parent has no chunk for a worktree-added seed
+    // (it would be silently dropped) and a stale one for a worktree-modified
+    // seed — so without this, the `seed-only` `_meta.overlay_graph` marker
+    // would lie for the headline case (new code added in the lane). Only the
+    // seed surfaces overlaid; the BFS expansion below stays parent-truth.
+    let overlay_seeds = overlay.map(|ov| ov.overlay_origin_seeds(&seed_results));
+
     // 2. BFS expand
     let expansion_capped = bfs_expand(&mut name_scores, graph, opts);
     tracing::info!(
@@ -621,7 +664,8 @@ pub fn gather_with_graph_overlay<Mode>(
     );
 
     // 3. Batch-fetch chunks, deduplicate
-    let (mut chunks, search_degraded) = fetch_and_assemble(store, &name_scores, root);
+    let (mut chunks, search_degraded) =
+        fetch_and_assemble(store, &name_scores, root, overlay_seeds.as_ref());
 
     // 3b. Attach seed provenance to depth-0 chunks. Expanded chunks (depth > 0)
     // weren't retrieved by fusion and keep an empty `rank_signals`.
@@ -835,7 +879,10 @@ pub fn gather_cross_index_with_index<Mode: Sync>(
     );
 
     // 5. Batch-fetch project chunks
-    let (project_chunks, search_degraded) = fetch_and_assemble(project_store, &name_scores, root);
+    // Cross-index gather seeds from the reference, not the project store —
+    // the worktree overlay does not apply (Part A), so no overlay seeds.
+    let (project_chunks, search_degraded) =
+        fetch_and_assemble(project_store, &name_scores, root, None);
 
     // 6. Combine ref seeds + project chunks, sort by score, truncate, re-sort to reading order
     let mut all_chunks = ref_chunks;

--- a/src/gather.rs
+++ b/src/gather.rs
@@ -480,6 +480,8 @@ pub(crate) fn sort_and_truncate(chunks: &mut Vec<GatheredChunk>, limit: usize) {
 ///
 /// Embeds the query internally (or uses `opts.query_embedding` if pre-computed).
 /// Loads the call graph internally. For pre-loaded graph, use [`gather_with_graph`].
+/// Serves the parent index for the seed search; for worktree-overlaid seeds use
+/// [`gather_with_overlay`].
 pub fn gather<Mode>(
     store: &Store<Mode>,
     embedder: &Embedder,
@@ -487,18 +489,43 @@ pub fn gather<Mode>(
     opts: &GatherOptions,
     root: &Path,
 ) -> Result<GatherResult, AnalysisError> {
+    gather_with_overlay(store, embedder, description, opts, root, None)
+}
+
+/// Like [`gather`] but accepts an optional worktree search overlay (
+/// Part A). `Some` shadows the parent index for the SEED search; `None` is
+/// byte-identical to [`gather`]. Only the daemon path (from an eligible
+/// worktree) passes `Some` — see `dispatch_gather`. The BFS expansion stays on
+/// parent-truth (the adapter emits a `seed-only` `_meta.overlay_graph` marker).
+pub fn gather_with_overlay<Mode>(
+    store: &Store<Mode>,
+    embedder: &Embedder,
+    description: &str,
+    opts: &GatherOptions,
+    root: &Path,
+    overlay: Option<&crate::worktree_overlay::WorktreeOverlay>,
+) -> Result<GatherResult, AnalysisError> {
     let query_embedding = match &opts.query_embedding {
         Some(emb) => emb.clone(),
         None => embedder.embed_query(description)?,
     };
     let graph = store.get_call_graph()?;
-    gather_with_graph(store, &query_embedding, description, opts, root, &graph)
+    gather_with_graph_overlay(
+        store,
+        &query_embedding,
+        description,
+        opts,
+        root,
+        &graph,
+        overlay,
+    )
 }
 
 /// Like [`gather`] but accepts a pre-loaded call graph.
 ///
 /// Use when the caller already has the graph (e.g., batch mode or `task()`
-/// which shares the graph across phases).
+/// which shares the graph across phases). Serves the parent index for the seed
+/// search; for worktree-overlaid seeds use [`gather_with_graph_overlay`].
 pub fn gather_with_graph<Mode>(
     store: &Store<Mode>,
     query_embedding: &crate::Embedding,
@@ -506,6 +533,24 @@ pub fn gather_with_graph<Mode>(
     opts: &GatherOptions,
     root: &Path,
     graph: &CallGraph,
+) -> Result<GatherResult, AnalysisError> {
+    gather_with_graph_overlay(store, query_embedding, query_text, opts, root, graph, None)
+}
+
+/// Like [`gather_with_graph`] but accepts an optional worktree search overlay
+/// (Part A). `Some` shadows the parent index for the SEED search so a
+/// worktree-added/edited file surfaces as a gather seed; `None` is byte-
+/// identical to [`gather_with_graph`]. The BFS / call-graph expansion stays on
+/// parent-truth — only the seed is overlaid (Part B extends the graph).
+#[allow(clippy::too_many_arguments)]
+pub fn gather_with_graph_overlay<Mode>(
+    store: &Store<Mode>,
+    query_embedding: &crate::Embedding,
+    query_text: &str,
+    opts: &GatherOptions,
+    root: &Path,
+    graph: &CallGraph,
+    overlay: Option<&crate::worktree_overlay::WorktreeOverlay>,
 ) -> Result<GatherResult, AnalysisError> {
     let _span = tracing::info_span!(
         "gather",
@@ -530,6 +575,21 @@ pub fn gather_with_graph<Mode>(
         opts.seed_limit,
         opts.seed_threshold,
     )?;
+
+    // Worktree overlay (Part A): shadow the parent index for the SEED
+    // search before BFS expansion. Inactive (`None`) ⇒ no-op. The expansion
+    // below walks the parent call graph — only the seeds reflect the worktree
+    // delta (the `seed-only` `_meta.overlay_graph` marker).
+    let seed_results = match overlay {
+        Some(ov) => ov.merge_seed_results(
+            seed_results,
+            query_embedding,
+            &filter,
+            opts.seed_limit,
+            opts.seed_threshold,
+        ),
+        None => seed_results,
+    };
     tracing::debug!(seed_count = seed_results.len(), "Seed search complete");
     if seed_results.is_empty() {
         return Ok(GatherResult {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,8 +207,9 @@ pub use store::{HnswKind, ModelInfo, SearchFilter, Store};
 pub use diff::{semantic_diff, DiffEntry, DiffResult};
 pub use focused_read::COMMON_TYPES;
 pub use gather::{
-    gather, gather_cross_index_with_index, gather_max_nodes, gather_with_graph, GatherDirection,
-    GatherOptions, GatherResult, GatheredChunk, DEFAULT_MAX_EXPANDED_NODES,
+    gather, gather_cross_index_with_index, gather_max_nodes, gather_with_graph,
+    gather_with_graph_overlay, gather_with_overlay, GatherDirection, GatherOptions, GatherResult,
+    GatheredChunk, DEFAULT_MAX_EXPANDED_NODES,
 };
 /// Cross-project call graph types and context.
 pub mod cross_project {
@@ -243,13 +244,14 @@ pub use project::{
 };
 pub use related::{find_related, RelatedFunction, RelatedResult};
 pub use scout::{
-    scout, scout_with_options, ChunkRole, FileGroup, ScoutChunk, ScoutOptions, ScoutResult,
-    ScoutSummary, DEFAULT_SCOUT_SEARCH_LIMIT, DEFAULT_SCOUT_SEARCH_THRESHOLD,
+    scout, scout_with_options, scout_with_overlay, ChunkRole, FileGroup, ScoutChunk, ScoutOptions,
+    ScoutResult, ScoutSummary, DEFAULT_SCOUT_SEARCH_LIMIT, DEFAULT_SCOUT_SEARCH_THRESHOLD,
 };
 pub use search::{parse_target, resolve_target, ResolvedTarget};
 pub use structural::Pattern;
 pub use task::{
-    extract_modify_targets, task, task_with_resources, FunctionRisk, TaskResult, TaskSummary,
+    extract_modify_targets, task, task_with_resources, task_with_resources_overlay, FunctionRisk,
+    TaskResult, TaskSummary,
 };
 pub use where_to_add::{
     suggest_placement, suggest_placement_with_options, FileSuggestion, LanguagePatternDef,

--- a/src/onboard.rs
+++ b/src/onboard.rs
@@ -270,7 +270,7 @@ pub fn onboard<Mode>(
     //    so we do a direct lookup and prefer the exact name + file match from scout.
     let entry_point = fetch_entry_point(store, &entry_name, &entry_file, root)?;
 
-    let (mut callee_chunks, _) = fetch_and_assemble(store, &callee_scores, root);
+    let (mut callee_chunks, _) = fetch_and_assemble(store, &callee_scores, root, None);
     // Sort by depth asc, then file/line within depth
     callee_chunks.sort_by(|a, b| {
         a.depth
@@ -281,7 +281,7 @@ pub fn onboard<Mode>(
     let call_chain: Vec<OnboardEntry> =
         callee_chunks.into_iter().map(gathered_to_onboard).collect();
 
-    let (mut caller_chunks, _) = fetch_and_assemble(store, &caller_scores, root);
+    let (mut caller_chunks, _) = fetch_and_assemble(store, &caller_scores, root, None);
     // Sort callers by score desc. Secondary sort on (file, line_start, name)
     // keeps equal-score callers deterministically ordered across process
     // invocations.

--- a/src/scout.rs
+++ b/src/scout.rs
@@ -137,6 +137,10 @@ pub fn scout<Mode>(
 }
 
 /// Run scout analysis with configurable search parameters.
+///
+/// Serves the parent index for the seed search — the CLI-direct / eval / no-
+/// daemon path. For worktree-overlaid seeds (daemon path) use
+/// [`scout_with_overlay`].
 pub fn scout_with_options<Mode>(
     store: &Store<Mode>,
     embedder: &Embedder,
@@ -144,6 +148,23 @@ pub fn scout_with_options<Mode>(
     root: &Path,
     limit: usize,
     opts: &ScoutOptions,
+) -> Result<ScoutResult, AnalysisError> {
+    scout_with_overlay(store, embedder, task, root, limit, opts, None)
+}
+
+/// Like [`scout_with_options`] but accepts an optional worktree search overlay
+/// (Part A). `Some` shadows the parent index for the SEED search so a
+/// worktree-added/edited file surfaces as a scout seed; `None` is byte-identical
+/// to [`scout_with_options`]. Only the daemon path (from an eligible worktree)
+/// passes `Some` — see `dispatch_scout`.
+pub fn scout_with_overlay<Mode>(
+    store: &Store<Mode>,
+    embedder: &Embedder,
+    task: &str,
+    root: &Path,
+    limit: usize,
+    opts: &ScoutOptions,
+    overlay: Option<&crate::worktree_overlay::WorktreeOverlay>,
 ) -> Result<ScoutResult, AnalysisError> {
     let _span = tracing::info_span!("scout", task_len = task.len(), limit).entered();
     let query_embedding = embedder.embed_query(task)?;
@@ -165,6 +186,7 @@ pub fn scout_with_options<Mode>(
         graph: &graph,
         test_chunks: &test_chunks,
         reachability: None,
+        overlay,
     })
 }
 
@@ -182,6 +204,13 @@ pub(crate) struct ScoutResources<'a, Mode> {
     /// the forward BFS (e.g. `cqs task`). `None` means `scout_core` computes it
     /// on demand inside `compute_hints_batch`.
     pub reachability: Option<&'a std::collections::HashMap<std::sync::Arc<str>, usize>>,
+    /// Worktree search overlay to shadow the parent index for the SEED search
+    /// (Part A). `Some` only on the daemon path from an eligible worktree;
+    /// `None` (CLI-direct / clean worktree / main checkout) serves the parent
+    /// index unchanged. Applied to the seed `search_filtered` result before
+    /// grouping; the downstream BFS/call-graph hints stay on parent-truth (the
+    /// `seed-only` `_meta.overlay_graph` marker the adapter emits says so).
+    pub overlay: Option<&'a crate::worktree_overlay::WorktreeOverlay>,
 }
 
 /// Core scout implementation accepting pre-loaded resources.
@@ -218,6 +247,22 @@ pub(crate) fn scout_core<Mode>(
         opts.search_limit,
         opts.search_threshold,
     )?;
+
+    // Worktree overlay (Part A): shadow the parent index for the SEED
+    // search so a worktree-added/edited file surfaces as a scout seed. Inactive
+    // (`None`) ⇒ no-op returning the parent seeds unchanged. The downstream
+    // grouping, caller counts, staleness, and BFS hints all reflect parent
+    // truth — the seeds are overlaid, the graph is not (Part B).
+    let results = match res.overlay {
+        Some(ov) => ov.merge_seed_results(
+            results,
+            query_embedding,
+            &filter,
+            opts.search_limit,
+            opts.search_threshold,
+        ),
+        None => results,
+    };
 
     tracing::debug!(search_results = results.len(), "Scout search complete");
 
@@ -743,6 +788,7 @@ mod tests {
             graph: &graph,
             test_chunks: &test_chunks,
             reachability: None,
+            overlay: None,
         })
         .unwrap();
 
@@ -821,6 +867,7 @@ mod tests {
             graph: &graph,
             test_chunks: &test_chunks,
             reachability: None,
+            overlay: None,
         })
         .unwrap();
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -249,6 +249,19 @@ pub(crate) fn task_core<Mode>(
         let mut name_scores: HashMap<String, (f32, usize)> =
             targets.iter().map(|n| (n.to_string(), (1.0, 0))).collect();
 
+        // Overlay-origin targets (depth 0): the scout phase surfaced these from
+        // the worktree delta, but `fetch_and_assemble` re-materializes by name
+        // from the PARENT store — which drops a worktree-added target and serves
+        // stale content for a worktree-modified one. Recover the overlay chunk
+        // by exact name so the `code` section is as honest about the delta as
+        // the scout phase that produced the targets. BFS expansion below (and
+        // the impact/placement phases) stay parent-truth (the `seed-only`
+        // marker).
+        let overlay_seeds = overlay.map(|ov| {
+            let target_names: Vec<&str> = targets.iter().map(|s| s.as_str()).collect();
+            ov.overlay_seed_chunks_for_names(&target_names)
+        });
+
         // `GatherOptions::default()` resolves `CQS_GATHER_MAX_NODES` for the
         // node cap; depth is `CQS_TASK_GATHER_DEPTH` / `CQS_GATHER_DEPTH`
         // overridable via `task_gather_depth()`.
@@ -260,7 +273,8 @@ pub(crate) fn task_core<Mode>(
                 .with_direction(GatherDirection::Both),
         );
 
-        let (mut chunks, _degraded) = fetch_and_assemble(store, &name_scores, root);
+        let (mut chunks, _degraded) =
+            fetch_and_assemble(store, &name_scores, root, overlay_seeds.as_ref());
         sort_and_truncate(&mut chunks, limit * TASK_GATHER_LIMIT_MULTIPLIER);
         chunks
     };

--- a/src/task.rs
+++ b/src/task.rs
@@ -130,7 +130,9 @@ pub fn task<Mode>(
 /// Like [`task`] but accepts pre-loaded call graph and test chunks.
 ///
 /// Use this in batch mode where `BatchContext` caches these resources across
-/// commands, avoiding repeated loading per pipeline stage.
+/// commands, avoiding repeated loading per pipeline stage. Serves the parent
+/// index for the scout seed; for worktree-overlaid seeds use
+/// [`task_with_resources_overlay`].
 pub fn task_with_resources<Mode>(
     store: &Store<Mode>,
     embedder: &Embedder,
@@ -139,6 +141,34 @@ pub fn task_with_resources<Mode>(
     limit: usize,
     graph: &crate::store::CallGraph,
     test_chunks: &[crate::store::ChunkSummary],
+) -> Result<TaskResult, AnalysisError> {
+    task_with_resources_overlay(
+        store,
+        embedder,
+        description,
+        root,
+        limit,
+        graph,
+        test_chunks,
+        None,
+    )
+}
+
+/// Like [`task_with_resources`] but accepts an optional worktree search overlay
+/// (Part A). `Some` shadows the parent index for the scout SEED search;
+/// `None` is byte-identical to [`task_with_resources`]. Only the daemon path
+/// (from an eligible worktree) passes `Some` — see `dispatch_task`. The
+/// downstream gather/impact/placement phases stay on parent-truth.
+#[allow(clippy::too_many_arguments)]
+pub fn task_with_resources_overlay<Mode>(
+    store: &Store<Mode>,
+    embedder: &Embedder,
+    description: &str,
+    root: &Path,
+    limit: usize,
+    graph: &crate::store::CallGraph,
+    test_chunks: &[crate::store::ChunkSummary],
+    overlay: Option<&crate::worktree_overlay::WorktreeOverlay>,
 ) -> Result<TaskResult, AnalysisError> {
     let _span = tracing::info_span!("task", description_len = description.len(), limit).entered();
 
@@ -155,6 +185,7 @@ pub fn task_with_resources<Mode>(
         limit,
         graph,
         test_chunks,
+        overlay,
     )
 }
 
@@ -171,6 +202,7 @@ pub(crate) fn task_core<Mode>(
     limit: usize,
     graph: &crate::store::CallGraph,
     test_chunks: &[crate::store::ChunkSummary],
+    overlay: Option<&crate::worktree_overlay::WorktreeOverlay>,
 ) -> Result<TaskResult, AnalysisError> {
     let _span =
         tracing::info_span!("task_core", description_len = description.len(), limit).entered();
@@ -187,7 +219,10 @@ pub(crate) fn task_core<Mode>(
         crate::impact::DEFAULT_MAX_TEST_SEARCH_DEPTH,
     );
 
-    // 2. Scout phase
+    // 2. Scout phase — overlaid seed search (Part A). The subsequent
+    // gather/impact/placement phases fetch by name from the parent store, so
+    // they stay on parent-truth; only the scout seed reflects the worktree
+    // delta (the `seed-only` `_meta.overlay_graph` marker the adapter emits).
     let scout = scout_core(&ScoutResources {
         store,
         query_embedding,
@@ -198,6 +233,7 @@ pub(crate) fn task_core<Mode>(
         graph,
         test_chunks,
         reachability: Some(&reachability),
+        overlay,
     })?;
     tracing::debug!(
         file_groups = scout.file_groups.len(),
@@ -790,6 +826,7 @@ mod tests {
             10,
             &graph,
             &test_chunks,
+            None,
         )
         .unwrap();
 

--- a/src/worktree_overlay.rs
+++ b/src/worktree_overlay.rs
@@ -267,6 +267,103 @@ impl WorktreeOverlay {
 
         merged
     }
+
+    /// Extract the overlay-ORIGIN seeds from a merged seed set, keyed by name.
+    ///
+    /// An overlay-origin seed is one whose `chunk.file` is in `masked_origins`
+    /// — i.e. it came from the overlay fan-out (a worktree-added, -renamed, or
+    /// -modified origin), not the masked-survivor parent tail. (A parent
+    /// survivor never has its file in `masked_origins`; `merge_seed_results`
+    /// drops those first.)
+    ///
+    /// `gather`/`task` PREFER these over a by-name re-fetch when assembling
+    /// depth-0 chunks: the parent store has no chunk for an overlay-only name
+    /// (a worktree-added function), and serves STALE content for a modified
+    /// origin's name. Surfacing the overlay seed itself makes gather/task as
+    /// honest about the worktree delta as `scout` (which consumes the merged
+    /// `SearchResult`s directly) — the `seed-only` `_meta.overlay_graph` marker
+    /// then tells the truth: seeds (and their chunks) overlaid, expansion
+    /// parent-truth. The expansion (BFS) stays parent-truth in Part A.
+    ///
+    /// Name-keyed: a name-collision between an overlay seed and an
+    /// equally-named parent BFS-expanded node resolves to the overlay version
+    /// only at depth 0 (`fetch_and_assemble` consults this map for depth-0
+    /// chunks only), matching where `merge_seed_results` placed it.
+    pub fn overlay_origin_seeds(
+        &self,
+        merged: &[crate::store::SearchResult],
+    ) -> std::collections::HashMap<String, crate::store::SearchResult> {
+        let _span = tracing::info_span!(
+            "overlay_origin_seeds",
+            merged = merged.len(),
+            masked = self.masked_origins.len()
+        )
+        .entered();
+        let mut out = std::collections::HashMap::new();
+        for sr in merged {
+            if self.masked_origins.contains(&sr.chunk.file) {
+                // Last writer wins on a name collision among overlay seeds —
+                // `merge_seed_results` already sorted by score desc, so the
+                // entry().or_insert keeps the highest-scoring overlay hit.
+                out.entry(sr.chunk.name.clone())
+                    .or_insert_with(|| sr.clone());
+            }
+        }
+        out
+    }
+
+    /// Fetch overlay-store chunks for `names` by EXACT name, restricted to
+    /// overlay-origin chunks, as a name → `SearchResult` map.
+    ///
+    /// `task`'s gather phase derives its targets as bare names from the scout
+    /// output (no `SearchResult` survives), then re-materializes chunks by name
+    /// from the PARENT store — which silently drops a worktree-added target and
+    /// serves stale content for a worktree-modified one. This recovers the
+    /// overlay chunk for any such target so the task `code` section carries the
+    /// worktree content, matching the overlaid scout phase that surfaced the
+    /// target in the first place.
+    ///
+    /// Exact-name (`get_chunks_by_names_batch`) rather than the FTS-fuzzy
+    /// `search_by_names_batch`: a target is an exact symbol name from scout, and
+    /// the overlay store is tiny, so a fuzzy match would only invite
+    /// false-positive overlay chunks. Score is a sentinel `1.0` (these are
+    /// pinned targets, not re-ranked hits). Best-effort: a store error logs and
+    /// degrades to an empty map (the parent re-fetch then runs unchanged).
+    pub fn overlay_seed_chunks_for_names(
+        &self,
+        names: &[&str],
+    ) -> std::collections::HashMap<String, crate::store::SearchResult> {
+        let _span = tracing::info_span!(
+            "overlay_seed_chunks_for_names",
+            count = names.len(),
+            masked = self.masked_origins.len()
+        )
+        .entered();
+        let mut out = std::collections::HashMap::new();
+        let by_name = match self.store.get_chunks_by_names_batch(names) {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "overlay seed-by-name fetch failed; task gather falls back to parent re-fetch"
+                );
+                return out;
+            }
+        };
+        for (name, chunks) in by_name {
+            // Keep only chunks whose origin is in the delta (overlay-origin) —
+            // the overlay store holds ONLY delta files, so this is belt-and-
+            // suspenders, but it keeps the invariant explicit and survives any
+            // future overlay-store contents change.
+            if let Some(chunk) = chunks
+                .into_iter()
+                .find(|c| self.masked_origins.contains(&c.file))
+            {
+                out.insert(name, crate::store::SearchResult::new(chunk, 1.0));
+            }
+        }
+        out
+    }
 }
 
 // ─── `_meta.worktree_overlay` envelope state ────────────────────────────────
@@ -1077,14 +1174,14 @@ mod tests {
         /// One-hot embedding (`1.0` at `slot`). Distinct slots are near-
         /// orthogonal, so a query at `slot` retrieves only the chunk seeded
         /// there from the brute-force overlay store.
-        fn one_hot(slot: usize) -> Embedding {
+        pub(super) fn one_hot(slot: usize) -> Embedding {
             let mut v = vec![0.0_f32; crate::EMBEDDING_DIM];
             v[slot] = 1.0;
             Embedding::new(v)
         }
 
         /// A project-side seed `SearchResult` for `(file, name, score)`.
-        fn project_result(file: &str, name: &str, score: f32) -> SearchResult {
+        pub(super) fn project_result(file: &str, name: &str, score: f32) -> SearchResult {
             let summary = ChunkSummary {
                 id: format!("{file}:{name}"),
                 file: PathBuf::from(file),
@@ -1108,7 +1205,10 @@ mod tests {
 
         /// Build a `WorktreeOverlay` whose in-memory store holds one chunk per
         /// `(file, name, slot)` triple, with `masked_origins` exactly `masked`.
-        fn overlay_with(seeds: &[(&str, &str, usize)], masked: &[&str]) -> WorktreeOverlay {
+        pub(super) fn overlay_with(
+            seeds: &[(&str, &str, usize)],
+            masked: &[&str],
+        ) -> WorktreeOverlay {
             let mut store = Store::open_memory().expect("open_memory");
             store.init(&ModelInfo::default()).expect("init store");
             store.set_dim(crate::EMBEDDING_DIM);
@@ -1242,6 +1342,90 @@ mod tests {
             assert_eq!(merged.len(), 2, "truncated to limit=2");
             assert_eq!(merged[0].chunk.name, "high", "overlay hit ranks first");
             assert_eq!(merged[1].chunk.name, "mid", "lowest-scoring hit dropped");
+        }
+    }
+
+    // ── overlay-origin seed surfacing (gather/task depth-0 preference) ──
+    //
+    // The seed sites PREFER these chunks at depth 0 so gather/task surface an
+    // overlay-origin seed's worktree content (matching scout). Reuses the
+    // `merge_seed_results` module's embedder-free fixtures via re-import.
+    mod overlay_origin_seeds {
+        use super::merge_seed_results::*;
+        use super::*;
+        use crate::store::SearchResult;
+
+        /// `overlay_origin_seeds` keeps ONLY the seeds whose origin is in the
+        /// delta (overlay-origin), keyed by name — the parent survivors are
+        /// dropped (they're served from the parent store by name, unchanged).
+        #[test]
+        fn keeps_only_overlay_origin_keyed_by_name() {
+            let overlay = overlay_with(&[("src/new.rs", "fresh_fn", 0)], &["src/new.rs"]);
+            // `merged` is what `merge_seed_results` would hand back: an overlay
+            // hit (origin in delta) plus an untouched parent survivor.
+            let merged = vec![
+                project_result("src/new.rs", "fresh_fn", 0.95),
+                project_result("src/old.rs", "existing_fn", 0.5),
+            ];
+            let map = overlay.overlay_origin_seeds(&merged);
+            assert!(
+                map.contains_key("fresh_fn"),
+                "overlay-origin seed must be kept; got {:?}",
+                map.keys().collect::<Vec<_>>()
+            );
+            assert!(
+                !map.contains_key("existing_fn"),
+                "parent-survivor seed must NOT be in the overlay map; got {:?}",
+                map.keys().collect::<Vec<_>>()
+            );
+            // The kept entry carries the overlay `SearchResult` (worktree
+            // content), not a placeholder.
+            assert_eq!(map["fresh_fn"].chunk.file, PathBuf::from("src/new.rs"));
+        }
+
+        /// On a name collision among overlay seeds, the highest-scoring one wins
+        /// (`merge_seed_results` already sorted by score desc, so first-writer-
+        /// wins on the pre-sorted slice keeps the top hit).
+        #[test]
+        fn name_collision_keeps_first_pre_sorted() {
+            let overlay = overlay_with(&[("src/a.rs", "dup", 0)], &["src/a.rs", "src/b.rs"]);
+            // Two overlay-origin hits with the same name, score-desc order.
+            let merged = vec![
+                project_result("src/a.rs", "dup", 0.9),
+                project_result("src/b.rs", "dup", 0.4),
+            ];
+            let map = overlay.overlay_origin_seeds(&merged);
+            assert_eq!(map.len(), 1, "one entry per name");
+            assert_eq!(
+                map["dup"].chunk.file,
+                PathBuf::from("src/a.rs"),
+                "highest-scoring (first in pre-sorted slice) overlay hit wins"
+            );
+        }
+
+        /// `overlay_seed_chunks_for_names` (task's by-exact-name path) recovers a
+        /// worktree-added function's chunk from the overlay store, restricted to
+        /// overlay-origin names. A name the overlay store doesn't hold is absent.
+        #[test]
+        fn by_name_recovers_overlay_chunk() {
+            let overlay = overlay_with(&[("src/new.rs", "fresh_fn", 0)], &["src/new.rs"]);
+            let map: std::collections::HashMap<String, SearchResult> =
+                overlay.overlay_seed_chunks_for_names(&["fresh_fn", "not_in_overlay"]);
+            assert!(
+                map.contains_key("fresh_fn"),
+                "task by-name fetch must recover the overlay-added chunk; got {:?}",
+                map.keys().collect::<Vec<_>>()
+            );
+            assert!(
+                !map.contains_key("not_in_overlay"),
+                "a name absent from the overlay store must not appear; got {:?}",
+                map.keys().collect::<Vec<_>>()
+            );
+            assert_eq!(map["fresh_fn"].chunk.file, PathBuf::from("src/new.rs"));
+            assert!(
+                map["fresh_fn"].chunk.content.contains("fresh_fn"),
+                "recovered chunk carries the overlay (worktree) content"
+            );
         }
     }
 }

--- a/src/worktree_overlay.rs
+++ b/src/worktree_overlay.rs
@@ -187,6 +187,88 @@ impl std::fmt::Debug for WorktreeOverlay {
     }
 }
 
+impl WorktreeOverlay {
+    /// Merge this overlay into a `SearchResult`-level parent result set — the
+    /// seed-search analogue of the binary's `UnifiedResult`-level
+    /// `apply_overlay` (Part A). Used by the `scout` / `gather` / `task`
+    /// seed sites, whose retrieval consumes `Vec<SearchResult>` directly rather
+    /// than the `UnifiedResult` the search surface produces.
+    ///
+    /// Three steps, mirroring `apply_overlay` so the two surfaces shadow the
+    /// parent index identically:
+    ///
+    /// 1. **Mask**: drop every parent hit whose `chunk.file` is in
+    ///    `masked_origins`. Origin-level, name-agnostic — a function deleted
+    ///    from a still-present file (its origin is in the delta but no overlay
+    ///    chunk shares its name) is correctly dropped, where `(origin, name)`
+    ///    shadowing would resurrect it.
+    /// 2. **Fan out**: search the overlay store with the *same* `query_embedding`
+    ///    + `filter` at `limit` / `threshold`, brute-force (`index = None` — the
+    ///    overlay holds at most a few hundred chunks). A fan-out failure is
+    ///    logged and degrades to the masked parent set (never a hard error on
+    ///    the query path).
+    /// 3. **Merge**: concatenate, sort by score descending (id tiebreak — the
+    ///    same total order `reference::merge_results` uses), and truncate to
+    ///    `limit`.
+    ///
+    /// Records the `Active { files, chunks }` envelope meta whenever it runs
+    /// (including the all-masked / no-overlay-hit empty case — the overlay still
+    /// shaped the answer). The BFS / call-graph expansion downstream of the seed
+    /// stays on parent-truth in Part A; the seed sites emit a `seed-only`
+    /// `_meta.overlay_graph` marker to make that honest.
+    pub fn merge_seed_results(
+        &self,
+        parent: Vec<crate::store::SearchResult>,
+        query_embedding: &crate::Embedding,
+        filter: &crate::store::SearchFilter,
+        limit: usize,
+        threshold: f32,
+    ) -> Vec<crate::store::SearchResult> {
+        let _span = tracing::info_span!(
+            "overlay_merge_seed_results",
+            masked = self.masked_origins.len(),
+            chunks = self.stats.chunks_indexed
+        )
+        .entered();
+
+        // 1. Mask: drop parent hits whose origin is in the delta.
+        let mut merged: Vec<crate::store::SearchResult> = parent
+            .into_iter()
+            .filter(|sr| !self.masked_origins.contains(&sr.chunk.file))
+            .collect();
+
+        // 2. Fan out over the overlay store (brute force; best-effort).
+        match self
+            .store
+            .search_filtered_with_index(query_embedding, filter, limit, threshold, None)
+        {
+            Ok(hits) => merged.extend(hits),
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "overlay seed search failed; serving masked parent seeds only"
+                );
+            }
+        }
+
+        // 3. Merge by score (highest first), id tiebreak — the same total order
+        //    `reference::merge_results` uses. Truncate to the requested limit.
+        merged.sort_by(|a, b| {
+            b.score
+                .total_cmp(&a.score)
+                .then(a.chunk.id.cmp(&b.chunk.id))
+        });
+        merged.truncate(limit);
+
+        set_overlay_meta(OverlayMeta::Active {
+            files: self.stats.files_in_delta,
+            chunks: self.stats.chunks_indexed,
+        });
+
+        merged
+    }
+}
+
 // ─── `_meta.worktree_overlay` envelope state ────────────────────────────────
 //
 // The overlay's outcome for a single search is surfaced as the skip-when-default
@@ -977,6 +1059,189 @@ mod tests {
         match prev {
             Some(v) => std::env::set_var("CQS_OVERLAY_MAX_FILES", v),
             None => std::env::remove_var("CQS_OVERLAY_MAX_FILES"),
+        }
+    }
+
+    // ── merge_seed_results: the SearchResult-level seed overlay (Part A) ──
+    //
+    // Mirrors the `overlay_merge` unit module in `query.rs`, but at the
+    // `SearchResult` granularity the scout/gather/task seed sites consume.
+    // Embedder-free: chunks are seeded with hand-built one-hot embeddings, so
+    // the brute-force overlay search runs without loading a model.
+    mod merge_seed_results {
+        use super::*;
+        use crate::parser::{Chunk, ChunkType, Language};
+        use crate::store::{ChunkSummary, ModelInfo, SearchResult};
+        use crate::{Embedding, SearchFilter};
+
+        /// One-hot embedding (`1.0` at `slot`). Distinct slots are near-
+        /// orthogonal, so a query at `slot` retrieves only the chunk seeded
+        /// there from the brute-force overlay store.
+        fn one_hot(slot: usize) -> Embedding {
+            let mut v = vec![0.0_f32; crate::EMBEDDING_DIM];
+            v[slot] = 1.0;
+            Embedding::new(v)
+        }
+
+        /// A project-side seed `SearchResult` for `(file, name, score)`.
+        fn project_result(file: &str, name: &str, score: f32) -> SearchResult {
+            let summary = ChunkSummary {
+                id: format!("{file}:{name}"),
+                file: PathBuf::from(file),
+                language: Language::Rust,
+                chunk_type: ChunkType::Function,
+                name: name.to_string(),
+                signature: format!("fn {name}()"),
+                content: format!("fn {name}() {{}}"),
+                doc: None,
+                line_start: 1,
+                line_end: 2,
+                content_hash: blake3::hash(name.as_bytes()).to_hex().to_string(),
+                window_idx: None,
+                parent_id: None,
+                parent_type_name: None,
+                parser_version: 0,
+                vendored: false,
+            };
+            SearchResult::new(summary, score)
+        }
+
+        /// Build a `WorktreeOverlay` whose in-memory store holds one chunk per
+        /// `(file, name, slot)` triple, with `masked_origins` exactly `masked`.
+        fn overlay_with(seeds: &[(&str, &str, usize)], masked: &[&str]) -> WorktreeOverlay {
+            let mut store = Store::open_memory().expect("open_memory");
+            store.init(&ModelInfo::default()).expect("init store");
+            store.set_dim(crate::EMBEDDING_DIM);
+            for (file, name, slot) in seeds {
+                let chunk = Chunk {
+                    id: format!("{file}:{name}"),
+                    file: PathBuf::from(file),
+                    language: Language::Rust,
+                    chunk_type: ChunkType::Function,
+                    name: name.to_string(),
+                    signature: format!("fn {name}()"),
+                    content: format!("fn {name}() {{}}"),
+                    doc: None,
+                    line_start: 1,
+                    line_end: 2,
+                    byte_start: 0,
+                    content_hash: blake3::hash(name.as_bytes()).to_hex().to_string(),
+                    canonical_hash: String::new(),
+                    parent_id: None,
+                    window_idx: None,
+                    parent_type_name: None,
+                    parser_version: 0,
+                };
+                store
+                    .upsert_chunks_batch(&[(chunk, one_hot(*slot))], Some(0))
+                    .expect("seed overlay chunk");
+            }
+            WorktreeOverlay {
+                store,
+                masked_origins: masked.iter().map(PathBuf::from).collect(),
+                fingerprint: [0u8; 32],
+                worktree_root: PathBuf::from("/wt"),
+                stats: OverlayStats {
+                    files_in_delta: masked.len(),
+                    chunks_indexed: seeds.len(),
+                    build_ms: 0,
+                },
+            }
+        }
+
+        fn names(results: &[SearchResult]) -> Vec<String> {
+            results.iter().map(|r| r.chunk.name.clone()).collect()
+        }
+
+        /// A worktree-ADDED file surfaces as a seed: the overlay holds a chunk
+        /// the parent index never had (a new file), and `merge_seed_results`
+        /// merges it into the parent seed set. This is the Part A headline — the
+        /// scout/gather seed reflects the worktree's new file.
+        #[test]
+        fn added_file_surfaces_as_seed() {
+            clear_overlay_meta();
+            // Overlay has a brand-new file `src/new.rs` at slot 0; its origin is
+            // in the delta (added). Parent seeds have an unrelated hit.
+            let overlay = overlay_with(&[("src/new.rs", "fresh_fn", 0)], &["src/new.rs"]);
+            let parent = vec![project_result("src/old.rs", "existing_fn", 0.5)];
+            let merged =
+                overlay.merge_seed_results(parent, &one_hot(0), &SearchFilter::default(), 10, 0.0);
+            let got = names(&merged);
+            assert!(
+                got.contains(&"fresh_fn".to_string()),
+                "worktree-added file must surface as a seed; got {got:?}"
+            );
+            assert!(
+                got.contains(&"existing_fn".to_string()),
+                "untouched parent seed must survive; got {got:?}"
+            );
+        }
+
+        /// Origin-level masking: a function deleted from a still-present edited
+        /// file (its origin is in the delta, no overlay chunk shares its name)
+        /// is dropped from the seed set — the `(origin, name)`-shadowing
+        /// falsifier `apply_overlay` also guards, at SearchResult granularity.
+        #[test]
+        fn masks_dead_function_in_edited_file() {
+            clear_overlay_meta();
+            let overlay = overlay_with(&[("src/a.rs", "live_fn", 0)], &["src/a.rs"]);
+            let parent = vec![
+                project_result("src/a.rs", "dead_fn", 0.9),
+                project_result("src/b.rs", "untouched", 0.5),
+            ];
+            // Query a slot the overlay can't answer (slot 5) so the overlay leg
+            // is empty and can't reintroduce `dead_fn`.
+            let merged =
+                overlay.merge_seed_results(parent, &one_hot(5), &SearchFilter::default(), 10, 0.0);
+            let got = names(&merged);
+            assert!(
+                !got.contains(&"dead_fn".to_string()),
+                "deleted function in an edited file must be masked; got {got:?}"
+            );
+            assert!(
+                got.contains(&"untouched".to_string()),
+                "a hit in an unmodified file must survive; got {got:?}"
+            );
+        }
+
+        /// The merge records the `Active {files, chunks}` envelope meta whenever
+        /// it runs (the seed sites' `_meta.worktree_overlay` source).
+        #[test]
+        fn records_active_meta() {
+            clear_overlay_meta();
+            let overlay = overlay_with(&[("src/x.rs", "f", 0)], &["src/x.rs"]);
+            let _ = overlay.merge_seed_results(
+                vec![project_result("src/y.rs", "g", 0.5)],
+                &one_hot(0),
+                &SearchFilter::default(),
+                10,
+                0.0,
+            );
+            match take_overlay_meta() {
+                Some(OverlayMeta::Active { files, chunks }) => {
+                    assert_eq!(files, 1, "files_in_delta surfaced");
+                    assert_eq!(chunks, 1, "chunks_indexed surfaced");
+                }
+                other => panic!("expected Active overlay meta, got {other:?}"),
+            }
+        }
+
+        /// Merge ordering: a higher-scoring overlay hit outranks a lower-scoring
+        /// parent hit, and the result truncates to `limit`.
+        #[test]
+        fn merges_by_score_and_truncates() {
+            clear_overlay_meta();
+            let overlay = overlay_with(&[("src/new.rs", "high", 0)], &["src/new.rs"]);
+            let parent = vec![
+                project_result("src/old.rs", "mid", 0.6),
+                project_result("src/old2.rs", "low", 0.3),
+            ];
+            // The overlay's one-hot self-match scores ~1.0 (> 0.6 > 0.3).
+            let merged =
+                overlay.merge_seed_results(parent, &one_hot(0), &SearchFilter::default(), 2, 0.0);
+            assert_eq!(merged.len(), 2, "truncated to limit=2");
+            assert_eq!(merged[0].chunk.name, "high", "overlay hit ranks first");
+            assert_eq!(merged[1].chunk.name, "mid", "lowest-scoring hit dropped");
         }
     }
 }

--- a/tests/cli_worktree_overlay_query_test.rs
+++ b/tests/cli_worktree_overlay_query_test.rs
@@ -9,9 +9,11 @@
 //! - **#15** `overlay_cli_direct_degrades_honestly`: from a worktree, no daemon,
 //!   `--overlay` serves the parent index and marks
 //!   `_meta.worktree_overlay = "skipped-no-daemon"` + warns.
-//! - **#19** `overlay_scout_not_overlaid`: `cqs scout` from a worktree emits NO
-//!   `worktree_overlay` meta — the scope guard (the overlay hook is
-//!   `retrieve_project` + the FTS short-circuits, which scout bypasses).
+//! - `overlay_scout_cli_direct_serves_parent` (inverts the old
+//!   `overlay_scout_not_overlaid` scope guard): scout's seed is overlay-capable
+//!   now, but only on the DAEMON path. CLI-direct (no daemon) serves the parent
+//!   index — no `worktree_overlay` / `overlay_graph` meta. The active seed-
+//!   overlay path is covered daemon-side in `handlers/search.rs`.
 //!
 //! Gated behind `slow-tests`: each runs `cqs init`/`index`, which cold-loads
 //! the embedder. The pure mask/merge/meta logic is covered unconditionally by
@@ -218,17 +220,26 @@ fn overlay_opt_out_beats_default_on_from_worktree() {
     );
 }
 
-/// #19 — scope guard. `cqs scout` from a worktree, even with `--overlay`
-/// requested, emits NO `worktree_overlay` meta: scout's seed retrieval bypasses
-/// `query_core`/`retrieve_project` (the only overlay hook), so the overlay
-/// cannot apply to it. A half-worktree graph/scout answer would be a new
-/// calibration lie; the architecture excludes it.
+/// Part A — scout's seed IS overlay-capable now (this inverts the old
+/// `overlay_scout_not_overlaid` scope guard). The seed retrieval routes through
+/// the worktree overlay on the DAEMON path. This CLI-direct test (daemon
+/// disabled) pins the honest CLI-direct behavior: scout serves the PARENT index
+/// — it cannot build an overlay without a daemon (phase 1, like search). The
+/// active seed-overlay path (a worktree-added symbol surfacing as a scout/gather
+/// seed + the `_meta.overlay_graph = "seed-only"` marker) is covered by the
+/// daemon-side end-to-end tests `overlay_scout_seed_overlaid` /
+/// `overlay_gather_seed_overlaid` in `src/cli/batch/handlers/search.rs`.
+///
+/// CLI-direct scout emits NO `worktree_overlay` meta (it didn't overlay) and NO
+/// `overlay_graph` marker (the marker rides only when the overlay was applied).
+/// Note the asymmetry with `search`, which marks `skipped-no-daemon` on
+/// CLI-direct — scout's CLI-direct honest-degradation marker is deferred (see
+/// the lane report's residual note).
 #[test]
-fn overlay_scout_not_overlaid() {
+fn overlay_scout_cli_direct_serves_parent() {
     let (_holder, _parent, wt) = fixture_with_parent_index();
 
-    // scout takes no --overlay flag; request it via the env equivalent to prove
-    // the env path also doesn't leak into scout.
+    // Request the overlay via the env equivalent; CLI-direct still can't build.
     let mut cmd = cqs(&wt);
     cmd.env("CQS_WORKTREE_OVERLAY", "1");
     let v = run_json(cmd.args(["scout", "alpha", "--json"]));
@@ -236,6 +247,12 @@ fn overlay_scout_not_overlaid() {
         v.get("_meta")
             .and_then(|m| m.get("worktree_overlay"))
             .is_none(),
-        "scout must never carry worktree_overlay meta (scope guard); got {v}"
+        "CLI-direct scout serves the parent index — no worktree_overlay meta; got {v}"
+    );
+    assert!(
+        v.get("_meta")
+            .and_then(|m| m.get("overlay_graph"))
+            .is_none(),
+        "CLI-direct scout did not overlay — no overlay_graph marker; got {v}"
     );
 }


### PR DESCRIPTION
## #1858 Part A — route scout/gather/task seed search through the worktree overlay

Phase-2 of the worktree overlay (#1821 §3 shipped it search-only). **Part A** makes the *seed* retrieval of `scout` / `gather` / `task` overlay-aware on the daemon path, so from a `.claude/worktrees/` checkout those commands' entry-point seeds reflect the worktree's dirty delta instead of the parent/main index. Call-graph BFS expansion stays parent-truth (that's **Part B**), signalled honestly by `_meta.overlay_graph = "seed-only"`.

This empties part of the agent-def hedge clause (#1254) and is a step toward closing #1821.

### Design
- **`WorktreeOverlay::merge_seed_results`** (new, in `src/worktree_overlay.rs` / lib) — the `SearchResult`-level analogue of the binary-crate `apply_overlay`: origin-level mask + merge-by-score + truncate + overlay-meta. Lives with the overlay struct because the existing merge is in the bin crate, unreachable from the lib seed sites. (Intentionally matches `overlay_mask_name_results` semantics — origin-level mask, no content-hash dedup; the divergence from `apply_overlay`'s dedup is flagged for Part B to reconcile.)
- **`*_overlay` entry-point variants** (`scout_with_overlay`, `gather_with_overlay`, `task_with_resources_overlay`) — existing simple entry points delegate with `None`, so CLI-direct / eval / tests are byte-unchanged.
- **Flattened `OverlayArgs`** shared into Scout/Gather/Task args; `Commands::overlay_tristate` binds `--overlay` to the subcommand.
- `gather --ref` (cross-index) correctly stays parent-truth.

### The Agent grant earning its keep
The lane spawned its own `code-reviewer` (first use of the #1896 grant), which found a **genuine calibration leak**: `dispatch_gather`'s `--ref` branch skipped `clear_overlay_meta()`, so a stale thread-local overlay from a prior errored query could leak onto a `gather --ref` response. **Fixed** (unconditional clear at dispatch entry, mirroring `dispatch_search`).

### Tests
`merge_seed_results` 4 new unit tests; 3 new daemon-e2e (`overlay_{scout,gather,task}_seed_overlaid`); the scope-guard pin inverted (`overlay_scout_not_overlaid` → `overlay_scout_cli_direct_serves_parent`); scout 20 / gather 12 / task 8 / worktree_overlay 17 / dispatch 77 / daemon_forward 34 / cli_envelope 8 — all green. fmt + clippy --all-targets + provenance lint clean.

### Gate battery (magnet area: index/overlay)
code-reviewer ✅ (done, found+fixed the leak). seam-auditor + interleaving-auditor in progress on this diff before merge.

### Residuals (tracked, deferred from Part A)
- CLI-direct scout/gather/task don't emit the `skipped-no-daemon` overlay marker `search` does (honest-degradation gap, not a false signal) → issue.
- The `overlay_graph: "seed-only"` marker + the seed/search merge-dedup divergence get revisited when **Part B** (graph add/subtract shadowing) lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
