### PR TITLE
feat(overlay): #1858 Part B PR1 — callers/callees through the worktree overlay

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -503,6 +503,10 @@ pub(crate) struct CallersArgs {
     /// rendering — both text and JSON paths respect the cap.
     #[command(flatten)]
     pub limit_arg: LimitArg,
+    /// Worktree-overlay tri-state for the call-graph query (#1858 Part B).
+    /// Built daemon-side only (phase 1); the CLI-direct adapter ignores it.
+    #[command(flatten)]
+    pub overlay: OverlayArgs,
 }
 
 /// Arguments shared between CLI `deps` and batch `deps`.

--- a/src/cli/batch/commands.rs
+++ b/src/cli/batch/commands.rs
@@ -1012,6 +1012,7 @@ mod tests {
                 cross_project: false,
                 limit_arg: crate::cli::args::LimitArg { limit: 5 },
                 edge_kind: None,
+                overlay: Default::default(),
             },
             output: TextJsonArgs { json: false },
         };

--- a/src/cli/batch/handlers/graph.rs
+++ b/src/cli/batch/handlers/graph.rs
@@ -163,11 +163,16 @@ pub(in crate::cli::batch) fn dispatch_callers(
         limit: args.limit_arg.limit,
         edge_kind,
     };
-    let output = callers_overlay(&ctx.store(), &core_args, overlay.as_deref())?;
+    let (output, overlay_participated) =
+        callers_overlay(&ctx.store(), &core_args, overlay.as_deref())?;
     let mut value = serde_json::to_value(&output)?;
