### PR TITLE
fix(#1909): centralize index.db freshness key across all three readers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -322,8 +322,8 @@ src/
     types.rs    - Type edge storage and queries
     backup.rs   - Filesystem snapshots of `index.db` taken before schema migrations run (covers commit-time I/O failures the migration transaction's rollback can't)
     summary_queue.rs - Write-coalescing queue for streamed LLM-summary inserts (routes through WRITE_LOCK instead of bypassing it with a raw INSERT OR IGNORE)
-    helpers/    - Types, embedding conversion, scoring, SQL utilities
-      mod.rs, embeddings.rs, error.rs, rows.rs, scoring.rs, search_filter.rs, sql.rs, types.rs
+    helpers/    - Types, embedding conversion, scoring, SQL utilities, shared index.db freshness key
+      mod.rs, embeddings.rs, error.rs, file_identity.rs, rows.rs, scoring.rs, search_filter.rs, sql.rs, types.rs
     migrations.rs - Schema migration framework (v10-v29, including v19 FK cascade, v20 trigger, v21 splade tokens, v22 chunks.umap_x/y, v23 reconcile fingerprint, v24 vendored-code trust, v25 notes.kind, v26 composite (source_type, origin) index on chunks, v27 chunks.needs_embedding for skip-first-pass embed under --llm-summaries, v28 chunks.canonical_hash for comment-canonical embedding reuse, v29 file_registry for zero-chunk fingerprint persistence + notes.sentiment discrete-value CHECK)
   parser/       - Code parsing (tree-sitter + custom parsers, delegates to language/ registry)
     mod.rs      - Parser struct, parse_file(), parse_file_all(), supported_extensions()

--- a/src/cli/batch/context.rs
+++ b/src/cli/batch/context.rs
@@ -10,27 +10,13 @@ use super::*;
 
 // ─── Data-version probe ──────────────────────────────────────────────────────
 
-/// Long-lived `PRAGMA data_version` probe connection.
-///
-/// `data_version` is a per-connection counter that SQLite bumps when *another*
-/// connection (including one in the same process — e.g. the watch loop's
-/// read-write Store) commits a change to the database. It moves on WAL commits
-/// that never touch the main `index.db` file, which is exactly the blind spot
-/// of the `DbFileIdentity` (inode/size/mtime) check: under WAL, incremental
-/// reindex writes land in `index.db-wal` and the main file's identity is
-/// unchanged until checkpoint.
-///
-/// The classic pitfall: the counter is only meaningful when queried repeatedly
-/// on the SAME connection — a fresh connection per check re-baselines every
-/// time and never observes a change. So the connection here must live as long
-/// as the `BatchContext` (and be re-opened when `index.db` is replaced via
-/// rename-over, since the old fd then points at the orphaned inode and its
-/// data_version never moves again).
-pub(super) struct DataVersionProbe {
-    conn: sqlx::SqliteConnection,
-    /// Last observed `PRAGMA data_version` value on `conn`.
-    last: i64,
-}
+/// Long-lived `PRAGMA data_version` probe — the shared type from
+/// [`cqs::store::DataVersionProbe`], so all three `index.db` readers
+/// (`BatchContext`, `CrossProjectContext`, `ReferenceIndex`) drive one probe
+/// implementation. Catches WAL-mode incremental commits that leave the main
+/// file's identity untouched until checkpoint — the false-negative class the
+/// `DbFileIdentity` (inode/size/mtime) check alone cannot see.
+use cqs::store::DataVersionProbe;
 
 // ─── Cross-project cache entry ───────────────────────────────────────────────
 
@@ -604,32 +590,7 @@ impl BatchContext {
     /// the open or the query fails — staleness detection then falls back to
     /// identity-only rather than panicking or silently skipping the check.
     fn open_data_version_probe(&self, index_path: &std::path::Path) -> Option<DataVersionProbe> {
-        use sqlx::ConnectOptions;
-        let result = self.runtime.block_on(async {
-            // Mirror the Store's read-only open shape (filename + read_only +
-            // WAL) so the probe sees the same journal-mode view of the DB.
-            let mut conn = sqlx::sqlite::SqliteConnectOptions::new()
-                .filename(index_path)
-                .read_only(true)
-                .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
-                .connect()
-                .await?;
-            let last: i64 = sqlx::query_scalar("PRAGMA data_version")
-                .fetch_one(&mut conn)
-                .await?;
-            Ok::<_, sqlx::Error>(DataVersionProbe { conn, last })
-        });
-        match result {
-            Ok(probe) => Some(probe),
-            Err(e) => {
-                tracing::warn!(
-                    error = %e,
-                    path = %index_path.display(),
-                    "Failed to open data_version probe — falling back to identity-only staleness detection"
-                );
-                None
-            }
-        }
+        DataVersionProbe::open(&self.runtime, index_path)
     }
 
     /// Query `PRAGMA data_version` on the long-lived probe connection and
@@ -650,26 +611,17 @@ impl BatchContext {
                 *slot = self.open_data_version_probe(&cqs::resolve_index_db(&self.cqs_dir));
                 false
             }
-            Some(probe) => {
-                let result = self.runtime.block_on(
-                    sqlx::query_scalar::<_, i64>("PRAGMA data_version").fetch_one(&mut probe.conn),
-                );
-                match result {
-                    Ok(v) => {
-                        let changed = v != probe.last;
-                        probe.last = v;
-                        changed
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            error = %e,
-                            "data_version probe query failed — dropping probe; will re-open on next staleness check"
-                        );
-                        *slot = None;
-                        false
-                    }
+            Some(probe) => match probe.changed(&self.runtime) {
+                Ok(changed) => changed,
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "data_version probe query failed — dropping probe; will re-open on next staleness check"
+                    );
+                    *slot = None;
+                    false
                 }
-            }
+            },
         }
     }
 