-    if overlay.is_some() {
-        // The graph query itself was overlaid — `"full"`, not Part A's
-        // `"seed-only"`.
+    if overlay_participated {
+        // The overlay actually changed THIS caller set (a parent row was masked
+        // or an overlay row was unioned) — `"full"`, not Part A's `"seed-only"`.
+        // Gating on participation, NOT `overlay.is_some()`, keeps the marker
+        // honest: a dirty worktree whose delta is irrelevant to this query, the
+        // `Type::method`-qualified path, and the kind-fallback path all return
+        // pure parent-truth and carry NO marker.
         super::attach_overlay_graph_meta_full(&mut value);
     }
     Ok(value)
@@ -223,9 +228,15 @@ pub(in crate::cli::batch) fn dispatch_callees(
         limit: args.limit_arg.limit,
         edge_kind,
     };
-    let output = callees_overlay(&ctx.store(), &core_args, overlay.as_deref())?;
+    let (output, overlay_participated) =
+        callees_overlay(&ctx.store(), &core_args, overlay.as_deref())?;
     let mut value = serde_json::to_value(&output)?;
-    if overlay.is_some() {
+    if overlay_participated {
+        // Marker gated on participation (= `x_def_masked`), not
+        // `overlay.is_some()`: an unedited-X callees query over a dirty worktree
+        // returns the parent callees untouched and must NOT claim `"full"`. The
+        // `Type::method`-qualified and kind-fallback paths likewise carry no
+        // marker.
         super::attach_overlay_graph_meta_full(&mut value);
     }
     Ok(value)
@@ -2401,10 +2412,13 @@ mod tests {
             limit: 50,
             edge_kind: None,
         };
-        let out = serde_json::to_value(
-            callers_overlay(&ctx.store(), &args, Some(&overlay)).expect("callers_overlay"),
-        )
-        .unwrap();
+        let (out, participated) =
+            callers_overlay(&ctx.store(), &args, Some(&overlay)).expect("callers_overlay");
+        assert!(
+            participated,
+            "a masked-origin drop + an overlay add must report overlay participation"
+        );
+        let out = serde_json::to_value(out).unwrap();
         let got = caller_names_json(&out);
         assert!(
             !got.contains(&"old_caller".to_string()),
@@ -2440,10 +2454,13 @@ mod tests {
             limit: 50,
             edge_kind: None,
         };
-        let out = serde_json::to_value(
-            callees_overlay(&ctx.store(), &args, Some(&overlay)).expect("callees_overlay"),
-        )
-        .unwrap();
+        let (out, participated) =
+            callees_overlay(&ctx.store(), &args, Some(&overlay)).expect("callees_overlay");
+        assert!(
+            participated,
+            "X edited (def-origin masked) must report overlay participation"
+        );
+        let out = serde_json::to_value(out).unwrap();
         let got = callee_names_json(&out);
         assert!(
             got.contains(&"worktree_callee".to_string()),
@@ -2477,10 +2494,14 @@ mod tests {
             limit: 50,
             edge_kind: None,
         };
-        let out = serde_json::to_value(
-            callees_overlay(&ctx.store(), &args, Some(&overlay)).expect("callees_overlay"),
-        )
-        .unwrap();
+        let (out, participated) =
+            callees_overlay(&ctx.store(), &args, Some(&overlay)).expect("callees_overlay");
+        assert!(
+            !participated,
+            "unedited X (def-origin unmasked) is pure parent-truth: overlay must NOT \
+             report participation (the marker would over-claim `full`)"
+        );
+        let out = serde_json::to_value(out).unwrap();
         let got = callee_names_json(&out);
         assert_eq!(
             got,
@@ -2508,10 +2529,13 @@ mod tests {
             limit: 50,
             edge_kind: None,
         };
-        let out = serde_json::to_value(
-            callees_overlay(&ctx.store(), &args, Some(&overlay)).expect("callees_overlay"),
-        )
-        .unwrap();
+        let (out, participated) =
+            callees_overlay(&ctx.store(), &args, Some(&overlay)).expect("callees_overlay");
+        assert!(
+            participated,
+            "worktree-added X (overlay defines it) must report overlay participation"
+        );
+        let out = serde_json::to_value(out).unwrap();
         let got = callee_names_json(&out);
         assert!(
             got.contains(&"new_callee".to_string()),
@@ -2533,10 +2557,13 @@ mod tests {
             limit: 5,
             edge_kind: None,
         };
-        let with_none = serde_json::to_value(
-            callers_overlay(&ctx.store(), &args, None).expect("callers_overlay none"),
-        )
-        .unwrap();
+        let (none_out, participated) =
+            callers_overlay(&ctx.store(), &args, None).expect("callers_overlay none");
+        assert!(
+            !participated,
+            "no overlay (None) must never report participation"
+        );
+        let with_none = serde_json::to_value(none_out).unwrap();
         let core =
             serde_json::to_value(callers_core(&ctx.store(), &args).expect("callers_core")).unwrap();
         assert_eq!(
@@ -2565,10 +2592,13 @@ mod tests {
             limit: 5,
             edge_kind: None,
         };
-        let with_none = serde_json::to_value(
-            callees_overlay(&ctx.store(), &args, None).expect("callees_overlay none"),
-        )
-        .unwrap();
+        let (none_out, participated) =
+            callees_overlay(&ctx.store(), &args, None).expect("callees_overlay none");
+        assert!(
+            !participated,
+            "no overlay (None) must never report participation"
+        );
+        let with_none = serde_json::to_value(none_out).unwrap();
         let core =
             serde_json::to_value(callees_core(&ctx.store(), &args).expect("callees_core")).unwrap();
         assert_eq!(
@@ -2580,6 +2610,201 @@ mod tests {
                 .as_array()
                 .is_some_and(|a| a.iter().any(|c| c["name"] == "c")),
             "seeded callee must be present: {core}"
+        );
+    }
+
+    // ─── Marker honesty on the DAEMON path ─────────────────────────────────
+    //
+    // Invariant: `_meta.overlay_graph = "full"` is emitted ONLY when the overlay
+    // actually consulted the delta for THIS answer — never merely because the
+    // worktree has some dirty file. These tests drive `dispatch_callers` /
+    // `dispatch_callees` end-to-end with an injected overlay (the
+    // `set_test_overlay_override` seam bypasses the embedder/git LRU build) and
+    // assert the marker is ABSENT on every parent-truth path (`Type::method`-
+    // qualified, kind-fallback, unedited-X callees) and PRESENT only on a
+    // genuine merge (masked-drop / overlay-add callers, edited-X callees).
+
+    /// Convenience: marker value or `None` when absent, from a dispatcher's JSON.
+    fn overlay_graph_marker(json: &serde_json::Value) -> Option<&str> {
+        json.get("_meta")
+            .and_then(|m| m.get("overlay_graph"))
+            .and_then(|v| v.as_str())
+    }
+
+    /// (a) `Type::method`-qualified callers — parent-truth in PR1, so even with
+    /// an active overlay the answer reflects main only. The marker must be
+    /// ABSENT (the old gate stamped `"full"`).
+    #[test]
+    fn dispatch_callers_type_method_no_full_marker_under_overlay() {
+        let (_dir, ctx) = parent_store_with(
+            &[("src/s.rs", "store_self"), ("src/s.rs", "Store")],
+            &[("store_self", "src/s.rs", 20, "search")],
+        );
+        // An active, non-trivial overlay (a masked origin + an overlay edge) —
+        // `overlay.is_some()` is true, so the OLD gate would stamp `"full"`.
+        let overlay = std::sync::Arc::new(overlay_with_edges(
+            &[("src/s.rs", "fresh")],
+            &[("fresh", "src/s.rs", 1, "search")],
+            &["src/s.rs"],
+        ));
+        let _guard = crate::cli::batch::view::set_test_overlay_override(overlay);
+        let args = CallersArgs {
+            name: "Store::search".into(),
+            cross_project: false,
+            limit_arg: crate::cli::args::LimitArg { limit: 10 },
+            edge_kind: None,
+            overlay: Default::default(),
+        };
+        let json = dispatch_callers(&ctx.build_view(None), &args).expect("dispatch_callers");
+        assert_eq!(
+            overlay_graph_marker(&json),
+            None,
+            "Type::method is parent-truth in PR1 — must NOT claim overlay_graph=full: {json}"
+        );
+    }
+
+    /// (b) kind-fallback (X is a const, not callable) — the kind is classified
+    /// from the PARENT store, so the fallback never reflects the overlay. The
+    /// marker must be ABSENT. This is Finding 1: the const→fn refactor footgun
+    /// where the fallback would falsely claim `"full"`.
+    #[test]
+    fn dispatch_callers_kind_fallback_no_full_marker_under_overlay() {
+        let (_dir, ctx) = seed_kind_corpus();
+        // Active overlay present (some dirty file) — old gate would stamp `"full"`.
+        let overlay = std::sync::Arc::new(overlay_with_edges(
+            &[("src/dirty.rs", "noise")],
+            &[("noise", "src/dirty.rs", 1, "whatever")],
+            &["src/dirty.rs"],
+        ));
+        let _guard = crate::cli::batch::view::set_test_overlay_override(overlay);
+        let args = CallersArgs {
+            name: "MAX_LEN".into(), // const in the kind corpus
+            cross_project: false,
+            limit_arg: crate::cli::args::LimitArg { limit: 10 },
+            edge_kind: None,
+            overlay: Default::default(),
+        };
+        let json = dispatch_callers(&ctx.build_view(None), &args).expect("dispatch_callers");
+        // Confirm we actually hit the fallback (const), not the function path.
+        assert_eq!(
+            json["kind"], "const",
+            "fixture must hit the const fallback: {json}"
+        );
+        assert_eq!(
+            overlay_graph_marker(&json),
+            None,
+            "kind-fallback is parent-truth — must NOT claim overlay_graph=full: {json}"
+        );
+    }
+
+    /// (c) callees of an UNEDITED X with an unrelated dirty file present — the
+    /// def-origin is unmasked, so `merge_callees` returns the parent set
+    /// untouched (pure parent-truth). The marker must be ABSENT (the old gate
+    /// stamped `"full"` because the worktree was dirty).
+    #[test]
+    fn dispatch_callees_unedited_x_no_full_marker_under_overlay() {
+        let (_dir, ctx) = parent_store_with(
+            &[("src/stable.rs", "X"), ("src/lib.rs", "real_callee")],
+            &[("X", "src/stable.rs", 1, "real_callee")],
+        );
+        // The delta touches an UNRELATED file; X's def-origin (src/stable.rs) is
+        // NOT masked, so callees(X) is pure parent-truth.
+        let overlay = std::sync::Arc::new(overlay_with_edges(
+            &[("src/unrelated.rs", "noise")],
+            &[("noise", "src/unrelated.rs", 1, "other")],
+            &["src/unrelated.rs"],
+        ));
+        let _guard = crate::cli::batch::view::set_test_overlay_override(overlay);
+        let args = CallersArgs {
+            name: "X".into(),
+            cross_project: false,
+            limit_arg: crate::cli::args::LimitArg { limit: 10 },
+            edge_kind: None,
+            overlay: Default::default(),
+        };
+        let json = dispatch_callees(&ctx.build_view(None), &args).expect("dispatch_callees");
+        // The parent callee survives (function path ran), confirming parent-truth.
+        let calls = json["calls"].as_array().expect("calls array");
+        assert!(
+            calls.iter().any(|c| c["name"] == "real_callee"),
+            "unedited X must still serve its parent callee: {json}"
+        );
+        assert_eq!(
+            overlay_graph_marker(&json),
+            None,
+            "unedited-X callees is parent-truth — must NOT claim overlay_graph=full: {json}"
+        );
+    }
+
+    /// PRESENT case 1: a genuine callers merge (a masked-origin parent drop +
+    /// an overlay-added caller) DOES reflect the delta — the marker must be
+    /// `"full"`. Guards against the fix over-correcting to never-stamp.
+    #[test]
+    fn dispatch_callers_genuine_merge_carries_full_marker() {
+        let (_dir, ctx) = parent_store_with(
+            &[
+                ("src/edited.rs", "old_caller"),
+                ("src/stable.rs", "stable_caller"),
+                ("src/lib.rs", "target"),
+            ],
+            &[
+                ("old_caller", "src/edited.rs", 1, "target"),
+                ("stable_caller", "src/stable.rs", 1, "target"),
+            ],
+        );
+        let overlay = std::sync::Arc::new(overlay_with_edges(
+            &[("src/edited.rs", "fresh_caller")],
+            &[("fresh_caller", "src/edited.rs", 1, "target")],
+            &["src/edited.rs"],
+        ));
+        let _guard = crate::cli::batch::view::set_test_overlay_override(overlay);
+        let args = CallersArgs {
+            name: "target".into(),
+            cross_project: false,
+            limit_arg: crate::cli::args::LimitArg { limit: 50 },
+            edge_kind: None,
+            overlay: Default::default(),
+        };
+        let json = dispatch_callers(&ctx.build_view(None), &args).expect("dispatch_callers");
+        assert_eq!(
+            overlay_graph_marker(&json),
+            Some("full"),
+            "a real masked-drop + overlay-add merge must claim overlay_graph=full: {json}"
+        );
+    }
+
+    /// PRESENT case 2: callees of an EDITED X (def-origin masked) serves the
+    /// overlay's out-edges — a genuine overlay answer. The marker must be
+    /// `"full"`.
+    #[test]
+    fn dispatch_callees_edited_x_carries_full_marker() {
+        let (_dir, ctx) = parent_store_with(
+            &[("src/x.rs", "X"), ("src/lib.rs", "parent_callee")],
+            &[("X", "src/x.rs", 1, "parent_callee")],
+        );
+        let overlay = std::sync::Arc::new(overlay_with_edges(
+            &[("src/x.rs", "X")],
+            &[("X", "src/x.rs", 1, "worktree_callee")],
+            &["src/x.rs"],
+        ));
+        let _guard = crate::cli::batch::view::set_test_overlay_override(overlay);
+        let args = CallersArgs {
+            name: "X".into(),
+            cross_project: false,
+            limit_arg: crate::cli::args::LimitArg { limit: 50 },
+            edge_kind: None,
+            overlay: Default::default(),
+        };
+        let json = dispatch_callees(&ctx.build_view(None), &args).expect("dispatch_callees");
+        let calls = json["calls"].as_array().expect("calls array");
+        assert!(
+            calls.iter().any(|c| c["name"] == "worktree_callee"),
+            "edited X must serve the overlay callee: {json}"
+        );
+        assert_eq!(
+            overlay_graph_marker(&json),
+            Some("full"),
+            "edited-X callees served from the overlay must claim overlay_graph=full: {json}"
         );
     }
 }

--- a/src/cli/batch/handlers/graph.rs
+++ b/src/cli/batch/handlers/graph.rs
@@ -19,10 +19,17 @@ use crate::cli::args::{
     CallersArgs, DepsArgs, ImpactArgs, ImpactDiffArgs, RelatedArgs, TestMapArgs, TraceArgs,
 };
 use crate::cli::commands::{
-    callees_core, callees_cross_core, callers_core, callers_cross_core, deps_core, impact_core,
-    parse_edge_kind, test_map_core, trace_core, CalleesArgs as CoreCalleesArgs, CallersCoreArgs,
-    DepsCoreArgs, ImpactCoreArgs, TestMapCoreArgs, TraceCoreArgs,
+    callees_cross_core, callees_overlay, callers_cross_core, callers_overlay, deps_core,
+    impact_core, parse_edge_kind, test_map_core, trace_core, CalleesArgs as CoreCalleesArgs,
+    CallersCoreArgs, DepsCoreArgs, ImpactCoreArgs, TestMapCoreArgs, TraceCoreArgs,
 };
+// `callers_core` / `callees_core` are the no-overlay entry points; production
+// dispatch now routes through the `*_overlay` variants above, so the plain cores
+// are referenced only by the parity tests (imported in the test module).
+// `SearchCtx` brings `BatchView::overlay()` into scope — the seam that resolves
+// + builds the per-worktree overlay from the request the dispatcher stamped
+// (#1858 Part B; mirrors the Part A seed handlers).
+use crate::cli::commands::search::search_ctx::SearchCtx;
 use cqs::parser::CallEdgeKind;
 
 /// Parse the daemon-side `--edge-kind` wire string into a typed
@@ -33,6 +40,26 @@ fn parse_dispatch_edge_kind(s: Option<&str>) -> Result<Option<CallEdgeKind>> {
         None => Ok(None),
         Some(s) => parse_edge_kind(s).map(Some).map_err(|e| anyhow::anyhow!(e)),
     }
+}
+
+/// Prepare + resolve the worktree overlay for a call-graph dispatcher (#1858
+/// Part B). Stamps the validated request from the wire tri-state flags (a
+/// foreign `--overlay-root` is rejected as a wire error), then resolves it
+/// through the daemon overlay LRU. Returns `Some(Arc<WorktreeOverlay>)` when the
+/// overlay is active for this query, else `None` (serve the parent index). The
+/// caller threads the `Some` into the `*_overlay` core and injects the `"full"`
+/// `_meta.overlay_graph` marker. Mirrors the seed handlers' `resolve_seed_overlay`.
+fn resolve_graph_overlay(
+    ctx: &BatchView,
+    overlay: &crate::cli::args::OverlayArgs,
+) -> Result<Option<std::sync::Arc<cqs::worktree_overlay::WorktreeOverlay>>> {
+    super::prepare_overlay_request_fields(
+        ctx,
+        overlay.overlay,
+        overlay.no_overlay,
+        overlay.overlay_root.as_deref(),
+    )?;
+    Ok(ctx.overlay())
 }
 
 // ─── Daemon dispatch handlers ──────────────────────────────────────────────
@@ -108,6 +135,11 @@ pub(in crate::cli::batch) fn dispatch_callers(
         cross_project
     )
     .entered();
+    // Clear leftover per-thread overlay meta before any branch can return — a
+    // reused daemon worker must not leak a prior query's `_meta.worktree_overlay`
+    // onto this response (the cross-project branch skips `resolve_graph_overlay`,
+    // which is where the seed path clears). Idempotent.
+    cqs::worktree_overlay::clear_overlay_meta();
     let edge_kind = parse_dispatch_edge_kind(args.edge_kind.as_deref())?;
     if cross_project {
         let cross_ctx = ctx.cross_project()?;
@@ -123,13 +155,22 @@ pub(in crate::cli::batch) fn dispatch_callers(
         return Ok(serde_json::to_value(&output)?);
     }
 
+    // Resolve the worktree overlay (Part B): merges the worktree delta into the
+    // call-graph query when active. `None` ⇒ parent-truth (the default).
+    let overlay = resolve_graph_overlay(ctx, &args.overlay)?;
     let core_args = CallersCoreArgs {
         name: name.to_string(),
         limit: args.limit_arg.limit,
         edge_kind,
     };
-    let output = callers_core(&ctx.store(), &core_args)?;
-    Ok(serde_json::to_value(&output)?)
+    let output = callers_overlay(&ctx.store(), &core_args, overlay.as_deref())?;
+    let mut value = serde_json::to_value(&output)?;
+    if overlay.is_some() {
+        // The graph query itself was overlaid — `"full"`, not Part A's
+        // `"seed-only"`.
+        super::attach_overlay_graph_meta_full(&mut value);
+    }
+    Ok(value)
 }
 
 /// Dispatches a request to retrieve all functions called by a specified function.
@@ -157,6 +198,8 @@ pub(in crate::cli::batch) fn dispatch_callees(
         cross_project
     )
     .entered();
+    // See `dispatch_callers`: clear leftover per-thread overlay meta first.
+    cqs::worktree_overlay::clear_overlay_meta();
     let edge_kind = parse_dispatch_edge_kind(args.edge_kind.as_deref())?;
     if cross_project {
         let cross_ctx = ctx.cross_project()?;
@@ -172,13 +215,20 @@ pub(in crate::cli::batch) fn dispatch_callees(
         return Ok(serde_json::to_value(&output)?);
     }
 
+    // Resolve the worktree overlay (Part B): the asymmetric callee merge lives
+    // in `callees_overlay`. `None` ⇒ parent-truth.
+    let overlay = resolve_graph_overlay(ctx, &args.overlay)?;
     let core_args = CoreCalleesArgs {
         name: name.to_string(),
         limit: args.limit_arg.limit,
         edge_kind,
     };
-    let output = callees_core(&ctx.store(), &core_args)?;
-    Ok(serde_json::to_value(&output)?)
+    let output = callees_overlay(&ctx.store(), &core_args, overlay.as_deref())?;
+    let mut value = serde_json::to_value(&output)?;
+    if overlay.is_some() {
+        super::attach_overlay_graph_meta_full(&mut value);
+    }
+    Ok(value)
 }
 
 /// Analyzes the impact of changes to a target and returns the results as JSON.
@@ -434,6 +484,9 @@ pub(in crate::cli::batch) fn dispatch_impact_diff(
 mod tests {
     use super::*;
     use crate::cli::batch::create_test_context;
+    // The no-overlay cores: referenced by the parity tests (production dispatch
+    // routes through the `*_overlay` variants).
+    use crate::cli::commands::{callees_core, callers_core};
     use cqs::embedder::Embedding;
     use cqs::parser::{CallEdgeKind, CallSite, Chunk, ChunkType, FunctionCalls, Language};
     use cqs::store::{ModelInfo, Store};
@@ -523,6 +576,7 @@ mod tests {
             cross_project: false,
             limit_arg: crate::cli::args::LimitArg { limit: 10 },
             edge_kind: None,
+            overlay: Default::default(),
         };
         let json = dispatch_callers(&ctx.build_view(None), &args).expect("dispatch_callers");
         // `callers_core` emits `{name, callers, count}` — the same object
@@ -545,6 +599,7 @@ mod tests {
             cross_project: false,
             limit_arg: crate::cli::args::LimitArg { limit: 10 },
             edge_kind: None,
+            overlay: Default::default(),
         };
         let json = dispatch_callees(&ctx.build_view(None), &args).expect("dispatch_callees");
         // `build_callees` emits `CalleesOutput { name, calls, count }` —
@@ -607,6 +662,7 @@ mod tests {
                 cross_project: false,
                 limit_arg: crate::cli::args::LimitArg { limit: 10 },
                 edge_kind: kind.map(String::from),
+                overlay: Default::default(),
             };
             let daemon =
                 dispatch_callers(&ctx.build_view(None), &daemon_args).expect("dispatch_callers");
@@ -641,6 +697,7 @@ mod tests {
                 cross_project: true,
                 limit_arg: crate::cli::args::LimitArg { limit: 10 },
                 edge_kind: Some("call".to_string()),
+                overlay: Default::default(),
             },
         )
         .expect("dispatch_callers cross + edge-kind call");
@@ -657,6 +714,7 @@ mod tests {
                 cross_project: true,
                 limit_arg: crate::cli::args::LimitArg { limit: 10 },
                 edge_kind: Some("call".to_string()),
+                overlay: Default::default(),
             },
         )
         .expect("dispatch_callees cross + edge-kind call");
@@ -674,6 +732,7 @@ mod tests {
                 cross_project: true,
                 limit_arg: crate::cli::args::LimitArg { limit: 10 },
                 edge_kind: Some("macro_heuristic".to_string()),
+                overlay: Default::default(),
             },
         )
         .expect("dispatch_callers cross + edge-kind macro_heuristic");
@@ -899,6 +958,7 @@ mod tests {
             cross_project: false,
             limit_arg: crate::cli::args::LimitArg { limit: 10 },
             edge_kind: None,
+            overlay: Default::default(),
         };
         let json = dispatch_callers(&ctx.build_view(None), &args).expect("dispatch_callers");
         assert_fallback_shape(&json, "const", "callers", "MAX_LEN");
@@ -913,6 +973,7 @@ mod tests {
             cross_project: false,
             limit_arg: crate::cli::args::LimitArg { limit: 10 },
             edge_kind: None,
+            overlay: Default::default(),
         };
         let json = dispatch_callees(&ctx.build_view(None), &args).expect("dispatch_callees");
         assert_fallback_shape(&json, "type", "callees", "MyConfig");
@@ -986,6 +1047,7 @@ mod tests {
             cross_project: false,
             limit_arg: crate::cli::args::LimitArg { limit: 10 },
             edge_kind: None,
+            overlay: Default::default(),
         };
         let json = dispatch_callers(&ctx.build_view(None), &args).expect("dispatch_callers");
         assert_fallback_shape(&json, "const", "callers", "MAX_LEN");
@@ -1042,6 +1104,7 @@ mod tests {
             cross_project: false,
             limit_arg: crate::cli::args::LimitArg { limit: 10 },
             edge_kind: None,
+            overlay: Default::default(),
         };
         let json = dispatch_callers(&ctx.build_view(None), &args)
             .expect("kind-detect store error must not fail the request");
@@ -1065,6 +1128,7 @@ mod tests {
                 cross_project: false,
                 limit_arg: crate::cli::args::LimitArg { limit: 5 },
                 edge_kind: None,
+                overlay: Default::default(),
             };
             let daemon = dispatch_callers(&view, &wire).expect("dispatch_callers");
             let core = serde_json::to_value(
@@ -1112,6 +1176,7 @@ mod tests {
             cross_project: true,
             limit_arg: crate::cli::args::LimitArg { limit: 5 },
             edge_kind: None,
+            overlay: Default::default(),
         };
         let daemon = dispatch_callers(&view, &wire).expect("dispatch_callers cross");
 
@@ -1156,6 +1221,7 @@ mod tests {
                 cross_project: false,
                 limit_arg: crate::cli::args::LimitArg { limit: 5 },
                 edge_kind: None,
+                overlay: Default::default(),
             };
             let daemon = dispatch_callees(&view, &wire).expect("dispatch_callees");
             let core = serde_json::to_value(
@@ -1199,6 +1265,7 @@ mod tests {
             cross_project: true,
             limit_arg: crate::cli::args::LimitArg { limit: 5 },
             edge_kind: None,
+            overlay: Default::default(),
         };
         let daemon = dispatch_callees(&view, &wire).expect("dispatch_callees cross");
 
@@ -1663,6 +1730,7 @@ mod tests {
             cross_project: false,
             limit_arg: crate::cli::args::LimitArg { limit: 1 },
             edge_kind: None,
+            overlay: Default::default(),
         };
         let json = dispatch_callers(&ctx.build_view(None), &args).expect("dispatch_callers");
         assert_eq!(json["count"], 1, "page is one entry");
@@ -1682,6 +1750,7 @@ mod tests {
             cross_project: false,
             limit_arg: crate::cli::args::LimitArg { limit: 10 },
             edge_kind: None,
+            overlay: Default::default(),
         };
         let daemon = dispatch_callers(&ctx.build_view(None), &args).expect("dispatch_callers");
 
@@ -1754,6 +1823,7 @@ mod tests {
             cross_project: false,
             limit_arg: crate::cli::args::LimitArg { limit: 10 },
             edge_kind: None,
+            overlay: Default::default(),
         };
         let daemon = dispatch_callers(&ctx.build_view(None), &args).expect("dispatch_callers");
         assert_eq!(daemon["count"], 0, "no callers under a bogus qualifier");
@@ -1792,6 +1862,7 @@ mod tests {
             cross_project: false,
             limit_arg: crate::cli::args::LimitArg { limit: 10 },
             edge_kind: None,
+            overlay: Default::default(),
         };
         let daemon = dispatch_callees(&ctx.build_view(None), &args).expect("dispatch_callees");
         assert_eq!(daemon["count"], 0, "no callees under a bogus qualifier");
@@ -1889,6 +1960,7 @@ mod tests {
             cross_project: false,
             limit_arg: crate::cli::args::LimitArg { limit: 10 },
             edge_kind: None,
+            overlay: Default::default(),
         };
         let daemon = dispatch_callees(&ctx.build_view(None), &args).expect("dispatch_callees");
         let calls: Vec<&str> = daemon["calls"]
@@ -1983,6 +2055,7 @@ mod tests {
             cross_project: false,
             limit_arg: crate::cli::args::LimitArg { limit: 10 },
             edge_kind: None,
+            overlay: Default::default(),
         };
         let daemon = dispatch_callers(&ctx.build_view(None), &args).expect("dispatch_callers");
         let names: Vec<&str> = daemon["callers"]
@@ -2076,6 +2149,7 @@ mod tests {
             cross_project: false,
             limit_arg: crate::cli::args::LimitArg { limit: 10 },
             edge_kind: None,
+            overlay: Default::default(),
         };
         let daemon = dispatch_callers(&ctx.build_view(None), &args).expect("dispatch_callers");
         let names: Vec<&str> = daemon["callers"]
@@ -2123,6 +2197,7 @@ mod tests {
             cross_project: false,
             limit_arg: crate::cli::args::LimitArg { limit: 10 },
             edge_kind: None,
+            overlay: Default::default(),
         };
         let daemon = dispatch_callers(&ctx.build_view(None), &args).expect("dispatch_callers");
         let candidates = daemon["candidates"]
@@ -2146,6 +2221,365 @@ mod tests {
         assert_eq!(
             daemon, core,
             "CLI==daemon parity for bare multi-def candidates"
+        );
+    }
+
+    // ─── Worktree-overlay call-graph merge (active path, #1858 Part B) ──────
+    //
+    // The unit module in `worktree_overlay.rs` covers the merge LOGIC over
+    // hand-built rows; these drive the full `*_overlay` CORE against a real
+    // parent store plus an in-memory overlay store seeded with chunks +
+    // function_calls — so they exercise the def-origin resolution
+    // (`callee_target_def_masked` + `get_chunks_by_name`) and the SQL → typed
+    // output translation. SQL-only (no embedder), so they run unconditionally.
+
+    use cqs::worktree_overlay::{OverlayStats, WorktreeOverlay};
+
+    /// Build an in-memory overlay store seeded with `(file, name)` chunks and
+    /// caller→callee `function_calls` edges, wrapped in a `WorktreeOverlay`
+    /// whose `masked_origins` is exactly `masked`. Each edge is
+    /// `(caller_name, caller_file, caller_line, callee_name)`.
+    fn overlay_with_edges(
+        chunks: &[(&str, &str)],
+        edges: &[(&str, &str, u32, &str)],
+        masked: &[&str],
+    ) -> WorktreeOverlay {
+        let mut store = Store::open_memory().expect("open_memory");
+        store.init(&ModelInfo::default()).expect("init store");
+        store.set_dim(cqs::EMBEDDING_DIM);
+        let mut emb = vec![0.0_f32; cqs::EMBEDDING_DIM];
+        emb[0] = 1.0;
+        let embedding = Embedding::new(emb);
+        for (file, name) in chunks {
+            let mut c = make_chunk(&format!("{file}:{name}"), name);
+            c.file = PathBuf::from(file);
+            store
+                .upsert_chunks_batch(&[(c, embedding.clone())], Some(0))
+                .expect("seed overlay chunk");
+        }
+        // Group edges by (caller_name, caller_file, caller_line) into FunctionCalls.
+        use std::collections::BTreeMap;
+        let mut grouped: BTreeMap<(String, String, u32), Vec<CallSite>> = BTreeMap::new();
+        for (caller_name, caller_file, caller_line, callee_name) in edges {
+            grouped
+                .entry((
+                    caller_name.to_string(),
+                    caller_file.to_string(),
+                    *caller_line,
+                ))
+                .or_default()
+                .push(CallSite {
+                    callee_name: callee_name.to_string(),
+                    line_number: caller_line + 1,
+                    kind: CallEdgeKind::Call,
+                });
+        }
+        for ((caller_name, caller_file, caller_line), calls) in grouped {
+            let fc = FunctionCalls {
+                name: caller_name,
+                line_start: caller_line,
+                calls,
+            };
+            store
+                .upsert_function_calls(Path::new(&caller_file), &[fc])
+                .expect("seed overlay edge");
+        }
+        WorktreeOverlay {
+            store,
+            masked_origins: masked.iter().map(PathBuf::from).collect(),
+            fingerprint: [0u8; 32],
+            worktree_root: PathBuf::from("/wt"),
+            stats: OverlayStats {
+                files_in_delta: masked.len(),
+                chunks_indexed: chunks.len(),
+                build_ms: 0,
+            },
+        }
+    }
+
+    /// Open a parent store, seed it, and re-open read-only for the core.
+    fn parent_store_with(
+        chunks: &[(&str, &str)],
+        edges: &[(&str, &str, u32, &str)],
+    ) -> (TempDir, crate::cli::batch::BatchContext) {
+        let dir = TempDir::new().expect("tempdir");
+        let cqs_dir = dir.path().join(".cqs");
+        std::fs::create_dir_all(&cqs_dir).expect("mkdir .cqs");
+        let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
+        let mut emb = vec![0.0_f32; cqs::EMBEDDING_DIM];
+        emb[0] = 1.0;
+        let embedding = Embedding::new(emb);
+        {
+            let store = Store::open(&index_path).expect("open store");
+            store.init(&ModelInfo::default()).expect("init");
+            for (file, name) in chunks {
+                let mut c = make_chunk(&format!("{file}:{name}"), name);
+                c.file = PathBuf::from(file);
+                store
+                    .upsert_chunks_batch(&[(c, embedding.clone())], Some(0))
+                    .expect("upsert parent chunk");
+            }
+            use std::collections::BTreeMap;
+            let mut grouped: BTreeMap<(String, String, u32), Vec<CallSite>> = BTreeMap::new();
+            for (caller_name, caller_file, caller_line, callee_name) in edges {
+                grouped
+                    .entry((
+                        caller_name.to_string(),
+                        caller_file.to_string(),
+                        *caller_line,
+                    ))
+                    .or_default()
+                    .push(CallSite {
+                        callee_name: callee_name.to_string(),
+                        line_number: caller_line + 1,
+                        kind: CallEdgeKind::Call,
+                    });
+            }
+            for ((caller_name, caller_file, caller_line), calls) in grouped {
+                let fc = FunctionCalls {
+                    name: caller_name,
+                    line_start: caller_line,
+                    calls,
+                };
+                store
+                    .upsert_function_calls(Path::new(&caller_file), &[fc])
+                    .expect("upsert parent edge");
+            }
+        }
+        let ctx = create_test_context(&cqs_dir).expect("create_test_context");
+        (dir, ctx)
+    }
+
+    /// Extract caller names from a serialized `callers_overlay` output. The
+    /// `CallersCoreOutput` enum is private to the `graph::callers` module, so the
+    /// tests read the serialized `{callers: [...]}` (function path) shape — the
+    /// same wire shape the dispatcher emits.
+    fn caller_names_json(out: &serde_json::Value) -> Vec<String> {
+        out["callers"]
+            .as_array()
+            .unwrap_or_else(|| panic!("expected function path with `callers` array, got: {out}"))
+            .iter()
+            .map(|c| c["name"].as_str().unwrap().to_string())
+            .collect()
+    }
+
+    fn callee_names_json(out: &serde_json::Value) -> Vec<String> {
+        out["calls"]
+            .as_array()
+            .unwrap_or_else(|| panic!("expected function path with `calls` array, got: {out}"))
+            .iter()
+            .map(|c| c["name"].as_str().unwrap().to_string())
+            .collect()
+    }
+
+    /// callers(X) active: a caller deleted from a delta file drops; an added
+    /// caller in a worktree-new file appears. End-to-end through `callers_overlay`.
+    #[test]
+    fn callers_overlay_deleted_drops_added_rises() {
+        // Parent: `old_caller` (in the edited file) and `stable_caller` both
+        // call `target`.
+        let (_dir, ctx) = parent_store_with(
+            &[
+                ("src/edited.rs", "old_caller"),
+                ("src/stable.rs", "stable_caller"),
+                ("src/lib.rs", "target"),
+            ],
+            &[
+                ("old_caller", "src/edited.rs", 1, "target"),
+                ("stable_caller", "src/stable.rs", 1, "target"),
+            ],
+        );
+        // Worktree: `src/edited.rs` was modified — it no longer calls `target`
+        // (no overlay edge from it) but a NEW caller `fresh_caller` does.
+        let overlay = overlay_with_edges(
+            &[("src/edited.rs", "fresh_caller")],
+            &[("fresh_caller", "src/edited.rs", 1, "target")],
+            &["src/edited.rs"],
+        );
+        let args = CallersCoreArgs {
+            name: "target".into(),
+            limit: 50,
+            edge_kind: None,
+        };
+        let out = serde_json::to_value(
+            callers_overlay(&ctx.store(), &args, Some(&overlay)).expect("callers_overlay"),
+        )
+        .unwrap();
+        let got = caller_names_json(&out);
+        assert!(
+            !got.contains(&"old_caller".to_string()),
+            "deleted caller in delta file must drop; got {got:?}"
+        );
+        assert!(
+            got.contains(&"fresh_caller".to_string()),
+            "worktree-added caller must appear; got {got:?}"
+        );
+        assert!(
+            got.contains(&"stable_caller".to_string()),
+            "untouched caller must survive; got {got:?}"
+        );
+    }
+
+    /// callees(X) active — X edited (its def file is in the delta): callees come
+    /// from the overlay (parent callee set dropped wholesale).
+    #[test]
+    fn callees_overlay_x_edited_served_from_overlay() {
+        // Parent: X (defined in src/x.rs) calls `parent_callee`.
+        let (_dir, ctx) = parent_store_with(
+            &[("src/x.rs", "X"), ("src/lib.rs", "parent_callee")],
+            &[("X", "src/x.rs", 1, "parent_callee")],
+        );
+        // Worktree edits src/x.rs: X now calls `worktree_callee` instead.
+        let overlay = overlay_with_edges(
+            &[("src/x.rs", "X")],
+            &[("X", "src/x.rs", 1, "worktree_callee")],
+            &["src/x.rs"],
+        );
+        let args = CoreCalleesArgs {
+            name: "X".into(),
+            limit: 50,
+            edge_kind: None,
+        };
+        let out = serde_json::to_value(
+            callees_overlay(&ctx.store(), &args, Some(&overlay)).expect("callees_overlay"),
+        )
+        .unwrap();
+        let got = callee_names_json(&out);
+        assert!(
+            got.contains(&"worktree_callee".to_string()),
+            "X edited: overlay callee must appear; got {got:?}"
+        );
+        assert!(
+            !got.contains(&"parent_callee".to_string()),
+            "X edited: parent callee set must be dropped; got {got:?}"
+        );
+    }
+
+    /// callees(X) active — X UNedited (def file outside the delta): parent
+    /// callees stay authoritative, the overlay is NOT unioned (no spurious rows).
+    #[test]
+    fn callees_overlay_x_unedited_parent_authoritative() {
+        // Parent: X (in src/stable.rs) calls `real_callee`.
+        let (_dir, ctx) = parent_store_with(
+            &[("src/stable.rs", "X"), ("src/lib.rs", "real_callee")],
+            &[("X", "src/stable.rs", 1, "real_callee")],
+        );
+        // The delta touches an UNRELATED file and (pathologically) the overlay
+        // store happens to hold a stray callee edge under the same name X — which
+        // must NOT leak in, because X's def file is unchanged.
+        let overlay = overlay_with_edges(
+            &[("src/unrelated.rs", "noise")],
+            &[("X", "src/unrelated.rs", 9, "spurious_callee")],
+            &["src/unrelated.rs"],
+        );
+        let args = CoreCalleesArgs {
+            name: "X".into(),
+            limit: 50,
+            edge_kind: None,
+        };
+        let out = serde_json::to_value(
+            callees_overlay(&ctx.store(), &args, Some(&overlay)).expect("callees_overlay"),
+        )
+        .unwrap();
+        let got = callee_names_json(&out);
+        assert_eq!(
+            got,
+            vec!["real_callee".to_string()],
+            "unedited X: parent callees authoritative, overlay NOT unioned; got {got:?}"
+        );
+    }
+
+    /// callees(X) active — X moved cross-boundary (worktree-added def): X is not
+    /// in the parent store at all, but the overlay defines it (in a delta file).
+    /// The overlay-def leg of `callee_target_def_masked` fires, so the callees
+    /// resolve to the overlay's view.
+    #[test]
+    fn callees_overlay_x_added_in_worktree_resolves_to_overlay() {
+        // Parent has no X (and no edges for it).
+        let (_dir, ctx) = parent_store_with(&[("src/lib.rs", "unrelated")], &[]);
+        // Worktree ADDS src/new.rs defining X, which calls `new_callee`.
+        let overlay = overlay_with_edges(
+            &[("src/new.rs", "X")],
+            &[("X", "src/new.rs", 1, "new_callee")],
+            &["src/new.rs"],
+        );
+        let args = CoreCalleesArgs {
+            name: "X".into(),
+            limit: 50,
+            edge_kind: None,
+        };
+        let out = serde_json::to_value(
+            callees_overlay(&ctx.store(), &args, Some(&overlay)).expect("callees_overlay"),
+        )
+        .unwrap();
+        let got = callee_names_json(&out);
+        assert!(
+            got.contains(&"new_callee".to_string()),
+            "worktree-added X: callees resolve to the overlay def; got {got:?}"
+        );
+    }
+
+    /// CLI==daemon / no-overlay parity: `callers_overlay(.., None)` is
+    /// byte-identical to the plain `callers_core` (the regression fence — the
+    /// overlay-aware core must not perturb the parent-truth path).
+    #[test]
+    fn callers_overlay_none_equals_core() {
+        let (_dir, ctx) = parent_store_with(
+            &[("src/a.rs", "a_caller"), ("src/lib.rs", "target")],
+            &[("a_caller", "src/a.rs", 1, "target")],
+        );
+        let args = CallersCoreArgs {
+            name: "target".into(),
+            limit: 5,
+            edge_kind: None,
+        };
+        let with_none = serde_json::to_value(
+            callers_overlay(&ctx.store(), &args, None).expect("callers_overlay none"),
+        )
+        .unwrap();
+        let core =
+            serde_json::to_value(callers_core(&ctx.store(), &args).expect("callers_core")).unwrap();
+        assert_eq!(
+            with_none, core,
+            "callers_overlay(None) must equal callers_core (no-overlay regression fence)"
+        );
+        // Grounded: the seeded caller is actually present (guards a both-empty
+        // false pass).
+        assert!(
+            core["callers"]
+                .as_array()
+                .is_some_and(|a| a.iter().any(|c| c["name"] == "a_caller")),
+            "seeded caller must be present: {core}"
+        );
+    }
+
+    /// No-overlay parity for callees.
+    #[test]
+    fn callees_overlay_none_equals_core() {
+        let (_dir, ctx) = parent_store_with(
+            &[("src/x.rs", "X"), ("src/lib.rs", "c")],
+            &[("X", "src/x.rs", 1, "c")],
+        );
+        let args = CoreCalleesArgs {
+            name: "X".into(),
+            limit: 5,
+            edge_kind: None,
+        };
+        let with_none = serde_json::to_value(
+            callees_overlay(&ctx.store(), &args, None).expect("callees_overlay none"),
+        )
+        .unwrap();
+        let core =
+            serde_json::to_value(callees_core(&ctx.store(), &args).expect("callees_core")).unwrap();
+        assert_eq!(
+            with_none, core,
+            "callees_overlay(None) must equal callees_core (no-overlay regression fence)"
+        );
+        assert!(
+            core["calls"]
+                .as_array()
+                .is_some_and(|a| a.iter().any(|c| c["name"] == "c")),
+            "seeded callee must be present: {core}"
         );
     }
 }

--- a/src/cli/batch/handlers/mod.rs
+++ b/src/cli/batch/handlers/mod.rs
@@ -93,6 +93,22 @@ pub(super) fn prepare_overlay_request_fields(
 /// two coexist (`merged_meta_value` merges the per-response entry with the
 /// process-level `worktree_overlay`).
 pub(super) fn attach_overlay_graph_meta(value: &mut serde_json::Value) {
+    attach_overlay_graph_marker(value, "seed-only");
+}
+
+/// Inject the `_meta.overlay_graph = "full"` marker (#1858 Part B). Called by
+/// the call-graph dispatchers (`callers` / `callees`) when the worktree overlay
+/// shadowed the graph query ITSELF — the result reflects the worktree delta, not
+/// just the seed. Distinguished from the `"seed-only"` marker so a consumer can
+/// tell a fully-overlaid graph answer from a scout/gather answer whose seed was
+/// overlaid but whose BFS expansion stayed on parent-truth.
+pub(super) fn attach_overlay_graph_meta_full(value: &mut serde_json::Value) {
+    attach_overlay_graph_marker(value, "full");
+}
+
+/// Shared writer for the `_meta.overlay_graph` marker. The two named wrappers
+/// pin the only two valid values (`"seed-only"`, `"full"`) at their call sites.
+fn attach_overlay_graph_marker(value: &mut serde_json::Value, marker: &str) {
     if let Some(obj) = value.as_object_mut() {
         let meta = obj
             .entry("_meta")
@@ -100,7 +116,7 @@ pub(super) fn attach_overlay_graph_meta(value: &mut serde_json::Value) {
         if let Some(meta_obj) = meta.as_object_mut() {
             meta_obj.insert(
                 "overlay_graph".to_string(),
-                serde_json::Value::String("seed-only".to_string()),
+                serde_json::Value::String(marker.to_string()),
             );
         }
     }

--- a/src/cli/batch/mod.rs
+++ b/src/cli/batch/mod.rs
@@ -761,6 +761,7 @@ mod tests {
             cross_project: true,
             edge_kind: None,
             limit_arg: LimitArg { limit: 5 },
+            overlay: Default::default(),
         };
 
         let view1 = ctx.build_view(None);

--- a/src/cli/batch/view.rs
+++ b/src/cli/batch/view.rs
@@ -6,6 +6,45 @@
 
 use super::*;
 
+#[cfg(test)]
+thread_local! {
+    /// Per-test overlay override for the daemon-path handler tests. When set,
+    /// [`BatchView::resolve_overlay`] returns it directly, bypassing the LRU /
+    /// embedder / git-delta build so a test can drive `dispatch_callers` /
+    /// `dispatch_callees` with a hand-built [`cqs::worktree_overlay::WorktreeOverlay`]
+    /// and assert the `_meta.overlay_graph` marker's honesty.
+    static TEST_OVERLAY_OVERRIDE: std::cell::RefCell<
+        Option<Arc<cqs::worktree_overlay::WorktreeOverlay>>,
+    > = const { std::cell::RefCell::new(None) };
+}
+
+/// Install a thread-local overlay override for the current test, returning a
+/// guard that clears it on drop (so a reused test thread never leaks the
+/// override into the next test).
+#[cfg(test)]
+pub(crate) fn set_test_overlay_override(
+    overlay: Arc<cqs::worktree_overlay::WorktreeOverlay>,
+) -> TestOverlayGuard {
+    TEST_OVERLAY_OVERRIDE.with(|cell| *cell.borrow_mut() = Some(overlay));
+    TestOverlayGuard
+}
+
+/// RAII guard from [`set_test_overlay_override`]; clears the thread-local on drop.
+#[cfg(test)]
+pub(crate) struct TestOverlayGuard;
+
+#[cfg(test)]
+impl Drop for TestOverlayGuard {
+    fn drop(&mut self) {
+        TEST_OVERLAY_OVERRIDE.with(|cell| *cell.borrow_mut() = None);
+    }
+}
+
+#[cfg(test)]
+fn test_overlay_override() -> Option<Arc<cqs::worktree_overlay::WorktreeOverlay>> {
+    TEST_OVERLAY_OVERRIDE.with(|cell| cell.borrow().clone())
+}
+
 /// Produce a `BatchView` from an `Arc<Mutex<BatchContext>>`. Lock the mutex
 /// briefly, snapshot the Arcs, drop the guard. The view carries the
 /// `Arc<Mutex<BatchContext>>` as a back-channel for `Refresh`.
@@ -1006,6 +1045,15 @@ impl BatchView {
     /// `embeddings_cache.db` (the intentional cross-boundary cache write,
     /// documented in `worktree_overlay_build`).
     fn resolve_overlay(&self) -> Option<Arc<cqs::worktree_overlay::WorktreeOverlay>> {
+        // Test seam: a directly-injected overlay short-circuits the LRU /
+        // embedder / git-delta build, so daemon-path handler tests can exercise
+        // the marker-honesty gate without a real worktree + CPU model.
+        // Thread-local because the override is per-test and the view is handed
+        // to handlers as `&BatchView` (no `&mut`); single-threaded per dispatch.
+        #[cfg(test)]
+        if let Some(ov) = test_overlay_override() {
+            return Some(ov);
+        }
         let worktree_root = self.overlay_request.borrow().clone()?;
         let _span = tracing::info_span!(
             "batch_view_resolve_overlay",

--- a/src/cli/commands/graph/callers.rs
+++ b/src/cli/commands/graph/callers.rs
@@ -298,25 +298,50 @@ pub(crate) fn build_callees(name: &str, callees: &[CalleeInfo], total: usize) ->
 /// vs. function-path selection, and the SQL → typed-output translation.
 /// Never prints, reads env, or branches on surface — the CLI and daemon
 /// adapters render the returned [`CallersCoreOutput`].
+///
+/// The plain entry point serves the parent index unchanged (byte-identical to
+/// the pre-overlay behaviour). The worktree-overlay merge lives in
+/// [`callers_overlay`]; this delegates to it with no overlay.
 pub(crate) fn callers_core(
     store: &Store<ReadOnly>,
     args: &CallersArgs,
 ) -> Result<CallersCoreOutput> {
+    callers_overlay(store, args, None)
+}
+
+/// Overlay-aware core for `cqs callers <name>` (single-project, #1858 Part B).
+///
+/// Identical to [`callers_core`] when `overlay` is `None` (the CLI / eval /
+/// tests path — byte-unchanged). When `Some`, the bare-name function path
+/// merges the worktree overlay's callers via
+/// [`WorktreeOverlay::merge_callers`]: parent callers whose call-site origin is
+/// in the delta are dropped, then the overlay's callers are unioned in. The
+/// edge-kind filter and `--limit` cap apply to the merged set.
+///
+/// The `Type::method`-qualified and kind-fallback paths stay on parent-truth in
+/// Part B PR1 — the merge is wired only for the bare-name call-graph query (the
+/// common surface). Extending the merge to the attributed `Type::method` path is
+/// follow-up work.
+pub(crate) fn callers_overlay(
+    store: &Store<ReadOnly>,
+    args: &CallersArgs,
+    overlay: Option<&cqs::worktree_overlay::WorktreeOverlay>,
+) -> Result<CallersCoreOutput> {
     let _span =
-        tracing::info_span!("callers_core", name = %args.name, limit = args.limit).entered();
+        tracing::info_span!("callers_overlay", name = %args.name, limit = args.limit).entered();
     // Standardised cap. The store query returns every caller; we truncate
     // before rendering so the user can paginate via repeated calls.
     let limit = args.limit.clamp(1, crate::cli::GRAPH_LIMIT_CAP);
 
     // `Type::method` receiver-type disambiguation. Resolved read-side
     // from `chunks.parent_type_name`, before kind detection (which classifies
-    // the *bare* name, never the qualified form).
+    // the *bare* name, never the qualified form). Parent-truth in PR1.
     if let Some((qual_type, method)) = split_type_qualifier(&args.name) {
         return callers_qualified(store, qual_type, method, args.edge_kind, limit);
     }
 
     // Polymorphic-routing kind detection. Dispatch the kind-mismatch
-    // fallback before the call-graph query.
+    // fallback before the call-graph query. Parent-truth in PR1.
     let (chunks, fallback) = super::detect_fallback(store, &args.name);
     if let Some(fk) = fallback {
         let text = notes_text::callers(fk);
@@ -328,6 +353,15 @@ pub(crate) fn callers_core(
     let mut callers = store
         .get_callers_full(&args.name)
         .context("Failed to load callers")?;
+    // Worktree-overlay merge: drop parent callers from delta-touched origins,
+    // union the overlay's callers (all from masked origins by construction).
+    if let Some(ov) = overlay {
+        let ov_callers = ov
+            .store
+            .get_callers_full(&args.name)
+            .context("Failed to load overlay callers")?;
+        callers = ov.merge_callers(callers, ov_callers);
+    }
     // Edge-kind filter (§1): drop edges whose provenance kind doesn't match,
     // BEFORE the cap so `--limit` applies to the filtered set.
     if let Some(want) = args.edge_kind {
@@ -496,16 +530,44 @@ fn attribution_field(a: cqs::store::CallerAttribution) -> String {
 }
 
 /// Surface-agnostic core for `cqs callees <name>` (single-project).
+///
+/// The plain entry point serves the parent index unchanged. The worktree-
+/// overlay merge lives in [`callees_overlay`]; this delegates with no overlay.
 pub(crate) fn callees_core(
     store: &Store<ReadOnly>,
     args: &CalleesArgs,
 ) -> Result<CalleesCoreOutput> {
+    callees_overlay(store, args, None)
+}
+
+/// Overlay-aware core for `cqs callees <name>` (single-project, #1858 Part B).
+///
+/// Identical to [`callees_core`] when `overlay` is `None`. When `Some`, the
+/// bare-name function path resolves the asymmetric callee masking key (X's
+/// DEFINITION file, NOT a per-row column — `function_calls` records callees by
+/// name only, so there is nothing per-row to mask):
+///
+/// - If X's def-origin is in the delta (its body changed) the entire parent
+///   callee set is suspect: drop ALL parent rows and serve the overlay's callee
+///   rows for X.
+/// - If X's def-origin is unchanged the parent callees are authoritative and the
+///   overlay is NOT unioned — X was not edited, so the overlay holds no callee
+///   rows for it. (Unioning here would inject unrelated overlay rows.)
+///
+/// The `x_def_masked` decision is [`WorktreeOverlay::callee_target_def_masked`]
+/// over X's parent definition origins plus an overlay-store def check.
+/// `Type::method` and kind-fallback paths stay on parent-truth in PR1.
+pub(crate) fn callees_overlay(
+    store: &Store<ReadOnly>,
+    args: &CalleesArgs,
+    overlay: Option<&cqs::worktree_overlay::WorktreeOverlay>,
+) -> Result<CalleesCoreOutput> {
     let _span =
-        tracing::info_span!("callees_core", name = %args.name, limit = args.limit).entered();
+        tracing::info_span!("callees_overlay", name = %args.name, limit = args.limit).entered();
     let limit = args.limit.clamp(1, crate::cli::GRAPH_LIMIT_CAP);
 
     // `Type::method` scoping: callees of the method as defined under
-    // the queried type, scoped by the def's origin file(s).
+    // the queried type, scoped by the def's origin file(s). Parent-truth in PR1.
     if let Some((qual_type, method)) = split_type_qualifier(&args.name) {
         return callees_qualified(store, qual_type, method, args.edge_kind, limit);
     }
@@ -521,6 +583,26 @@ pub(crate) fn callees_core(
     let mut callees = store
         .get_callees_full(&args.name, None, None)
         .context("Failed to load callees")?;
+    // Worktree-overlay merge: the asymmetric callee key. X's callee set is
+    // suspect iff X's DEFINITION lives in a delta-touched file.
+    if let Some(ov) = overlay {
+        // X's parent definition origins (where X is defined in main).
+        let parent_def_origins = store
+            .get_chunks_by_name(&args.name)
+            .context("Failed to resolve callee target definition origins")?
+            .into_iter()
+            .map(|c| c.file);
+        let x_def_masked = ov.callee_target_def_masked(&args.name, parent_def_origins);
+        let ov_callees = if x_def_masked {
+            ov.store
+                .get_callees_full(&args.name, None, None)
+                .context("Failed to load overlay callees")?
+        } else {
+            // Body unchanged: the overlay scan is irrelevant; skip the query.
+            Vec::new()
+        };
+        callees = ov.merge_callees(callees, ov_callees, x_def_masked);
+    }
     if let Some(want) = args.edge_kind {
         callees.retain(|c| c.edge_kind == want);
     }

--- a/src/cli/commands/graph/callers.rs
+++ b/src/cli/commands/graph/callers.rs
@@ -301,12 +301,13 @@ pub(crate) fn build_callees(name: &str, callees: &[CalleeInfo], total: usize) ->
 ///
 /// The plain entry point serves the parent index unchanged (byte-identical to
 /// the pre-overlay behaviour). The worktree-overlay merge lives in
-/// [`callers_overlay`]; this delegates to it with no overlay.
+/// [`callers_overlay`]; this delegates to it with no overlay (so participation
+/// is always `false` and is discarded).
 pub(crate) fn callers_core(
     store: &Store<ReadOnly>,
     args: &CallersArgs,
 ) -> Result<CallersCoreOutput> {
-    callers_overlay(store, args, None)
+    Ok(callers_overlay(store, args, None)?.0)
 }
 
 /// Overlay-aware core for `cqs callers <name>` (single-project, #1858 Part B).
@@ -318,6 +319,17 @@ pub(crate) fn callers_core(
 /// in the delta are dropped, then the overlay's callers are unioned in. The
 /// edge-kind filter and `--limit` cap apply to the merged set.
 ///
+/// Returns `(output, overlay_participated)`. The bool reports whether the
+/// overlay actually consulted the delta for THIS answer — true only when the
+/// merge changed the caller set (a parent row's call-site origin was masked OR
+/// ≥1 overlay row was unioned). It is `false` on every parent-truth path:
+/// `overlay == None`, the `Type::method`-qualified early-return, the
+/// kind-fallback early-return, and an active overlay that touched no origin
+/// relevant to this query. The daemon adapter gates the
+/// `_meta.overlay_graph = "full"` calibration marker on this bool so the marker
+/// never over-claims: `overlay.is_some()` means "the worktree has some dirty
+/// file", NOT "this answer reflects the delta".
+///
 /// The `Type::method`-qualified and kind-fallback paths stay on parent-truth in
 /// Part B PR1 — the merge is wired only for the bare-name call-graph query (the
 /// common surface). Extending the merge to the attributed `Type::method` path is
@@ -326,7 +338,7 @@ pub(crate) fn callers_overlay(
     store: &Store<ReadOnly>,
     args: &CallersArgs,
     overlay: Option<&cqs::worktree_overlay::WorktreeOverlay>,
-) -> Result<CallersCoreOutput> {
+) -> Result<(CallersCoreOutput, bool)> {
     let _span =
         tracing::info_span!("callers_overlay", name = %args.name, limit = args.limit).entered();
     // Standardised cap. The store query returns every caller; we truncate
@@ -335,19 +347,28 @@ pub(crate) fn callers_overlay(
 
     // `Type::method` receiver-type disambiguation. Resolved read-side
     // from `chunks.parent_type_name`, before kind detection (which classifies
-    // the *bare* name, never the qualified form). Parent-truth in PR1.
+    // the *bare* name, never the qualified form). Parent-truth in PR1 — the
+    // overlay never participates here, so this path reports `false`.
     if let Some((qual_type, method)) = split_type_qualifier(&args.name) {
-        return callers_qualified(store, qual_type, method, args.edge_kind, limit);
+        return Ok((
+            callers_qualified(store, qual_type, method, args.edge_kind, limit)?,
+            false,
+        ));
     }
 
     // Polymorphic-routing kind detection. Dispatch the kind-mismatch
-    // fallback before the call-graph query. Parent-truth in PR1.
+    // fallback before the call-graph query. Parent-truth in PR1 — the kind is
+    // classified from the parent store, so a fallback verdict never reflects
+    // the overlay: report `false`.
     let (chunks, fallback) = super::detect_fallback(store, &args.name);
     if let Some(fk) = fallback {
         let text = notes_text::callers(fk);
-        return Ok(CallersCoreOutput::Fallback(KindFallbackOutput::new(
-            &args.name, &chunks, fk, "callers", &text,
-        )));
+        return Ok((
+            CallersCoreOutput::Fallback(KindFallbackOutput::new(
+                &args.name, &chunks, fk, "callers", &text,
+            )),
+            false,
+        ));
     }
 
     let mut callers = store
@@ -355,11 +376,19 @@ pub(crate) fn callers_overlay(
         .context("Failed to load callers")?;
     // Worktree-overlay merge: drop parent callers from delta-touched origins,
     // union the overlay's callers (all from masked origins by construction).
+    // `participated` records whether the merge actually changed the set: the
+    // overlay added ≥1 caller, OR a parent caller's call-site origin was masked.
+    // An active overlay whose delta touches no origin relevant to this query
+    // leaves `participated == false` — the answer is pure parent-truth and must
+    // not be stamped `"full"`.
+    let mut participated = false;
     if let Some(ov) = overlay {
         let ov_callers = ov
             .store
             .get_callers_full(&args.name)
             .context("Failed to load overlay callers")?;
+        participated =
+            !ov_callers.is_empty() || callers.iter().any(|c| ov.masked_origins.contains(&c.file));
         callers = ov.merge_callers(callers, ov_callers);
     }
     // Edge-kind filter (§1): drop edges whose provenance kind doesn't match,
@@ -375,7 +404,7 @@ pub(crate) fn callers_overlay(
     // A bare name with more than one definition advertises the `Type::method`
     // forms the user can re-query with.
     output.candidates = multi_def_candidates(store, &args.name)?;
-    Ok(CallersCoreOutput::Callers(output))
+    Ok((CallersCoreOutput::Callers(output), participated))
 }
 
 /// Split a `Type::method` qualifier into `(type, method)`, or `None` for a
@@ -532,12 +561,13 @@ fn attribution_field(a: cqs::store::CallerAttribution) -> String {
 /// Surface-agnostic core for `cqs callees <name>` (single-project).
 ///
 /// The plain entry point serves the parent index unchanged. The worktree-
-/// overlay merge lives in [`callees_overlay`]; this delegates with no overlay.
+/// overlay merge lives in [`callees_overlay`]; this delegates with no overlay
+/// (participation is always `false` and is discarded).
 pub(crate) fn callees_core(
     store: &Store<ReadOnly>,
     args: &CalleesArgs,
 ) -> Result<CalleesCoreOutput> {
-    callees_overlay(store, args, None)
+    Ok(callees_overlay(store, args, None)?.0)
 }
 
 /// Overlay-aware core for `cqs callees <name>` (single-project, #1858 Part B).
@@ -557,11 +587,19 @@ pub(crate) fn callees_core(
 /// The `x_def_masked` decision is [`WorktreeOverlay::callee_target_def_masked`]
 /// over X's parent definition origins plus an overlay-store def check.
 /// `Type::method` and kind-fallback paths stay on parent-truth in PR1.
+///
+/// Returns `(output, overlay_participated)`. For callees, participation is
+/// exactly `x_def_masked`: the overlay path ran (parent rows dropped, overlay
+/// rows served) only when X's definition lives in the delta. An active overlay
+/// with X unedited returns the parent callees untouched — pure parent-truth,
+/// `false`. The early-return parent-truth paths (`overlay == None`,
+/// `Type::method`-qualified, kind-fallback) all report `false` too. The daemon
+/// adapter gates the `_meta.overlay_graph = "full"` marker on this bool.
 pub(crate) fn callees_overlay(
     store: &Store<ReadOnly>,
     args: &CalleesArgs,
     overlay: Option<&cqs::worktree_overlay::WorktreeOverlay>,
-) -> Result<CalleesCoreOutput> {
+) -> Result<(CalleesCoreOutput, bool)> {
     let _span =
         tracing::info_span!("callees_overlay", name = %args.name, limit = args.limit).entered();
     let limit = args.limit.clamp(1, crate::cli::GRAPH_LIMIT_CAP);
@@ -569,22 +607,31 @@ pub(crate) fn callees_overlay(
     // `Type::method` scoping: callees of the method as defined under
     // the queried type, scoped by the def's origin file(s). Parent-truth in PR1.
     if let Some((qual_type, method)) = split_type_qualifier(&args.name) {
-        return callees_qualified(store, qual_type, method, args.edge_kind, limit);
+        return Ok((
+            callees_qualified(store, qual_type, method, args.edge_kind, limit)?,
+            false,
+        ));
     }
 
     let (chunks, fallback) = super::detect_fallback(store, &args.name);
     if let Some(fk) = fallback {
         let text = notes_text::callees(fk);
-        return Ok(CalleesCoreOutput::Fallback(KindFallbackOutput::new(
-            &args.name, &chunks, fk, "callees", &text,
-        )));
+        return Ok((
+            CalleesCoreOutput::Fallback(KindFallbackOutput::new(
+                &args.name, &chunks, fk, "callees", &text,
+            )),
+            false,
+        ));
     }
 
     let mut callees = store
         .get_callees_full(&args.name, None, None)
         .context("Failed to load callees")?;
     // Worktree-overlay merge: the asymmetric callee key. X's callee set is
-    // suspect iff X's DEFINITION lives in a delta-touched file.
+    // suspect iff X's DEFINITION lives in a delta-touched file. `x_def_masked`
+    // IS the participation signal — when false the parent callees are returned
+    // untouched (pure parent-truth) and the overlay is never unioned.
+    let mut participated = false;
     if let Some(ov) = overlay {
         // X's parent definition origins (where X is defined in main).
         let parent_def_origins = store
@@ -593,6 +640,7 @@ pub(crate) fn callees_overlay(
             .into_iter()
             .map(|c| c.file);
         let x_def_masked = ov.callee_target_def_masked(&args.name, parent_def_origins);
+        participated = x_def_masked;
         let ov_callees = if x_def_masked {
             ov.store
                 .get_callees_full(&args.name, None, None)
@@ -610,7 +658,7 @@ pub(crate) fn callees_overlay(
     callees.truncate(limit);
     let mut output = build_callees(&args.name, &callees, total);
     output.candidates = multi_def_candidates(store, &args.name)?;
-    Ok(CalleesCoreOutput::Callees(output))
+    Ok((CalleesCoreOutput::Callees(output), participated))
 }
 
 /// Resolve callees of `Type::method` by scoping `get_callees_full` to

--- a/src/cli/commands/graph/mod.rs
+++ b/src/cli/commands/graph/mod.rs
@@ -10,9 +10,15 @@ mod test_map;
 pub(crate) mod trace;
 
 pub(crate) use callers::{
-    callees_core, callees_cross_core, callers_core, callers_cross_core, cmd_callees, cmd_callers,
-    parse_edge_kind, CalleesArgs, CallersArgs as CallersCoreArgs,
+    callees_cross_core, callees_overlay, callers_cross_core, callers_overlay, cmd_callees,
+    cmd_callers, parse_edge_kind, CalleesArgs, CallersArgs as CallersCoreArgs,
 };
+// The no-overlay cores: `cmd_callers` / `cmd_callees` call them intra-module
+// unqualified, so this `pub(crate)` re-export exists only for the parity tests
+// (test-gated to keep the non-test bin warning-clean — production dispatch
+// routes through the `*_overlay` variants).
+#[cfg(test)]
+pub(crate) use callers::{callees_core, callers_core};
 pub(crate) use deps::{cmd_deps, deps_core, DepsArgs as DepsCoreArgs};
 pub(crate) use explain::cmd_explain;
 pub(crate) use impact::{cmd_impact, impact_core, impact_cross_core, ImpactArgs as ImpactCoreArgs};

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -78,11 +78,17 @@ pub(crate) use graph::parse_edge_kind;
 // `serde_json::to_value` / `to_value()` without being named at the call
 // site, so they stay internal to the graph module.
 pub(crate) use graph::{
-    callees_core, callees_cross_core, callers_core, callers_cross_core, deps_core, impact_core,
-    impact_cross_core, test_map_core, test_map_cross_core, test_map_max_nodes, trace_core,
-    trace_cross_core, trace_max_nodes, CalleesArgs, CallersCoreArgs, DepsCoreArgs, ImpactCoreArgs,
-    TestMapCoreArgs, TraceCoreArgs,
+    callees_cross_core, callees_overlay, callers_cross_core, callers_overlay, deps_core,
+    impact_core, impact_cross_core, test_map_core, test_map_cross_core, test_map_max_nodes,
+    trace_core, trace_cross_core, trace_max_nodes, CalleesArgs, CallersCoreArgs, DepsCoreArgs,
+    ImpactCoreArgs, TestMapCoreArgs, TraceCoreArgs,
 };
+// The no-overlay callers/callees cores. Production dispatch routes through the
+// `*_overlay` variants above (Part B); these plain entry points are consumed by
+// the parity tests in `batch/handlers/graph.rs`, which assert the no-overlay
+// path equals the plain core.
+#[cfg(test)]
+pub(crate) use graph::{callees_core, callers_core};
 
 // -- review --
 pub(crate) use review::cmd_affected;

--- a/src/cli/definitions.rs
+++ b/src/cli/definitions.rs
@@ -1142,18 +1142,22 @@ impl Commands {
         }
     }
 
-    /// The worktree-overlay tri-state `(overlay, no_overlay)` for the seed-
-    /// overlaid graph-adjacent commands (`scout` / `gather` / `task`,
-    /// Part A), or `None` for every other command. The `search` overlay flags
-    /// live on the top-level `Cli` (the default `cqs "query"` form), so the
-    /// dispatch-forward path reads those directly; this accessor covers only the
-    /// subcommand-bound seed overlays. Returns the raw flags — the caller folds
-    /// them through `resolve_overlay_active` with worktree eligibility.
+    /// The worktree-overlay tri-state `(overlay, no_overlay)` for the
+    /// overlay-capable subcommands — the seed-overlaid graph-adjacent commands
+    /// (`scout` / `gather` / `task`, Part A) plus the call-graph commands
+    /// (`callers` / `callees`, #1858 Part B) — or `None` for every other
+    /// command. The `search` overlay flags live on the top-level `Cli` (the
+    /// default `cqs "query"` form), so the dispatch-forward path reads those
+    /// directly; this accessor covers only the subcommand-bound overlays.
+    /// Returns the raw flags — the caller folds them through
+    /// `resolve_overlay_active` with worktree eligibility.
     pub(crate) fn overlay_tristate(&self) -> Option<(bool, bool)> {
         match self {
             Commands::Scout { args, .. } => Some((args.overlay.overlay, args.overlay.no_overlay)),
             Commands::Gather { args, .. } => Some((args.overlay.overlay, args.overlay.no_overlay)),
             Commands::Task { args, .. } => Some((args.overlay.overlay, args.overlay.no_overlay)),
+            Commands::Callers { args, .. } => Some((args.overlay.overlay, args.overlay.no_overlay)),
+            Commands::Callees { args, .. } => Some((args.overlay.overlay, args.overlay.no_overlay)),
             _ => None,
         }
     }
@@ -1450,7 +1454,9 @@ mod tests {
     #[test]
     fn overlay_tristate_reads_subcommand_flags() {
         use clap::Parser;
-        for cmd in ["scout", "gather", "task"] {
+        // scout/gather/task (Part A) + callers/callees (#1858 Part B) are the
+        // overlay-capable subcommands.
+        for cmd in ["scout", "gather", "task", "callers", "callees"] {
             let cli = Cli::try_parse_from(["cqs", cmd, "q", "--overlay"])
                 .unwrap_or_else(|e| panic!("{cmd} --overlay must parse: {e}"));
             // The flag bound to the subcommand, NOT the top-level default.
@@ -1462,6 +1468,14 @@ mod tests {
                 cli.command.as_ref().unwrap().overlay_tristate(),
                 Some((true, false)),
                 "{cmd}: overlay_tristate must report the subcommand flags"
+            );
+            // `--no-overlay` is the opt-out counterpart.
+            let off = Cli::try_parse_from(["cqs", cmd, "q", "--no-overlay"])
+                .unwrap_or_else(|e| panic!("{cmd} --no-overlay must parse: {e}"));
+            assert_eq!(
+                off.command.as_ref().unwrap().overlay_tristate(),
+                Some((false, true)),
+                "{cmd}: overlay_tristate must report --no-overlay"
             );
         }
         // A non-overlay command has no tri-state.

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -642,13 +642,14 @@ fn try_daemon_query(cqs_dir: &std::path::Path, cli: &Cli) -> Result<Option<Strin
     // re-validates it (canonicalize + `resolve_main_project_dir == served root`)
     // before reading any files.
     //
-    // Forwards for `search` (whole-result overlay) plus `scout` / `gather` /
-    // `task` (seed-only overlay), and only from an eligible worktree. The
-    // overlay flags live in two places: top-level `Cli.overlay`/`no_overlay`
-    // for the default `cqs "query"` search form, and on the subcommand's
-    // flattened `OverlayArgs` for `scout`/`gather`/`task` (so `cqs scout q
-    // --overlay` binds to the subcommand, not the top-level flag). We read the
-    // effective tri-state from whichever applies.
+    // Forwards for `search` (whole-result overlay), `scout` / `gather` /
+    // `task` (seed-only overlay), and `callers` / `callees` (full call-graph
+    // overlay, #1858 Part B), and only from an eligible worktree. The overlay
+    // flags live in two places: top-level `Cli.overlay`/`no_overlay` for the
+    // default `cqs "query"` search form, and on the subcommand's flattened
+    // `OverlayArgs` for the rest (so `cqs callers f --overlay` binds to the
+    // subcommand, not the top-level flag). We read the effective tri-state from
+    // whichever applies.
     //
     // Activation is the shared tri-state resolution (the default-on flip):
     // default-on requires eligibility (`overlay_root.is_some()`), so we resolve
@@ -663,9 +664,13 @@ fn try_daemon_query(cqs_dir: &std::path::Path, cli: &Cli) -> Result<Option<Strin
     // overlay can never activate (`--no-overlay` / `CQS_WORKTREE_OVERLAY=0`),
     // there is no reason to resolve the project root or read `.git` on every
     // query, so the default-on probe stays off the opted-out hot path.
-    if matches!(command.as_str(), "search" | "scout" | "gather" | "task") {
+    if matches!(
+        command.as_str(),
+        "search" | "scout" | "gather" | "task" | "callers" | "callees"
+    ) {
         // Effective overlay tri-state: the subcommand's flattened flags for
-        // scout/gather/task, else the top-level Cli flags (default search).
+        // scout/gather/task/callers/callees, else the top-level Cli flags
+        // (default search).
         let (flag_on, flag_off) = cli
             .command
             .as_ref()

--- a/src/worktree_overlay.rs
+++ b/src/worktree_overlay.rs
@@ -268,6 +268,139 @@ impl WorktreeOverlay {
         merged
     }
 
+    /// Merge the overlay's call-graph callers into a parent `callers(X)` result.
+    ///
+    /// `function_calls.file` is the CALLER's call-site origin (there is no
+    /// callee-origin column — the callee is identified by name), so the merge is
+    /// a single-call mask plus a union:
+    ///
+    /// 1. **Mask**: drop every parent caller whose `file` (its call-site origin)
+    ///    is in `masked_origins`. That caller's out-edge to X may have changed or
+    ///    vanished in the worktree, so its parent row is no longer authoritative.
+    ///    A caller deleted from a delta file thus drops out with no overlay
+    ///    replacement (the count falls); a caller whose body changed is replaced
+    ///    by its overlay row below.
+    /// 2. **Union**: append every overlay caller. By construction every chunk in
+    ///    the overlay store comes from a masked origin, so every overlay caller
+    ///    row is from a masked origin — the mask above already removed any
+    ///    parent counterpart, so the union cannot double-count. An added caller
+    ///    in a worktree-new file appears only here (the count rises).
+    ///
+    /// The result is the parent callers minus the suspect (masked-origin) ones,
+    /// plus the worktree's fresh view of those same origins. Edge-kind filtering
+    /// and the `--limit` cap stay in the core, applied to the merged set.
+    pub fn merge_callers(
+        &self,
+        parent: Vec<crate::store::CallerInfo>,
+        overlay: Vec<crate::store::CallerInfo>,
+    ) -> Vec<crate::store::CallerInfo> {
+        let _span = tracing::info_span!(
+            "overlay_merge_callers",
+            masked = self.masked_origins.len(),
+            parent = parent.len(),
+            overlay = overlay.len()
+        )
+        .entered();
+        let mut merged: Vec<crate::store::CallerInfo> = parent
+            .into_iter()
+            .filter(|c| !self.masked_origins.contains(&c.file))
+            .collect();
+        merged.extend(overlay);
+        merged
+    }
+
+    /// Merge the overlay's call-graph callees into a parent `callees(X)` result.
+    ///
+    /// The masking key is asymmetric to `merge_callers`. A callee row carries no
+    /// file (`function_calls` records the callee by NAME), so there is no
+    /// per-row origin to mask against. What governs authority is X's DEFINITION
+    /// file — a property of the query target, not of any row:
+    ///
+    /// - **`x_def_masked == true`** (X's body lives in a delta-touched file, so
+    ///   its entire out-edge set is suspect): drop ALL parent callee rows and
+    ///   serve the overlay's callee rows for X. The overlay reflects X's
+    ///   worktree body — added calls appear, deleted calls vanish.
+    /// - **`x_def_masked == false`** (X's body is unchanged): the parent callees
+    ///   are authoritative and there is nothing to mask (callees are name-only).
+    ///   Return them untouched and do NOT union the overlay — X was not edited,
+    ///   so the overlay holds no callee rows for it, and unioning could only
+    ///   inject rows from a stale or unrelated overlay scan.
+    ///
+    /// The caller (the core) resolves `x_def_masked` via
+    /// [`WorktreeOverlay::callee_target_def_masked`]. Edge-kind filtering and the
+    /// cap stay in the core.
+    ///
+    /// Accepted fidelity loss when a name is multiply-defined: the bare-name
+    /// callee query aggregates the out-edges of EVERY definition of X (callees
+    /// carry no def-origin to scope by). If one definition lives in the delta and
+    /// another does not, `x_def_masked` is true and the parent rows — including
+    /// the UNEDITED definition's callees — are all dropped in favour of the
+    /// overlay's, which only covers the edited file. This over-masks in the safe
+    /// direction (never serves a stale edge for the edited X; only loses some
+    /// valid edges of the co-named unedited X) and is forced by the schema. The
+    /// def-origin-scoped path that could separate them is the `Type::method`
+    /// query, which stays on parent-truth in PR1.
+    pub fn merge_callees(
+        &self,
+        parent: Vec<crate::store::CalleeInfo>,
+        overlay: Vec<crate::store::CalleeInfo>,
+        x_def_masked: bool,
+    ) -> Vec<crate::store::CalleeInfo> {
+        let _span = tracing::info_span!(
+            "overlay_merge_callees",
+            masked = self.masked_origins.len(),
+            parent = parent.len(),
+            overlay = overlay.len(),
+            x_def_masked
+        )
+        .entered();
+        if x_def_masked {
+            overlay
+        } else {
+            parent
+        }
+    }
+
+    /// Whether X's DEFINITION lives in a delta-touched file — the masking key
+    /// for [`WorktreeOverlay::merge_callees`]. True when either (a) any of X's
+    /// parent-store definition origins is in `masked_origins` (X's def file was
+    /// modified, deleted, or is the masked old path of a rename), or (b) the
+    /// overlay store itself defines X (X was added in the worktree, or moved into
+    /// a delta file, so the parent has no def at the new path). Either condition
+    /// means X's body is suspect and its out-edges must be served from the
+    /// overlay.
+    ///
+    /// `parent_def_origins` is X's definition origins read from the parent store
+    /// (e.g. `Store::get_chunks_by_name(X)` projected to `.file`); the overlay
+    /// check is done here against the overlay store so the predicate is
+    /// self-contained and unit-testable.
+    pub fn callee_target_def_masked<I>(&self, name: &str, parent_def_origins: I) -> bool
+    where
+        I: IntoIterator<Item = PathBuf>,
+    {
+        let _span = tracing::debug_span!("callee_target_def_masked", name).entered();
+        // (a) X's parent def-origin was touched by the delta.
+        for origin in parent_def_origins {
+            if self.masked_origins.contains(&origin) {
+                return true;
+            }
+        }
+        // (b) The overlay store itself defines X (worktree-added / moved-in X,
+        // whose parent def-origin is absent or is a masked old path). A store
+        // error degrades to `false` — the parent callees stay authoritative,
+        // which is the safe default (it never injects unrelated overlay rows).
+        match self.store.get_chunks_by_name(name) {
+            Ok(chunks) => chunks.iter().any(|c| self.masked_origins.contains(&c.file)),
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "overlay get_chunks_by_name failed; treating X def as unmasked"
+                );
+                false
+            }
+        }
+    }
+
     /// Extract the overlay-ORIGIN seeds from a merged seed set, keyed by name.
     ///
     /// An overlay-origin seed is one whose `chunk.file` is in `masked_origins`
@@ -1425,6 +1558,199 @@ mod tests {
             assert!(
                 map["fresh_fn"].chunk.content.contains("fresh_fn"),
                 "recovered chunk carries the overlay (worktree) content"
+            );
+        }
+    }
+
+    // ── call-graph merge (callers / callees, #1858 Part B) ──────────────
+    //
+    // `merge_callers` / `merge_callees` operate on `CallerInfo` / `CalleeInfo`
+    // vecs, so the merge LOGIC is tested with hand-built rows (no store). The
+    // def-origin predicate `callee_target_def_masked` queries the overlay store,
+    // so its overlay-side leg reuses the `overlay_with` chunk-seeding fixture.
+    mod merge_call_graph {
+        use super::merge_seed_results::overlay_with;
+        use super::*;
+        use crate::parser::CallEdgeKind;
+        use crate::store::{CalleeInfo, CallerInfo};
+
+        fn caller(file: &str, name: &str) -> CallerInfo {
+            CallerInfo {
+                name: name.to_string(),
+                file: PathBuf::from(file),
+                line: 1,
+                edge_kind: CallEdgeKind::Call,
+            }
+        }
+
+        fn callee(name: &str) -> CalleeInfo {
+            CalleeInfo {
+                name: name.to_string(),
+                line: 1,
+                edge_kind: CallEdgeKind::Call,
+            }
+        }
+
+        fn caller_names(rows: &[CallerInfo]) -> Vec<String> {
+            rows.iter().map(|c| c.name.clone()).collect()
+        }
+
+        fn callee_names(rows: &[CalleeInfo]) -> Vec<String> {
+            rows.iter().map(|c| c.name.clone()).collect()
+        }
+
+        /// An overlay holding only the mask set (no chunks needed for the
+        /// caller-merge logic — `merge_callers` masks by row file).
+        fn overlay_masking(masked: &[&str]) -> WorktreeOverlay {
+            overlay_with(&[], masked)
+        }
+
+        /// callers — deleted caller: a parent caller in a delta-touched file with
+        /// NO overlay replacement drops out (the count falls). Calibration: the
+        /// mask is what makes this fail without the merge — without dropping the
+        /// masked-origin parent row, `dead_caller` would survive.
+        #[test]
+        fn callers_deleted_caller_count_drops() {
+            // `src/edited.rs` is in the delta; the worktree deleted the call to X
+            // there, so the overlay has NO caller from that origin.
+            let overlay = overlay_masking(&["src/edited.rs"]);
+            let parent = vec![
+                caller("src/edited.rs", "dead_caller"),
+                caller("src/stable.rs", "live_caller"),
+            ];
+            let merged = overlay.merge_callers(parent, Vec::new());
+            let got = caller_names(&merged);
+            assert!(
+                !got.contains(&"dead_caller".to_string()),
+                "a caller in a delta file with no overlay replacement must drop; got {got:?}"
+            );
+            assert!(
+                got.contains(&"live_caller".to_string()),
+                "a caller in an untouched file must survive; got {got:?}"
+            );
+            assert_eq!(merged.len(), 1, "count fell from 2 to 1");
+        }
+
+        /// callers — added caller: a worktree-new caller (overlay-only, from a
+        /// masked origin) raises the count.
+        #[test]
+        fn callers_added_caller_count_rises() {
+            let overlay = overlay_masking(&["src/new.rs"]);
+            let parent = vec![caller("src/stable.rs", "existing_caller")];
+            let overlay_rows = vec![caller("src/new.rs", "fresh_caller")];
+            let merged = overlay.merge_callers(parent, overlay_rows);
+            let got = caller_names(&merged);
+            assert!(
+                got.contains(&"fresh_caller".to_string()),
+                "a worktree-added caller must surface; got {got:?}"
+            );
+            assert!(
+                got.contains(&"existing_caller".to_string()),
+                "an untouched parent caller must survive; got {got:?}"
+            );
+            assert_eq!(merged.len(), 2, "count rose from 1 to 2");
+        }
+
+        /// callers — modified caller: the parent row from the delta file is
+        /// dropped and the overlay's fresh row from the SAME origin replaces it
+        /// (no double-count).
+        #[test]
+        fn callers_modified_caller_replaced_not_duplicated() {
+            let overlay = overlay_masking(&["src/edited.rs"]);
+            // Parent and overlay both have a caller named `caller_fn` in the
+            // edited file — the overlay row is the authoritative one.
+            let parent = vec![caller("src/edited.rs", "caller_fn")];
+            let overlay_rows = vec![caller("src/edited.rs", "caller_fn")];
+            let merged = overlay.merge_callers(parent, overlay_rows);
+            assert_eq!(
+                merged.len(),
+                1,
+                "the masked parent row is replaced by the overlay row, not duplicated"
+            );
+        }
+
+        /// callees — X edited (def-origin masked): the parent callee set is
+        /// dropped wholesale and the overlay's callees for X take over.
+        #[test]
+        fn callees_x_edited_served_from_overlay() {
+            let overlay = overlay_masking(&["src/x.rs"]);
+            let parent = vec![callee("old_call"), callee("removed_call")];
+            let overlay_rows = vec![callee("new_call"), callee("kept_call")];
+            let merged = overlay.merge_callees(parent, overlay_rows, /* x_def_masked */ true);
+            let got = callee_names(&merged);
+            assert_eq!(
+                got,
+                vec!["new_call".to_string(), "kept_call".to_string()],
+                "X's body changed: parent callees dropped, overlay callees served; got {got:?}"
+            );
+        }
+
+        /// callees — X unedited (def-origin NOT masked): parent callees are
+        /// authoritative and the overlay is NOT unioned (no spurious rows).
+        #[test]
+        fn callees_x_unedited_parent_authoritative_no_overlay_union() {
+            let overlay = overlay_masking(&["src/other.rs"]);
+            let parent = vec![callee("real_call")];
+            // Even if the overlay scan returned rows, an unedited X must ignore
+            // them — passing a non-empty overlay vec proves the no-union path.
+            let overlay_rows = vec![callee("spurious_overlay_call")];
+            let merged = overlay.merge_callees(parent, overlay_rows, /* x_def_masked */ false);
+            let got = callee_names(&merged);
+            assert_eq!(
+                got,
+                vec!["real_call".to_string()],
+                "unedited X: parent callees authoritative, overlay NOT unioned; got {got:?}"
+            );
+        }
+
+        /// `callee_target_def_masked` — (a) parent def-origin in the delta: X is
+        /// defined in a modified file, so its parent def-origin is masked.
+        #[test]
+        fn def_masked_by_parent_origin_in_delta() {
+            let overlay = overlay_masking(&["src/x.rs"]);
+            // X's parent definition lives in the masked file.
+            assert!(
+                overlay.callee_target_def_masked("X", [PathBuf::from("src/x.rs")]),
+                "X defined in a delta file ⇒ def masked"
+            );
+        }
+
+        /// `callee_target_def_masked` — (b) overlay defines X: X is worktree-added
+        /// (the parent has no def-origin for it), but the overlay store holds a
+        /// chunk named X from a masked origin.
+        #[test]
+        fn def_masked_by_overlay_definition() {
+            // Overlay store has a chunk `added_fn` at masked `src/new.rs`.
+            let overlay = overlay_with(&[("src/new.rs", "added_fn", 0)], &["src/new.rs"]);
+            // No parent def-origins (worktree-added), but the overlay defines it.
+            assert!(
+                overlay.callee_target_def_masked("added_fn", std::iter::empty()),
+                "a worktree-added X (overlay defines it) ⇒ def masked"
+            );
+        }
+
+        /// `callee_target_def_masked` — unedited X: parent def-origin is outside
+        /// the delta AND the overlay doesn't define X ⇒ NOT masked.
+        #[test]
+        fn def_not_masked_for_unedited_target() {
+            let overlay = overlay_masking(&["src/unrelated.rs"]);
+            assert!(
+                !overlay.callee_target_def_masked("X", [PathBuf::from("src/stable.rs")]),
+                "X defined in an untouched file, absent from overlay ⇒ NOT masked"
+            );
+        }
+
+        /// `callee_target_def_masked` — rename: X's parent def-origin is the OLD
+        /// path (still in the parent index), which `discover_delta` masks for a
+        /// rename, so the predicate fires on the old path.
+        #[test]
+        fn def_masked_for_renamed_def_file_old_path() {
+            // Rename masks both old and new paths; the parent index still has X
+            // at the old path.
+            let overlay = overlay_masking(&["src/old.rs", "src/new.rs"]);
+            assert!(
+                overlay.callee_target_def_masked("X", [PathBuf::from("src/old.rs")]),
+                "renamed def file: the masked old path fires the predicate"
             );
         }
     }

--- a/tests/cli_worktree_overlay_query_test.rs
+++ b/tests/cli_worktree_overlay_query_test.rs
@@ -256,3 +256,33 @@ fn overlay_scout_cli_direct_serves_parent() {
         "CLI-direct scout did not overlay — no overlay_graph marker; got {v}"
     );
 }
+
+/// #1858 Part B — `callers` / `callees` accept `--overlay` and (like scout/
+/// gather/task) build the overlay daemon-side only. CLI-direct (daemon
+/// disabled) serves the PARENT call graph: the command succeeds, and emits NO
+/// `worktree_overlay` meta and NO `overlay_graph` marker (the marker rides only
+/// when the overlay was actually applied — `"full"` on the daemon path). The
+/// active full-overlay merge is covered daemon-side by the `callers_overlay` /
+/// `callees_overlay` core tests in `src/cli/batch/handlers/graph.rs`.
+#[test]
+fn overlay_callers_callees_cli_direct_serves_parent() {
+    let (_holder, _parent, wt) = fixture_with_parent_index();
+
+    for cmd_name in ["callers", "callees"] {
+        let mut cmd = cqs(&wt);
+        cmd.env("CQS_WORKTREE_OVERLAY", "1");
+        let v = run_json(cmd.args([cmd_name, "alpha", "--json", "--overlay"]));
+        assert!(
+            v.get("_meta")
+                .and_then(|m| m.get("worktree_overlay"))
+                .is_none(),
+            "CLI-direct {cmd_name} serves the parent index — no worktree_overlay meta; got {v}"
+        );
+        assert!(
+            v.get("_meta")
+                .and_then(|m| m.get("overlay_graph"))
+                .is_none(),
+            "CLI-direct {cmd_name} did not overlay — no overlay_graph marker; got {v}"
+        );
+    }
+}


### PR DESCRIPTION
## #1858 Part B PR1 — callers + callees through the worktree overlay

The graph half of the worktree overlay (Part A shipped the seed/search half in #1900). PR1 is the lower-risk pair; PR2 (impact+dead, the merged-CallGraph machinery) follows. `partially addresses #1858`.

The crux is the schema asymmetry: `function_calls.file` is the **caller's origin only** — the callee is name-keyed with no file column.

- **callers(X)** — single-call mask+union: drop parent callers whose `file ∈ masked_origins`, union all overlay callers (overlay rows are from masked origins by construction → no double-count). Deleted caller → dropped (count falls); added → overlay row (count rises).
- **callees(X)** — the asymmetry: callees carry no file, so the mask key is **X's *definition* origin**, not a per-row column. `callee_target_def_masked` is true iff X's parent def-origin ∈ masked_origins **or** the overlay store itself defines X (worktree-added / moved-in). Masked → drop all parent callee rows, serve overlay; not masked → parent authoritative, overlay not even queried.

Daemon-only (the Part A pattern): `*_overlay` cores threading `Option<&WorktreeOverlay>`, `resolve_graph_overlay` resolves `ctx.overlay()`, CLI passes `None`. New `"full"` overlay-graph marker (vs Part A's `"seed-only"`). Merge logic housed as `WorktreeOverlay::merge_callers`/`merge_callees`/`callee_target_def_masked` for unit-testability.

### Gates
9 merge-logic unit tests + 7 active-overlay core tests + 2 no-overlay parity fences + 1 CLI-direct integration test. Red→green calibration shown (neutering the callers mask → `callers_deleted_caller_count_drops` goes red). Full `cargo test --features cuda-index --tests` (global-state exception — adds a marker value + wire arg): **4592 passed, 0 failed**. fmt + clippy --all-targets + provenance clean. **code-reviewer (opus): APPROVE**, LOW–MEDIUM. seam-audit on the masking join in progress before merge.

### Residual for PR2
`resolve_graph_overlay` + the `"full"` marker + the `*_overlay` core pattern are the plumbing PR2 (impact+dead) inherits; `dead`'s zero-caller verdicts reuse `merge_callers` directly. One ISSUE-WORTHY item flagged: the `Type::method`-qualified / kind-fallback paths stay parent-truth in PR1 (extending them could fix the conservative multi-def callee over-masking caveat — tracked for PR2/follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