@@ -679,13 +631,12 @@ impl BatchContext {
     /// orphaned inode, so its counter would never move again. Also called at
     /// construction and on manual `refresh`.
     fn rebaseline_data_version_probe(&self, index_path: &std::path::Path) {
-        use sqlx::Connection;
         let mut slot = self.data_version_probe.borrow_mut();
         if let Some(old) = slot.take() {
             // Explicit close so sqlite finalizes the old handle now instead
             // of whenever Drop gets around to it. Best-effort — the fd is
             // dead-weight either way.
-            let _ = self.runtime.block_on(old.conn.close());
+            old.close(&self.runtime);
         }
         *slot = self.open_data_version_probe(index_path);
     }

--- a/src/cli/batch/mod.rs
+++ b/src/cli/batch/mod.rs
@@ -45,7 +45,7 @@ use std::io::{BufRead, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
-use std::time::{Instant, SystemTime};
+use std::time::Instant;
 
 use anyhow::Result;
 use clap::Parser;
@@ -80,70 +80,13 @@ pub(crate) use view::{get_all_refs_via_refs_lru, get_ref_via_refs_lru};
 #[cfg(test)]
 pub(in crate::cli) use session::create_test_context;
 
-/// Opaque identity of `index.db` used to detect that it has been replaced
-/// or rewritten between two observations.
-///
-/// Combines inode (unix), size, and mtime. This catches:
-///
-/// - **Replacement via rename** (e.g. `cqs index --force` writes a fresh
-///   `index.db.tmp` then renames it over `index.db`): the new inode
-///   differs, so the identity changes even if size/mtime happened to
-///   match.
-/// - **In-place size change**: size differs.
-/// - **Overwrite that kept the size**: mtime differs (modulo the
-///   filesystem's mtime resolution).
-///
-/// ## Why not mtime alone?
-///
-/// WSL DrvFS / NTFS report mtime at 1-second resolution. A tight
-/// `cqs index --force` followed by a daemon query burst could share the
-/// same mtime bucket, causing `BatchContext` to keep serving results from
-/// the orphaned inode. Mixing in inode and size closes that sub-second
-/// race: the rename-over gives a new inode immediately, regardless of
-/// whether the mtime ticked.
-///
-/// On non-unix platforms the inode fields are omitted and the struct
-/// falls back to `(size, mtime)`; replacement on Windows still changes
-/// the mtime and/or the size, so this is weaker than unix but strictly
-/// better than mtime alone.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct DbFileIdentity {
-    #[cfg(unix)]
-    dev: u64,
-    #[cfg(unix)]
-    inode: u64,
-    size: u64,
-    mtime: Option<SystemTime>,
-}
-
-impl DbFileIdentity {
-    /// Read the identity fields for `path`, returning `None` if the
-    /// metadata stat fails (path missing, permission denied, etc.).
-    fn from_path(path: &Path) -> Option<Self> {
-        let meta = std::fs::metadata(path).ok()?;
-        // mtime is best-effort — some exotic filesystems don't record
-        // it. Falling back to `None` here still leaves inode + size as
-        // useful discriminators.
-        let mtime = meta.modified().ok();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::MetadataExt;
-            Some(Self {
-                dev: meta.dev(),
-                inode: meta.ino(),
-                size: meta.len(),
-                mtime,
-            })
-        }
-        #[cfg(not(unix))]
-        {
-            Some(Self {
-                size: meta.len(),
-                mtime,
-            })
-        }
-    }
-}
+/// The shared `index.db` freshness key, re-exported under the batch module's
+/// historical name so the existing call sites (`DbFileIdentity::from_path`)
+/// keep reading. The type, its doc, and its construction live single-source in
+/// [`cqs::store::FileIdentity`] — both sibling readers
+/// (`CrossProjectContext`, `ReferenceIndex`) use the same type, so a hardening
+/// here propagates to all three by construction rather than leaving a straggler.
+pub(super) use cqs::store::FileIdentity as DbFileIdentity;
 
 /// Default idle timeout for ONNX sessions (embedder, reranker) in minutes.
 /// After this many minutes without a command, sessions are cleared to free

--- a/src/cli/batch/view.rs
+++ b/src/cli/batch/view.rs
@@ -175,7 +175,7 @@ pub(crate) fn get_ref_via_refs_lru(
             if existing.is_stale() {
                 tracing::info!(
                     reference = %name,
-                    "Cached reference stale (index.db mtime/size changed) — evicting for reload"
+                    "Cached reference stale (index.db changed) — evicting for reload"
                 );
                 cache.pop(name);
             } else {
@@ -233,7 +233,7 @@ pub(crate) fn get_all_refs_via_refs_lru(
                 if existing.is_stale() {
                     tracing::info!(
                         reference = %cfg.name,
-                        "Cached reference stale (index.db mtime/size changed) — evicting for reload"
+                        "Cached reference stale (index.db changed) — evicting for reload"
                     );
                     cache.pop(&cfg.name);
                     misses.push(cfg.clone());

--- a/src/cli/commands/search/query.rs
+++ b/src/cli/commands/search/query.rs
@@ -1800,14 +1800,7 @@ mod tests {
                     .expect("upsert ref chunk");
             }
             let store = Store::open_readonly(&db).expect("open ref readonly");
-            ReferenceIndex {
-                name: "stdlib".to_string(),
-                store,
-                index: None,
-                weight: 1.0,
-                db_path: db,
-                loaded_identity: None,
-            }
+            ReferenceIndex::new_loaded("stdlib".to_string(), store, None, 1.0, db)
         }
 
         /// Build a `CountingCtx` plus the seeded query embedding. The embedder's

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -5,12 +5,18 @@
 //! from references have their scores multiplied by a weight (default 0.8) to
 //! rank them below equally-similar project results.
 
+use std::sync::{Arc, Mutex};
+
 use rayon::prelude::*;
+use tokio::runtime::Runtime;
 
 use crate::config::ReferenceConfig;
 use crate::hnsw::HnswIndex;
 use crate::index::VectorIndex;
-use crate::store::{ReadOnly, SearchFilter, SearchResult, Store, StoreError, UnifiedResult};
+use crate::store::{
+    DataVersionProbe, FileIdentity, ReadOnly, SearchFilter, SearchResult, Store, StoreError,
+    UnifiedResult,
+};
 use crate::Embedding;
 
 /// A loaded reference index ready for searching
@@ -30,14 +36,27 @@ pub struct ReferenceIndex {
     /// Score multiplier (0.0-1.0)
     pub weight: f32,
     /// Path to the reference's `index.db` — kept so staleness checks can
-    /// re-stat the file without reconstructing the path from `name + path`.
+    /// re-stat the file and re-open the data_version probe without
+    /// reconstructing the path from `name + path`.
     pub db_path: std::path::PathBuf,
-    /// (mtime, size) of `index.db` at load time. Long-lived
-    /// daemons that cache loaded references need to invalidate them when
-    /// the reference's own `cqs ref update <name>` rewrites the DB. The
-    /// primary project's mtime change wouldn't catch this, so each
-    /// cached reference tracks its own identity.
-    pub loaded_identity: Option<(std::time::SystemTime, u64)>,
+    /// Freshness key of `index.db` at load time. Long-lived daemons that cache
+    /// loaded references need to invalidate them when the reference's own
+    /// `cqs ref update <name>` reindexes the DB. The primary project's identity
+    /// change wouldn't catch this, so each cached reference tracks its own.
+    pub loaded_identity: Option<FileIdentity>,
+    /// Long-lived `PRAGMA data_version` probe — the second freshness
+    /// discriminator. `cqs ref update` reindexes the DB *in place* (incremental
+    /// pipeline, not rename-over), so WAL-mode commits can land before the
+    /// closing checkpoint moves the file identity; the probe is the only
+    /// discriminator that catches that window. Interior-mutable (`Mutex`)
+    /// because [`Self::is_stale`] is `&self` — the index is shared across daemon
+    /// threads via `Arc<ReferenceIndex>` in the references LRU. `None` when the
+    /// probe couldn't be opened (warned, identity-only fallback); re-opened
+    /// lazily on the next staleness check.
+    data_version_probe: Mutex<Option<DataVersionProbe>>,
+    /// Runtime handle (cloned from the store) that drives the probe's async
+    /// sqlx queries, so the probe stays on the store's worker pool.
+    runtime: Arc<Runtime>,
 }
 
 impl std::fmt::Debug for ReferenceIndex {
@@ -131,57 +150,98 @@ fn load_single_reference(cfg: &ReferenceConfig) -> Option<ReferenceIndex> {
     // would otherwise load as `EMBEDDING_DIM`-dim garbage.
     let index = HnswIndex::try_load_with_ef(&cfg.path, None, store.dim());
 
-    // Capture (mtime, size) at load time so cached references can be
-    // invalidated when the reference itself is re-indexed. `None` on stat
-    // failure is fine — `is_stale` treats that as "can't tell, keep using it"
-    // rather than thrashing the cache on transient errors.
-    let loaded_identity = stat_identity(&db_path);
-
-    Some(ReferenceIndex {
-        name: cfg.name.clone(),
+    // `new_loaded` captures the freshness key (file identity + data_version
+    // probe) at load time so cached references can be invalidated when the
+    // reference itself is re-indexed.
+    Some(ReferenceIndex::new_loaded(
+        cfg.name.clone(),
         store,
         index,
-        weight: cfg.weight,
+        cfg.weight,
         db_path,
-        loaded_identity,
-    })
-}
-
-/// Stat `path` and return `(mtime, size)` if readable. Used for reference
-/// staleness detection. Errors are logged at debug and treated as "unknown"
-/// (caller falls back to keeping the cached value).
-fn stat_identity(path: &std::path::Path) -> Option<(std::time::SystemTime, u64)> {
-    match std::fs::metadata(path) {
-        Ok(md) => match md.modified() {
-            Ok(t) => Some((t, md.len())),
-            Err(e) => {
-                tracing::debug!(path = %path.display(), error = %e, "metadata.modified() failed");
-                None
-            }
-        },
-        Err(e) => {
-            tracing::debug!(path = %path.display(), error = %e, "stat failed");
-            None
-        }
-    }
+    ))
 }
 
 impl ReferenceIndex {
+    /// Construct a `ReferenceIndex` around an already-opened store, deriving the
+    /// freshness key (file identity + data_version probe) from `db_path`.
+    ///
+    /// The single construction path besides [`load_single_reference`], so the
+    /// freshness-key fields stay private and a caller cannot hand-assemble a
+    /// `ReferenceIndex` with an ad-hoc `(mtime, size)` key — the next hardening
+    /// of [`FileIdentity`] propagates here by construction. The runtime is
+    /// cloned from the store so the probe stays on the store's worker pool.
+    pub fn new_loaded(
+        name: String,
+        store: Store<ReadOnly>,
+        index: Option<Box<dyn VectorIndex>>,
+        weight: f32,
+        db_path: std::path::PathBuf,
+    ) -> Self {
+        let loaded_identity = FileIdentity::from_path(&db_path);
+        let runtime = Arc::clone(store.runtime());
+        let data_version_probe = Mutex::new(DataVersionProbe::open(&runtime, &db_path));
+        Self {
+            name,
+            store,
+            index,
+            weight,
+            db_path,
+            loaded_identity,
+            data_version_probe,
+            runtime,
+        }
+    }
+
     /// Has the reference's `index.db` been rewritten since load?
     ///
-    /// Returns `true` when the current (mtime, size) differs from the value
-    /// captured at construction. If we couldn't read the file at all (or
-    /// had no identity at load time), returns `false` so the caller keeps
-    /// using the cached index — transient NFS/permission glitches shouldn't
-    /// thrash the LRU.
+    /// Two discriminators, OR-combined:
+    /// 1. [`FileIdentity`] change — catches rename-over and checkpoint (the
+    ///    `cqs ref update` close folds the WAL back, moving size/mtime/inode).
+    /// 2. `PRAGMA data_version` movement on the long-lived probe — catches the
+    ///    in-place WAL-incremental window before that checkpoint.
+    ///
+    /// If we couldn't read the file (or had no identity at load), returns
+    /// `false` so the caller keeps using the cached index — transient
+    /// NFS/permission glitches shouldn't thrash the LRU. A `true` result causes
+    /// the references LRU to pop and reload this entry, so the probe baseline is
+    /// only meaningful for the steady-state "not stale" path, where each query
+    /// advances it to observe the next commit.
     pub fn is_stale(&self) -> bool {
         let Some(loaded) = self.loaded_identity else {
             return false;
         };
-        let Some(current) = stat_identity(&self.db_path) else {
+        let Some(current) = FileIdentity::from_path(&self.db_path) else {
             return false;
         };
-        current != loaded
+        if current != loaded {
+            return true;
+        }
+        // Identity unchanged — consult the probe for the WAL-incremental case.
+        let mut slot = self
+            .data_version_probe
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        match slot.as_mut() {
+            Some(probe) => match probe.changed(&self.runtime) {
+                Ok(changed) => changed,
+                Err(e) => {
+                    tracing::warn!(
+                        name = %self.name,
+                        error = %e,
+                        "data_version probe query failed — dropping probe; will re-open on next staleness check"
+                    );
+                    *slot = None;
+                    false
+                }
+            },
+            None => {
+                // Earlier open failed (or the probe was dropped after a query
+                // error) — retry. Freshly baselined, so nothing to compare.
+                *slot = DataVersionProbe::open(&self.runtime, &self.db_path);
+                false
+            }
+        }
     }
 }
 
@@ -652,5 +712,126 @@ mod tests {
     fn test_ref_path_rejects_traversal() {
         assert!(ref_path("../etc").is_none());
         assert!(ref_path("foo/bar").is_none());
+    }
+
+    /// Build a `ReferenceIndex` backed by a real on-disk `index.db` so the
+    /// freshness-key tests can rewrite the file underneath it. Keeps the
+    /// tempdir alive (`keep`) for the test duration. Returns the index and its
+    /// `index.db` path.
+    fn make_disk_reference() -> (ReferenceIndex, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join(crate::INDEX_DB_FILENAME);
+        let model_info = crate::store::ModelInfo::default();
+        let store =
+            Store::<ReadOnly>::open_readonly_after_init(&db_path, |s| s.init(&model_info)).unwrap();
+        let _keep = dir.keep();
+        let ref_idx =
+            ReferenceIndex::new_loaded("disk-ref".to_string(), store, None, 1.0, db_path.clone());
+        (ref_idx, db_path)
+    }
+
+    /// Sub-second, same-size, in-place replacement (rename-over) of the
+    /// reference's `index.db` must flip `is_stale()` true via the file-identity
+    /// inode bump — even when mtime and size are unchanged.
+    ///
+    /// Calibration: RED against the previous `(mtime, size)`-only key (a
+    /// same-size rewrite inside one WSL mtime bucket reads as unchanged → stale
+    /// serve from the LRU). GREEN with [`FileIdentity`], which mixes in the
+    /// inode. Pins the inode-catchable replace case.
+    #[cfg(unix)]
+    #[test]
+    fn test_is_stale_detects_same_size_rename_over() {
+        use std::os::unix::fs::MetadataExt;
+
+        let (ref_idx, db_path) = make_disk_reference();
+        assert!(!ref_idx.is_stale(), "freshly loaded reference is not stale");
+
+        let size_before = std::fs::metadata(&db_path).unwrap().len();
+        let inode_before = std::fs::metadata(&db_path).unwrap().ino();
+        let orig_mtime = std::fs::metadata(&db_path).unwrap().modified().unwrap();
+
+        // Byte-identical copy → same size; rename-over → new inode. Force the
+        // original mtime so only the inode discriminator can fire.
+        let replacement = db_path.with_extension("db.replacement");
+        std::fs::copy(&db_path, &replacement).unwrap();
+        std::fs::File::open(&replacement)
+            .unwrap()
+            .set_modified(orig_mtime)
+            .unwrap();
+        std::fs::rename(&replacement, &db_path).unwrap();
+
+        let md_after = std::fs::metadata(&db_path).unwrap();
+        assert_eq!(md_after.len(), size_before, "precondition: size unchanged");
+        assert_ne!(
+            md_after.ino(),
+            inode_before,
+            "precondition: rename-over landed a new inode"
+        );
+        assert_eq!(
+            md_after.modified().unwrap(),
+            orig_mtime,
+            "precondition: mtime forced equal — only the inode discriminator can fire"
+        );
+
+        assert!(
+            ref_idx.is_stale(),
+            "same-size rename-over (new inode, same mtime/size) must flip is_stale()"
+        );
+    }
+
+    /// A WAL-mode commit with NO checkpoint leaves the reference's `index.db`
+    /// identity (inode/size/mtime) unchanged, yet the cached index is stale.
+    /// The `PRAGMA data_version` probe must catch it.
+    ///
+    /// Calibration: RED against EITHER `(mtime, size)`-only OR the
+    /// `FileIdentity`-only key (neither moves on an uncheckpointed WAL commit).
+    /// GREEN only with the long-lived data_version probe. Pins the
+    /// WAL-incremental case — the real `cqs ref update` shape (in-place
+    /// incremental reindex before the closing checkpoint).
+    #[test]
+    fn test_is_stale_detects_wal_commit_without_checkpoint() {
+        use sqlx::{ConnectOptions, Connection};
+
+        let (ref_idx, db_path) = make_disk_reference();
+        // Baseline both discriminators.
+        assert!(!ref_idx.is_stale(), "freshly loaded reference is not stale");
+
+        let id_before = FileIdentity::from_path(&db_path).unwrap();
+
+        // Second connection, WAL commit, NO checkpoint, kept open across the
+        // assertions so closing the last writer can't auto-checkpoint and mask
+        // the discriminator under test.
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let mut writer = rt
+            .block_on(
+                sqlx::sqlite::SqliteConnectOptions::new()
+                    .filename(&db_path)
+                    .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
+                    .connect(),
+            )
+            .unwrap();
+        rt.block_on(async {
+            sqlx::query("CREATE TABLE IF NOT EXISTS wal_poke (x INTEGER)")
+                .execute(&mut writer)
+                .await?;
+            sqlx::query("INSERT INTO wal_poke (x) VALUES (1)")
+                .execute(&mut writer)
+                .await?;
+            Ok::<_, sqlx::Error>(())
+        })
+        .unwrap();
+
+        assert_eq!(
+            FileIdentity::from_path(&db_path).unwrap(),
+            id_before,
+            "precondition: WAL commit must leave main-file identity unchanged"
+        );
+
+        assert!(
+            ref_idx.is_stale(),
+            "WAL commit with no checkpoint must flip is_stale() via data_version"
+        );
+
+        let _ = rt.block_on(writer.close());
     }
 }

--- a/src/store/calls/cross_project.rs
+++ b/src/store/calls/cross_project.rs
@@ -6,7 +6,10 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use tokio::runtime::Runtime;
+
 use crate::store::helpers::{CallGraph, CallerInfo, ChunkSummary, StoreError};
+use crate::store::{DataVersionProbe, FileIdentity};
 use crate::Store;
 
 /// A named store for cross-project context.
@@ -20,20 +23,33 @@ pub struct NamedStore {
     pub name: String,
     /// The open Store handle.
     pub store: Store<crate::store::ReadOnly>,
-    /// The `index.db` path this store was opened from, plus the
-    /// `(mtime, size)` identity captured at open time. Used by
+    /// The `index.db` path this store was opened from. Kept so staleness
+    /// checks can re-stat the file and re-open the data_version probe without
+    /// reconstructing the path.
+    db_path: std::path::PathBuf,
+    /// Freshness key captured at open time, used by
     /// [`CrossProjectContext::is_stale`] so a daemon caching the context
     /// across requests self-heals after a `cqs ref update <name>` (which
     /// rewrites a reference's `index.db` without touching the primary
     /// project's). `None` when the file was unstattable at open — the
     /// staleness check then keeps the cached store rather than thrashing on
     /// a transient glitch.
-    db_path: std::path::PathBuf,
-    loaded_identity: Option<(std::time::SystemTime, u64)>,
+    loaded_identity: Option<FileIdentity>,
+    /// Long-lived `PRAGMA data_version` probe — the second freshness
+    /// discriminator. `cqs ref update` reindexes a reference's `index.db`
+    /// *in place* (incremental pipeline, not rename-over), so WAL-mode commits
+    /// can land before the closing checkpoint moves the file identity; the
+    /// probe is the only discriminator that catches that window. `None` when
+    /// the probe couldn't be opened (warned, identity-only fallback);
+    /// re-opened lazily on the next staleness check.
+    data_version_probe: Option<DataVersionProbe>,
+    /// Runtime handle (cloned from the store) that drives the probe's async
+    /// sqlx queries, so the probe stays on the store's worker pool.
+    runtime: Arc<Runtime>,
 }
 
 impl NamedStore {
-    /// Construct a `NamedStore`, capturing the `index.db` identity from
+    /// Construct a `NamedStore`, capturing the `index.db` freshness key from
     /// `path` for later staleness detection. `path` is the file the store was
     /// opened from; callers that already hold it (e.g.
     /// [`CrossProjectContext::from_config`]) avoid a redundant stat by passing
@@ -43,12 +59,69 @@ impl NamedStore {
         store: Store<crate::store::ReadOnly>,
         path: std::path::PathBuf,
     ) -> Self {
-        let loaded_identity = stat_identity(&path);
+        let loaded_identity = FileIdentity::from_path(&path);
+        let runtime = Arc::clone(store.runtime());
+        let data_version_probe = DataVersionProbe::open(&runtime, &path);
         Self {
             name,
             store,
             db_path: path,
             loaded_identity,
+            data_version_probe,
+            runtime,
+        }
+    }
+
+    /// Has this store's `index.db` been rewritten since it was opened?
+    ///
+    /// Two discriminators, OR-combined:
+    /// 1. [`FileIdentity`] change — catches rename-over and checkpoint (the
+    ///    `cqs ref update` close folds the WAL back, moving size/mtime/inode).
+    /// 2. `PRAGMA data_version` movement on the long-lived probe — catches the
+    ///    in-place WAL-incremental window before that checkpoint.
+    ///
+    /// On an identity change the probe is re-opened against the (possibly
+    /// replaced) file: a rename-over leaves the old fd pointing at the orphaned
+    /// inode, whose counter never moves again. An unstattable file or a missing
+    /// identity yields `false` (keep the cached store) — a transient glitch
+    /// shouldn't thrash the cache.
+    fn is_stale(&mut self) -> bool {
+        let Some(loaded) = self.loaded_identity else {
+            return false;
+        };
+        let Some(current) = FileIdentity::from_path(&self.db_path) else {
+            return false;
+        };
+        if current != loaded {
+            // Identity moved — re-baseline the probe against the new file so a
+            // subsequent in-place WAL commit is still caught.
+            if let Some(old) = self.data_version_probe.take() {
+                old.close(&self.runtime);
+            }
+            self.data_version_probe = DataVersionProbe::open(&self.runtime, &self.db_path);
+            self.loaded_identity = Some(current);
+            return true;
+        }
+        // Identity unchanged — consult the probe for the WAL-incremental case.
+        match self.data_version_probe.as_mut() {
+            Some(probe) => match probe.changed(&self.runtime) {
+                Ok(changed) => changed,
+                Err(e) => {
+                    tracing::warn!(
+                        name = %self.name,
+                        error = %e,
+                        "data_version probe query failed — dropping probe; will re-open on next staleness check"
+                    );
+                    self.data_version_probe = None;
+                    false
+                }
+            },
+            None => {
+                // Earlier open failed (or the probe was dropped after a query
+                // error) — retry. Freshly baselined, so nothing to compare.
+                self.data_version_probe = DataVersionProbe::open(&self.runtime, &self.db_path);
+                false
+            }
         }
     }
 }
@@ -60,15 +133,6 @@ impl std::fmt::Debug for NamedStore {
             .field("store", &"<Store>")
             .finish()
     }
-}
-
-/// Stat `path` and return `(mtime, size)` if readable. Mirrors the helper
-/// in `reference.rs`; an unreadable path yields `None` (treated as
-/// "unknown", caller keeps the cached value).
-fn stat_identity(path: &std::path::Path) -> Option<(std::time::SystemTime, u64)> {
-    let md = std::fs::metadata(path).ok()?;
-    let mtime = md.modified().ok()?;
-    Some((mtime, md.len()))
 }
 
 /// Caller info enriched with the originating project name.
@@ -210,23 +274,26 @@ impl CrossProjectContext {
     }
 
     /// Has any underlying `index.db` been rewritten since this context was
-    /// built? Catches `cqs ref update <name>` (rewrites a reference's
-    /// `index.db`) and a local reindex (rewrites the primary `index.db`) —
-    /// both leave the cached `graphs` map and the merged graph pointing at a
-    /// stale generation.
+    /// built? Catches `cqs ref update <name>` (reindexes a reference's
+    /// `index.db` in place) and a local reindex (rewrites the primary
+    /// `index.db`) — both leave the cached `graphs` map and the merged graph
+    /// pointing at a stale generation.
     ///
-    /// Returns `true` on the first store whose current `(mtime, size)`
-    /// differs from the value captured at open. Stores with no captured
-    /// identity (unstattable at open) or that are now unstattable are
+    /// Returns `true` if any store's freshness key moved (file identity or
+    /// `PRAGMA data_version`; see [`NamedStore::is_stale`]). Stores with no
+    /// captured identity (unstattable at open) or that are now unstattable are
     /// skipped — a transient glitch shouldn't force a rebuild.
-    pub fn is_stale(&self) -> bool {
-        self.stores.iter().any(|ns| match ns.loaded_identity {
-            Some(loaded) => match stat_identity(&ns.db_path) {
-                Some(current) => current != loaded,
-                None => false,
-            },
-            None => false,
-        })
+    ///
+    /// `&mut self` (not `&self`): the data_version probe advances its baseline
+    /// on each query, and every store must be polled so no probe falls behind —
+    /// hence a full fold rather than a short-circuiting `any`.
+    pub fn is_stale(&mut self) -> bool {
+        let mut stale = false;
+        for ns in self.stores.iter_mut() {
+            // Poll every store (no short-circuit) so each probe advances.
+            stale |= ns.is_stale();
+        }
+        stale
     }
 
     /// Number of projects in this context.
@@ -739,12 +806,12 @@ mod tests {
         forward.insert("caller_a".to_string(), vec!["target".to_string()]);
         let ns = make_named_store("proj_a", forward, StdMap::new());
         let db_path = ns.db_path.clone();
-        let ctx = CrossProjectContext::new(vec![ns]);
+        let mut ctx = CrossProjectContext::new(vec![ns]);
 
         assert!(!ctx.is_stale(), "freshly built context is not stale");
 
-        // Append a byte and bump mtime past the 1s FS granularity floor so the
-        // (mtime, size) identity changes.
+        // Append bytes and bump mtime past the 1s FS granularity floor so the
+        // file identity (size + mtime) changes.
         std::thread::sleep(std::time::Duration::from_secs(2));
         {
             use std::io::Write;
@@ -760,6 +827,123 @@ mod tests {
             ctx.is_stale(),
             "rewriting the underlying index.db must mark the context stale"
         );
+    }
+
+    /// Sub-second, same-size, in-place replacement (rename-over) of a backing
+    /// `index.db` must mark the context stale via the file-identity inode bump —
+    /// even when mtime and size are unchanged.
+    ///
+    /// Calibration: RED against the previous `(mtime, size)`-only key (a
+    /// same-size rewrite inside one WSL mtime bucket reads as unchanged → stale
+    /// serve). GREEN with [`FileIdentity`], which mixes in the inode: the
+    /// rename-over gives a new inode immediately. Pins the inode-catchable
+    /// replace case.
+    #[cfg(unix)]
+    #[test]
+    fn test_is_stale_detects_same_size_rename_over() {
+        use std::os::unix::fs::MetadataExt;
+
+        let mut forward = StdMap::new();
+        forward.insert("caller_a".to_string(), vec!["target".to_string()]);
+        let ns = make_named_store("proj_a", forward, StdMap::new());
+        let db_path = ns.db_path.clone();
+        let mut ctx = CrossProjectContext::new(vec![ns]);
+        assert!(!ctx.is_stale(), "freshly built context is not stale");
+
+        // Build a byte-identical replacement (copy the file) and rename it over
+        // the original. Same size; the copy lands a NEW inode. Pin both
+        // preconditions so the test proves it's the inode (not size/mtime)
+        // doing the catching.
+        let size_before = std::fs::metadata(&db_path).unwrap().len();
+        let inode_before = std::fs::metadata(&db_path).unwrap().ino();
+        let orig_mtime = std::fs::metadata(&db_path).unwrap().modified().unwrap();
+        let replacement = db_path.with_extension("db.replacement");
+        std::fs::copy(&db_path, &replacement).unwrap();
+        // Force the same mtime as the original so the (mtime, size) key cannot
+        // see the change — only the inode moves.
+        std::fs::File::open(&replacement)
+            .unwrap()
+            .set_modified(orig_mtime)
+            .unwrap();
+        std::fs::rename(&replacement, &db_path).unwrap();
+
+        let md_after = std::fs::metadata(&db_path).unwrap();
+        assert_eq!(md_after.len(), size_before, "precondition: size unchanged");
+        assert_ne!(
+            md_after.ino(),
+            inode_before,
+            "precondition: rename-over landed a new inode"
+        );
+        assert_eq!(
+            md_after.modified().unwrap(),
+            orig_mtime,
+            "precondition: mtime forced equal — only the inode discriminator can fire"
+        );
+
+        assert!(
+            ctx.is_stale(),
+            "same-size rename-over (new inode, same mtime/size) must mark the context stale"
+        );
+    }
+
+    /// A WAL-mode commit with NO checkpoint leaves the backing file's identity
+    /// (inode/size/mtime) unchanged, yet the cached context is stale. The
+    /// `PRAGMA data_version` probe must catch it.
+    ///
+    /// Calibration: RED against EITHER `(mtime, size)`-only OR the
+    /// `FileIdentity`-only key (neither moves on an uncheckpointed WAL commit).
+    /// GREEN only with the long-lived data_version probe. Pins the
+    /// WAL-incremental case — the real `cqs ref update` shape (in-place
+    /// incremental reindex before the closing checkpoint).
+    #[test]
+    fn test_is_stale_detects_wal_commit_without_checkpoint() {
+        use sqlx::{ConnectOptions, Connection};
+
+        let ns = make_named_store("proj_a", StdMap::new(), StdMap::new());
+        let db_path = ns.db_path.clone();
+        let mut ctx = CrossProjectContext::new(vec![ns]);
+        // Baseline both discriminators.
+        assert!(!ctx.is_stale(), "freshly built context is not stale");
+
+        let id_before = FileIdentity::from_path(&db_path).unwrap();
+
+        // Second connection, WAL commit, NO checkpoint, kept open across the
+        // assertions so closing the last writer can't auto-checkpoint into the
+        // main file and mask the discriminator under test.
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let mut writer = rt
+            .block_on(
+                sqlx::sqlite::SqliteConnectOptions::new()
+                    .filename(&db_path)
+                    .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
+                    .connect(),
+            )
+            .unwrap();
+        rt.block_on(async {
+            sqlx::query("CREATE TABLE IF NOT EXISTS wal_poke (x INTEGER)")
+                .execute(&mut writer)
+                .await?;
+            sqlx::query("INSERT INTO wal_poke (x) VALUES (1)")
+                .execute(&mut writer)
+                .await?;
+            Ok::<_, sqlx::Error>(())
+        })
+        .unwrap();
+
+        // Precondition: the commit landed in the WAL, not the main file — if
+        // identity moved, this would prove nothing about data_version.
+        assert_eq!(
+            FileIdentity::from_path(&db_path).unwrap(),
+            id_before,
+            "precondition: WAL commit must leave main-file identity unchanged"
+        );
+
+        assert!(
+            ctx.is_stale(),
+            "WAL commit with no checkpoint must mark the context stale via data_version"
+        );
+
+        let _ = rt.block_on(writer.close());
     }
 
     #[test]

--- a/src/store/helpers/file_identity.rs
+++ b/src/store/helpers/file_identity.rs
@@ -1,0 +1,260 @@
+//! Shared file-freshness key for `index.db` staleness detection.
+//!
+//! A long-lived reader (the daemon's `BatchContext`, a cached
+//! `CrossProjectContext`, or an LRU-resident `ReferenceIndex`) caches data
+//! derived from an `index.db` and must notice when another process or thread
+//! rewrites that file so it can drop the stale derivation. Every such reader
+//! needs the SAME freshness key — so it lives here, single-source, rather than
+//! being re-derived at each site (where a hardening applied to one copy silently
+//! left the others behind).
+//!
+//! Two discriminators, combined, cover the rewrite shapes:
+//!
+//! 1. [`FileIdentity`] — `(dev, inode, size, mtime)` on unix, `(size, mtime)`
+//!    elsewhere. Catches replacement-via-rename and checkpoint (the inode/size
+//!    move) and in-place size/mtime changes.
+//! 2. [`DataVersionProbe`] — a long-lived `PRAGMA data_version` connection.
+//!    Catches WAL-mode incremental commits that land in `index.db-wal` and
+//!    leave the main file's identity untouched until checkpoint — the
+//!    false-negative class identity alone cannot see.
+
+use std::path::Path;
+use std::time::SystemTime;
+
+use tokio::runtime::Runtime;
+
+/// Opaque identity of an `index.db` file used to detect that it has been
+/// replaced or rewritten between two observations.
+///
+/// Combines inode (unix), size, and mtime. This catches:
+///
+/// - **Replacement via rename** (e.g. `cqs index --force` writes a fresh
+///   `index.db.tmp` then renames it over `index.db`): the new inode
+///   differs, so the identity changes even if size/mtime happened to
+///   match.
+/// - **Checkpoint after WAL writes**: a `wal_checkpoint(TRUNCATE)` folds the
+///   WAL back into the main file, moving size and mtime.
+/// - **In-place size change**: size differs.
+/// - **Overwrite that kept the size**: mtime differs (modulo the
+///   filesystem's mtime resolution).
+///
+/// ## Why not mtime alone?
+///
+/// WSL DrvFS / NTFS report mtime at 1-second resolution. A tight
+/// `cqs index --force` followed by a daemon query burst could share the
+/// same mtime bucket, causing a reader to keep serving results from the
+/// orphaned inode. Mixing in inode and size closes that sub-second race:
+/// the rename-over gives a new inode immediately, regardless of whether the
+/// mtime ticked. A same-size in-place rewrite that lands a new inode
+/// (checkpoint-truncate, copy-rename) is caught the same way.
+///
+/// ## What identity does NOT catch
+///
+/// A WAL-mode incremental commit writes to `index.db-wal` and leaves the main
+/// file's identity unchanged until checkpoint. [`DataVersionProbe`] covers that
+/// blind spot; pair the two for full coverage.
+///
+/// On non-unix platforms the inode fields are omitted and the struct falls back
+/// to `(size, mtime)`; replacement on Windows still changes the mtime and/or
+/// the size, so this is weaker than unix but strictly better than mtime alone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FileIdentity {
+    #[cfg(unix)]
+    dev: u64,
+    #[cfg(unix)]
+    inode: u64,
+    size: u64,
+    mtime: Option<SystemTime>,
+}
+
+impl FileIdentity {
+    /// Read the identity fields for `path`, returning `None` if the
+    /// metadata stat fails (path missing, permission denied, etc.).
+    ///
+    /// `None` means "can't tell" — a caller comparing against a captured
+    /// identity should treat that as "keep the cached value" rather than
+    /// forcing a reload on a transient glitch.
+    pub fn from_path(path: &Path) -> Option<Self> {
+        let meta = std::fs::metadata(path).ok()?;
+        // mtime is best-effort — some exotic filesystems don't record
+        // it. Falling back to `None` here still leaves inode + size as
+        // useful discriminators.
+        let mtime = meta.modified().ok();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            Some(Self {
+                dev: meta.dev(),
+                inode: meta.ino(),
+                size: meta.len(),
+                mtime,
+            })
+        }
+        #[cfg(not(unix))]
+        {
+            Some(Self {
+                size: meta.len(),
+                mtime,
+            })
+        }
+    }
+}
+
+/// Long-lived `PRAGMA data_version` probe connection.
+///
+/// `data_version` is a per-connection counter that SQLite bumps when *another*
+/// connection (including one in the same process — e.g. the watch loop's
+/// read-write Store, or a concurrent `cqs ref update`) commits a change to the
+/// database. It moves on WAL commits that never touch the main `index.db` file,
+/// which is exactly the blind spot of the [`FileIdentity`] check: under WAL,
+/// incremental reindex writes land in `index.db-wal` and the main file's
+/// identity is unchanged until checkpoint.
+///
+/// The classic pitfall: the counter is only meaningful when queried repeatedly
+/// on the SAME connection — a fresh connection per check re-baselines every
+/// time and never observes a change. A pool (which hands out a different
+/// connection each acquire) has the same defect. So the connection here must be
+/// a dedicated, long-lived handle — held as long as the reader caching from
+/// `index.db`, and re-opened when the file is replaced via rename-over (the old
+/// fd then points at the orphaned inode and its data_version never moves
+/// again).
+pub struct DataVersionProbe {
+    conn: sqlx::SqliteConnection,
+    /// Last observed `PRAGMA data_version` value on `conn`.
+    last: i64,
+}
+
+impl DataVersionProbe {
+    /// Open a fresh probe connection against `index_path` and read its
+    /// baseline `PRAGMA data_version`. Returns `None` (with a `warn!`) when
+    /// the open or the query fails — staleness detection then falls back to
+    /// identity-only rather than panicking or silently skipping the check.
+    ///
+    /// `rt` drives the async sqlx open; callers pass the runtime their Store
+    /// already owns (`Arc::clone(store.runtime())`) so the probe stays on the
+    /// same worker pool.
+    pub fn open(rt: &Runtime, index_path: &Path) -> Option<Self> {
+        use sqlx::ConnectOptions;
+        let result = rt.block_on(async {
+            // Mirror the Store's read-only open shape (filename + read_only +
+            // WAL) so the probe sees the same journal-mode view of the DB.
+            let mut conn = sqlx::sqlite::SqliteConnectOptions::new()
+                .filename(index_path)
+                .read_only(true)
+                .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
+                .connect()
+                .await?;
+            let last: i64 = sqlx::query_scalar("PRAGMA data_version")
+                .fetch_one(&mut conn)
+                .await?;
+            Ok::<_, sqlx::Error>(DataVersionProbe { conn, last })
+        });
+        match result {
+            Ok(probe) => Some(probe),
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    path = %index_path.display(),
+                    "Failed to open data_version probe — falling back to identity-only staleness detection"
+                );
+                None
+            }
+        }
+    }
+
+    /// Query `PRAGMA data_version` on this long-lived connection and compare
+    /// against the last observed value, updating it. Returns `true` when
+    /// another connection has committed since the previous observation — WAL or
+    /// not.
+    ///
+    /// On query failure: warns and returns `Err` so the caller can drop the
+    /// probe (the next check re-opens it, re-baselining). Never panics.
+    pub fn changed(&mut self, rt: &Runtime) -> Result<bool, sqlx::Error> {
+        let v: i64 = rt.block_on(
+            sqlx::query_scalar::<_, i64>("PRAGMA data_version").fetch_one(&mut self.conn),
+        )?;
+        let changed = v != self.last;
+        self.last = v;
+        Ok(changed)
+    }
+
+    /// Explicitly close the underlying connection so sqlite finalizes the
+    /// handle now instead of whenever Drop gets around to it. Best-effort —
+    /// the fd is dead-weight either way. Called when re-opening against a
+    /// replaced file (rename-over).
+    pub fn close(self, rt: &Runtime) {
+        use sqlx::Connection;
+        let _ = rt.block_on(self.conn.close());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// Completeness guard for the `index.db` freshness key: every long-lived
+    /// reader that caches data derived from an index must route its staleness
+    /// check through the shared [`super::FileIdentity`] — and none may
+    /// re-introduce the bare `(mtime, size)` / `(SystemTime, u64)` tuple key
+    /// that the two stragglers carried before centralization.
+    ///
+    /// Asserted on source text (not behavior): the failing case is a fourth
+    /// site that hand-rolls its own weaker key. A behavioral test can't see a
+    /// site it doesn't know to exercise; this enumerates the peer-set and
+    /// fails when a member diverges, so the NEXT hardening of `FileIdentity`
+    /// propagates by construction rather than leaving a silent straggler.
+    #[test]
+    fn freshness_discriminator_sites_route_through_shared_key() {
+        let manifest_dir = env!("CARGO_MANIFEST_DIR");
+
+        // The peer-set: every reader file that holds a long-lived `index.db`
+        // freshness key. Adding a new such reader means adding it here (and
+        // routing it through `FileIdentity`) — that is the intended friction.
+        let sites = [
+            "src/store/calls/cross_project.rs",
+            "src/reference.rs",
+            "src/cli/batch/mod.rs",
+        ];
+
+        // The forbidden shape: a freshness helper whose return type is the
+        // bare `(SystemTime, u64)` tuple (the pre-centralization
+        // `stat_identity` signature, in either qualification). String-literals
+        // and doc comments are inert to the compiler, but they shouldn't carry
+        // this either — a reviewer copying one would re-seed the straggler.
+        let forbidden = [
+            "Option<(std::time::SystemTime, u64)>",
+            "Option<(SystemTime, u64)>",
+        ];
+
+        let mut offenders: Vec<String> = Vec::new();
+        for rel in sites {
+            let path = std::path::Path::new(manifest_dir).join(rel);
+            let src = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+
+            // (a) Must reference the shared key by name.
+            if !src.contains("FileIdentity") {
+                offenders.push(format!(
+                    "{rel}: a freshness-discriminator file no longer mentions \
+                     `FileIdentity` — it must route its staleness key through \
+                     the shared constructor"
+                ));
+            }
+            // (b) Must not re-introduce the bare `(mtime, size)` tuple key.
+            for bad in forbidden {
+                if src.contains(bad) {
+                    offenders.push(format!(
+                        "{rel}: contains the bare tuple freshness key `{bad}` — \
+                         use `FileIdentity::from_path` instead so the hardened \
+                         key (inode + dev + size + mtime, plus the data_version \
+                         probe) is single-source"
+                    ));
+                }
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "freshness-key completeness guard failed:\n{}",
+            offenders.join("\n")
+        );
+    }
+}

--- a/src/store/helpers/mod.rs
+++ b/src/store/helpers/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Submodules by responsibility:
 //! - `error` - Store error types
+//! - `file_identity` - Shared `index.db` freshness key (identity + data_version)
 //! - `rows` - Database row-to-struct conversions
 //! - `types` - Domain types (ChunkSummary, SearchResult, CallerInfo, etc.)
 //! - `search_filter` - Search filter and scoring options
@@ -11,6 +12,7 @@
 
 mod embeddings;
 mod error;
+mod file_identity;
 mod rows;
 mod scoring;
 mod search_filter;
@@ -23,6 +25,12 @@ mod types;
 
 // Error types
 pub use error::StoreError;
+
+// Shared file-freshness key. Every long-lived reader that caches data derived
+// from an `index.db` (the daemon BatchContext, cached CrossProjectContext,
+// LRU-resident ReferenceIndex) routes its staleness check through these so a
+// hardening propagates by construction instead of leaving a straggler behind.
+pub use file_identity::{DataVersionProbe, FileIdentity};
 
 // Row types (crate-internal)
 pub(crate) use rows::{

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -125,6 +125,10 @@ pub use helpers::StaleReport;
 /// Store operation errors.
 pub use helpers::StoreError;
 
+/// Shared `index.db` freshness key (identity + data_version probe) for
+/// long-lived readers that cache data derived from an index.
+pub use helpers::{DataVersionProbe, FileIdentity};
+
 /// Unified search result (code chunk or note).
 pub use helpers::UnifiedResult;
 

--- a/tests/gather_test.rs
+++ b/tests/gather_test.rs
@@ -299,14 +299,13 @@ fn test_gather_callees_only() {
 /// Helper: build a ReferenceIndex from a TestStore
 fn make_ref_index(store: &TestStore, name: &str) -> ReferenceIndex {
     let ref_store = cqs::Store::open_readonly(&store.db_path()).unwrap();
-    ReferenceIndex {
-        name: name.to_string(),
-        store: ref_store,
-        index: None,
-        weight: 1.0,
-        db_path: std::path::PathBuf::new(),
-        loaded_identity: None,
-    }
+    ReferenceIndex::new_loaded(
+        name.to_string(),
+        ref_store,
+        None,
+        1.0,
+        std::path::PathBuf::new(),
+    )
 }
 
 #[test]

--- a/tests/reference_test.rs
+++ b/tests/reference_test.rs
@@ -127,14 +127,13 @@ fn test_search_reference_applies_weight() {
     insert_chunks(&store, &[c1], 1.0);
 
     let ref_store = cqs::Store::open_readonly(&store.db_path()).unwrap();
-    let ref_idx = ReferenceIndex {
-        name: "test-ref".to_string(),
-        store: ref_store,
-        index: None,
-        weight: 0.7,
-        db_path: std::path::PathBuf::new(),
-        loaded_identity: None,
-    };
+    let ref_idx = ReferenceIndex::new_loaded(
+        "test-ref".to_string(),
+        ref_store,
+        None,
+        0.7,
+        std::path::PathBuf::new(),
+    );
 
     let query = mock_embedding(1.0);
     let filter = SearchFilter::default();
@@ -159,14 +158,13 @@ fn test_search_reference_weight_filters_below_threshold() {
     insert_chunks(&store, &[c1], 1.0);
 
     let ref_store = cqs::Store::open_readonly(&store.db_path()).unwrap();
-    let ref_idx = ReferenceIndex {
-        name: "test-ref".to_string(),
-        store: ref_store,
-        index: None,
-        weight: 0.5, // Low weight
-        db_path: std::path::PathBuf::new(),
-        loaded_identity: None,
-    };
+    let ref_idx = ReferenceIndex::new_loaded(
+        "test-ref".to_string(),
+        ref_store,
+        None,
+        0.5,
+        std::path::PathBuf::new(),
+    );
 
     let query = mock_embedding(1.0);
     let filter = SearchFilter::default();
@@ -186,14 +184,13 @@ fn test_search_reference_by_name_weight() {
     insert_chunks(&store, &[c1], 1.0);
 
     let ref_store = cqs::Store::open_readonly(&store.db_path()).unwrap();
-    let ref_idx = ReferenceIndex {
-        name: "test-ref".to_string(),
-        store: ref_store,
-        index: None,
-        weight: 0.6,
-        db_path: std::path::PathBuf::new(),
-        loaded_identity: None,
-    };
+    let ref_idx = ReferenceIndex::new_loaded(
+        "test-ref".to_string(),
+        ref_store,
+        None,
+        0.6,
+        std::path::PathBuf::new(),
+    );
 
     let results =
         reference::search_reference_by_name(&ref_idx, "lookup_fn", 10, 0.0, true).unwrap();
@@ -238,14 +235,13 @@ fn test_search_reference_unweighted_returns_raw_scores() {
     insert_chunks(&store, &[c1], 1.0);
 
     let ref_store = cqs::Store::open_readonly(&store.db_path()).unwrap();
-    let ref_idx = ReferenceIndex {
-        name: "test-ref".to_string(),
-        store: ref_store,
-        index: None,
-        weight: 0.5, // Low weight — should NOT be applied
-        db_path: std::path::PathBuf::new(),
-        loaded_identity: None,
-    };
+    let ref_idx = ReferenceIndex::new_loaded(
+        "test-ref".to_string(),
+        ref_store,
+        None,
+        0.5,
+        std::path::PathBuf::new(),
+    );
 
     let query = mock_embedding(1.0);
     let filter = SearchFilter::default();
@@ -274,22 +270,20 @@ fn test_search_reference_unweighted_vs_weighted() {
     let ref_store_u = cqs::Store::open_readonly(&store.db_path()).unwrap();
 
     let weight = 0.6;
-    let ref_idx_w = ReferenceIndex {
-        name: "weighted".to_string(),
-        store: ref_store_w,
-        index: None,
+    let ref_idx_w = ReferenceIndex::new_loaded(
+        "weighted".to_string(),
+        ref_store_w,
+        None,
         weight,
-        db_path: std::path::PathBuf::new(),
-        loaded_identity: None,
-    };
-    let ref_idx_u = ReferenceIndex {
-        name: "unweighted".to_string(),
-        store: ref_store_u,
-        index: None,
+        std::path::PathBuf::new(),
+    );
+    let ref_idx_u = ReferenceIndex::new_loaded(
+        "unweighted".to_string(),
+        ref_store_u,
+        None,
         weight,
-        db_path: std::path::PathBuf::new(),
-        loaded_identity: None,
-    };
+        std::path::PathBuf::new(),
+    );
 
     let query = mock_embedding(1.0);
     let filter = SearchFilter::default();
@@ -331,14 +325,13 @@ fn test_search_reference_by_name_unweighted() {
     insert_chunks(&store, &[c1], 1.0);
 
     let ref_store = cqs::Store::open_readonly(&store.db_path()).unwrap();
-    let ref_idx = ReferenceIndex {
-        name: "test-ref".to_string(),
-        store: ref_store,
-        index: None,
-        weight: 0.5,
-        db_path: std::path::PathBuf::new(),
-        loaded_identity: None,
-    };
+    let ref_idx = ReferenceIndex::new_loaded(
+        "test-ref".to_string(),
+        ref_store,
+        None,
+        0.5,
+        std::path::PathBuf::new(),
+    );
 
     let results =
         reference::search_reference_by_name(&ref_idx, "name_search_fn", 10, 0.0, false).unwrap();
@@ -361,14 +354,13 @@ fn test_search_reference_by_name_unweighted_threshold() {
     insert_chunks(&store, &[c1], 1.0);
 
     let ref_store = cqs::Store::open_readonly(&store.db_path()).unwrap();
-    let ref_idx = ReferenceIndex {
-        name: "test-ref".to_string(),
-        store: ref_store,
-        index: None,
-        weight: 0.5,
-        db_path: std::path::PathBuf::new(),
-        loaded_identity: None,
-    };
+    let ref_idx = ReferenceIndex::new_loaded(
+        "test-ref".to_string(),
+        ref_store,
+        None,
+        0.5,
+        std::path::PathBuf::new(),
+    );
 
     // Very high threshold should filter everything
     let results =

--- a/tests/search_test.rs
+++ b/tests/search_test.rs
@@ -762,14 +762,13 @@ fn test_search_reference_by_name() {
 
     // Create a reference index (open separate Store to same DB)
     let ref_store = cqs::Store::open_readonly(&store.db_path()).unwrap();
-    let ref_idx = ReferenceIndex {
-        name: "test-ref".to_string(),
-        store: ref_store,
-        index: None,
-        weight: 0.8,
-        db_path: std::path::PathBuf::new(),
-        loaded_identity: None,
-    };
+    let ref_idx = ReferenceIndex::new_loaded(
+        "test-ref".to_string(),
+        ref_store,
+        None,
+        0.8,
+        std::path::PathBuf::new(),
+    );
 
     // Search by name
     let results =
@@ -795,14 +794,13 @@ fn test_search_reference_by_name_threshold() {
     insert_chunks(&store, &[c1], 1.0);
 
     let ref_store = cqs::Store::open_readonly(&store.db_path()).unwrap();
-    let ref_idx = ReferenceIndex {
-        name: "test-ref".to_string(),
-        store: ref_store,
-        index: None,
-        weight: 0.5, // Low weight
-        db_path: std::path::PathBuf::new(),
-        loaded_identity: None,
-    };
+    let ref_idx = ReferenceIndex::new_loaded(
+        "test-ref".to_string(),
+        ref_store,
+        None,
+        0.5,
+        std::path::PathBuf::new(),
+    );
 
     // High threshold should filter out results (score * weight < threshold)
     let results =


### PR DESCRIPTION
Closes #1909.

## What

Centralizes cqs's `index.db` file-freshness key so all three long-lived readers use the same hardened discriminators. #1909 named one site; there were **three** — and two never received the primary's hardening (`+inode +data_version`). This is the incomplete-sweep-of-the-hardening class, closed by construction.

## The shared type

New `src/store/helpers/file_identity.rs`:
- **`FileIdentity`** = `(dev, inode, size, mtime)` on unix (`(size, mtime)` off-unix).
- **`DataVersionProbe`** = a long-lived `PRAGMA data_version` connection, runtime passed as a parameter (decoupled from `BatchContext`).

Re-exported at `cqs::store::{FileIdentity, DataVersionProbe}`.

## Sites adopted

- **Primary** (`src/cli/batch/`): `DbFileIdentity` is now a `use cqs::store::FileIdentity as DbFileIdentity` **alias** — literally single-source, not a copy. The probe plumbing delegates to the shared probe. Behavior-preserving (all batch tests pass, incl. the pre-existing WAL/probe/rename staleness tests).
- **cross_project** (`src/store/calls/cross_project.rs`): dropped its `(SystemTime, u64)` `stat_identity`; adopted `FileIdentity` + a per-store `DataVersionProbe`. `is_stale` folds all probes (no short-circuit) so every baseline advances.
- **references LRU** (`src/reference.rs`): dropped its `(SystemTime, u64)` `stat_identity`; adopted `FileIdentity` + an interior-mutable probe (`is_stale(&self)` is called on `Arc<ReferenceIndex>` across daemon threads). Freshness-key fields are now **private**, constructible only via `ReferenceIndex::new_loaded` — which forced 12 ad-hoc struct literals through the canonical path.

## data_version parity: achieved for both siblings (no residual)

`cqs ref update` reindexes a reference's `index.db` **in place** (incremental pipeline, not rename-over), so the WAL-incremental window is the *primary* real case for references, not an edge. Each sibling holds its own dedicated long-lived probe connection (driven by the store's runtime). No connection-model restructuring required, so full parity was reached in-lane.

## Guards (calibrated)

Per sibling, two tests + a sweep guard:
- **same-size rename-over** (new inode, mtime forced equal, size unchanged): RED against the stubbed key, GREEN with `FileIdentity` alone — pins the inode-catchable replace case.
- **WAL commit without checkpoint** (identity asserted unchanged): RED against `FileIdentity`-only, GREEN only with the data_version probe — pins the WAL-incremental case.
- **sweep guard**: source-text enumeration over the three reader files — each must mention `FileIdentity`, none may contain the bare `(SystemTime, u64)` tuple key. Calibrated RED by injecting the forbidden tuple.

## Review / gates

`code-reviewer` (opus): APPROVE, zero P1/P2 (one P3 folded — broadened a now-understated LRU eviction log line). `fmt` / `clippy --all-targets` / targeted tests / provenance lint all clean. No global-state change → no full `--tests` sweep required.
