### PR TITLE
fix(#1911): close chunk-id non-injectivity (markdown table collision + re-id suffix) — PARSER_VERSION 8 to 9

### DIFF
--- a/src/cli/pipeline/parsing.rs
+++ b/src/cli/pipeline/parsing.rs
@@ -308,6 +308,12 @@ pub(super) fn parser_stage(
                             // Rewrite paths to be relative for storage
                             // Normalize path separators to forward slashes for cross-platform consistency
                             let path_str = normalize_path(rel_path);
+                            // The path display string the extract-time sites
+                            // (`extract_chunk`, the markdown parser) folded into
+                            // each chunk's id. `chunk.id` was built from THIS
+                            // path; `new_id` rebuilds from the normalized
+                            // relative `path_str`.
+                            let abs_path_display = abs_path.display().to_string();
                             // Build a map of old IDs -> new IDs for parent_id fixup.
                             // MUST reconstruct via the same `chunk_id` helper the
                             // extract-time site used, including `byte_start`, or the
@@ -315,15 +321,38 @@ pub(super) fn parser_stage(
                             // injective within a file (same-line byte-identical
                             // chunks no longer collide), so this map no longer
                             // collapses distinct chunks onto one entry.
+                            //
+                            // Suffix preservation: some chunks carry a structural
+                            // suffix appended after the 4-field base (markdown
+                            // table chunks `:t{idx}`, table windows `:t{idx}w{widx}`
+                            // — see `chunk_id_suffixed`). The base reconstruction
+                            // alone would drop that suffix, sending a suffixed
+                            // `chunk.id` to a suffix-less `new_id`: non-injective
+                            // (distinct table windows collapse onto one id) and the
+                            // remapped id no longer matches the stored chunk. So we
+                            // recover the suffix by stripping the extract-time base
+                            // (rebuilt from the same absolute path) off `chunk.id`,
+                            // then re-append it to the new base. Path-safe even when
+                            // the path contains colons (the base prefix is matched
+                            // whole, not by colon-splitting).
                             let id_map: std::collections::HashMap<String, String> = chunks
                                 .iter()
                                 .map(|chunk| {
-                                    let new_id = cqs::parser::chunk_id(
+                                    let new_base = cqs::parser::chunk_id(
                                         &path_str,
                                         chunk.line_start,
                                         chunk.byte_start,
                                         &chunk.content_hash,
                                     );
+                                    let old_base = cqs::parser::chunk_id(
+                                        &abs_path_display,
+                                        chunk.line_start,
+                                        chunk.byte_start,
+                                        &chunk.content_hash,
+                                    );
+                                    let suffix =
+                                        chunk.id.strip_prefix(&old_base).unwrap_or("");
+                                    let new_id = format!("{new_base}{suffix}");
                                     (chunk.id.clone(), new_id)
                                 })
                                 .collect();
@@ -334,7 +363,12 @@ pub(super) fn parser_stage(
                             //   - new ids collide -> distinct chunks UPSERT onto
                             //     one `chunks.id` PRIMARY KEY row -> fewer distinct
                             //     values than keys.
-                            // Check both against `chunks.len()`.
+                            // The new-id check reads the values ACTUALLY assigned
+                            // to `chunk.id` below (suffix included), not bare base
+                            // ids — a base-only check would pass even when two
+                            // table windows differ solely by their dropped suffix.
+                            // The keys are the stored `chunk.id`s (suffix
+                            // included), so the old-id check sees the real ids too.
                             #[cfg(debug_assertions)]
                             {
                                 let distinct_new: std::collections::HashSet<&String> =
@@ -930,6 +964,128 @@ mod tests {
             rels_seen <= 1,
             "relationships should ride with at most one batch, saw {rels_seen}"
         );
+    }
+
+    /// Re-id must preserve a chunk's structural id suffix end-to-end.
+    ///
+    /// Table windows (and the markdown table chunk) carry a `:t{idx}w{widx}`
+    /// suffix appended AFTER the four-field base by `chunk_id_suffixed`. The
+    /// re-id remap rebuilds each chunk's id from its persisted coordinates
+    /// (path absolute→relative); a base-only reconstruction drops the suffix,
+    /// so the suffixed extract-time `chunk.id` would be rewritten to a
+    /// suffix-LESS id — diverging from the parser-native form. The store would
+    /// then hold an id no fresh `parse_file` can reproduce, so an incremental
+    /// re-index churns the row, and parent_id resolution across the windows of
+    /// one table goes ambiguous. This drives a no-heading markdown file that is
+    /// one LARGE table (forcing row-wise windowing) through the full
+    /// `parser_stage` and asserts every stored window id still ends in its
+    /// `:t0w{idx}` suffix and equals the suffix-aware re-id form.
+    #[test]
+    fn parser_stage_preserves_table_window_id_suffix_through_reid() {
+        let _lock = super::super::types::TEST_ENV_MUTEX
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+
+        // A no-heading file that is EXACTLY one table, wide+long enough to
+        // exceed MAX_TABLE_CHARS (1500) so the table is split row-wise into
+        // multiple windows. No trailing newline (also stresses the #1911 P1
+        // whole-file/table base collision: the whole-file chunk and the table
+        // share the (1, 0) start coords).
+        let mut md = String::new();
+        md.push_str("| Column A | Column B | Column C | Column D | Column E |\n");
+        md.push_str("|----------|----------|----------|----------|----------|\n");
+        for i in 0..60 {
+            use std::fmt::Write as _;
+            writeln!(
+                &mut md,
+                "| value_{i}_aaaa | value_{i}_bbbb | value_{i}_cccc | value_{i}_dddd | value_{i}_eeee |"
+            )
+            .unwrap();
+        }
+        while md.ends_with('\n') {
+            md.pop();
+        }
+        let rel = PathBuf::from("only_table.md");
+        std::fs::write(root.join(&rel), &md).unwrap();
+
+        let db_path = root.join("index.db");
+        let store = Arc::new(Store::open(&db_path).unwrap());
+        store.init(&cqs::store::ModelInfo::default()).unwrap();
+        let parser = Arc::new(CqParser::new().unwrap());
+
+        let (tx, rx) = unbounded::<ParsedBatch>();
+        let ctx = ParserStageContext {
+            root: root.clone(),
+            force: true,
+            parser: Arc::clone(&parser),
+            store: Arc::clone(&store),
+            parsed_count: Arc::new(AtomicUsize::new(0)),
+            parse_errors: Arc::new(AtomicUsize::new(0)),
+            model_config: cqs::embedder::ModelConfig::resolve(None, None),
+        };
+        parser_stage(vec![rel.clone()], ctx, tx).unwrap();
+
+        let chunks: Vec<cqs::Chunk> = rx.try_iter().flat_map(|b| b.chunks).collect();
+        assert!(!chunks.is_empty(), "parser_stage produced no chunks");
+
+        // Every stored id is injective within the file.
+        let mut ids: HashSet<&str> = HashSet::new();
+        for c in &chunks {
+            assert!(
+                ids.insert(c.id.as_str()),
+                "stored chunk id collision after re-id: {} (name={:?})",
+                c.id,
+                c.name,
+            );
+        }
+
+        // The table windowed: at least two window chunks exist (window_idx set).
+        let windows: Vec<&cqs::Chunk> = chunks.iter().filter(|c| c.window_idx.is_some()).collect();
+        assert!(
+            windows.len() >= 2,
+            "fixture must produce >=2 table windows, got {} (chunks: {:?})",
+            windows.len(),
+            chunks.iter().map(|c| c.id.as_str()).collect::<Vec<_>>(),
+        );
+
+        // Each window's stored id must STILL carry its `:t{idx}w{widx}` suffix
+        // and equal the suffix-aware re-id reconstruction from the normalized
+        // relative path. A base-only re-id (the bug) drops the `:t…w…` tail.
+        let path_str = normalize_path(&rel);
+        for w in &windows {
+            let widx = w.window_idx.unwrap();
+            let expected = cqs::parser::chunk_id_suffixed(
+                &path_str,
+                w.line_start,
+                w.byte_start,
+                &w.content_hash,
+                &format!("t0w{widx}"),
+            );
+            assert_eq!(
+                w.id, expected,
+                "table window id lost its suffix through re-id: stored {} vs expected {}",
+                w.id, expected,
+            );
+            assert!(
+                w.id.contains(":t0w"),
+                "table window id must retain its :t{{idx}}w{{widx}} suffix: {}",
+                w.id,
+            );
+        }
+
+        // parent_id of every window resolves to exactly one chunk (the section).
+        for w in &windows {
+            if let Some(pid) = &w.parent_id {
+                let matches = chunks.iter().filter(|o| &o.id == pid).count();
+                assert!(
+                    matches <= 1,
+                    "window parent_id {pid} resolves to {matches} chunks — ambiguous",
+                );
+            }
+        }
     }
 
     /// Incremental (`force=false`) runs must parse ONLY files whose disk

--- a/src/cli/pipeline/windowing.rs
+++ b/src/cli/pipeline/windowing.rs
@@ -66,6 +66,17 @@ pub(crate) fn apply_windowing(chunks: Vec<Chunk>, embedder: &Embedder) -> Vec<Ch
                     // boundaries anyway, so tree-precision buys nothing here.
                     let window_canonical = cqs::canonical_hash_fallback(&window_content);
                     result.push(Chunk {
+                        // Code windows are split at the embedding stage, AFTER
+                        // the re-id step has rewritten `parent_id` to its final
+                        // (normalized-path) form. `parent_id` is already the
+                        // canonical base, so the window id is base + `:w{idx}`.
+                        // Unlike the table-window suffix, this id is never
+                        // reconstructed by a re-id remap, so it appends to the
+                        // existing base rather than rebuilding via
+                        // `chunk_id_suffixed`: rebuilding would have to use
+                        // `chunk.file` (the raw rel-path), which can diverge
+                        // from the normalized path baked into `parent_id` on
+                        // platforms with backslash separators.
                         id: format!("{}:w{}", parent_id, window_idx),
                         file: chunk.file.clone(),
                         language: chunk.language,

--- a/src/parser/chunk.rs
+++ b/src/parser/chunk.rs
@@ -18,8 +18,16 @@ use super::Parser;
 /// source bytes are identical to a previously-indexed version. The
 /// store-side UPSERT clause must include
 /// `OR chunks.parser_version != excluded.parser_version` so the bump
-/// triggers a refresh.
-pub const PARSER_VERSION: u32 = 8;
+/// triggers a refresh. The `id` IS such a field: a change to its format for
+/// any chunk class (e.g. the markdown table-chunk `:t{idx}` disambiguator)
+/// alters the stored id for byte-identical source, so it requires a bump —
+/// without one, a fingerprint-unchanged file is never re-parsed and keeps the
+/// old-format (potentially colliding) id until its bytes next change.
+///
+/// 9: markdown table chunks gained a `:t{idx}` id suffix
+/// (`chunk_id_suffixed`) so a top-of-file table no longer collides with the
+/// whole-file/section chunk that shares its `(line_start, byte_start, hash)`.
+pub const PARSER_VERSION: u32 = 9;
 
 /// Build the canonical chunk id from its identifying coordinates.
 ///
@@ -49,6 +57,43 @@ pub fn chunk_id(
 ) -> String {
     let hash_prefix = content_hash.get(..8).unwrap_or(content_hash);
     format!("{path_display}:{line_start}:{byte_start}:{hash_prefix}")
+}
+
+/// Build a chunk id carrying a structural disambiguator suffix appended to the
+/// canonical [`chunk_id`] base.
+///
+/// Some chunks legitimately share all four base coordinates
+/// (`path`/`line_start`/`byte_start`/`hash8`) with another chunk of the same
+/// file, so the base alone is NOT injective for them. Two cases:
+///
+/// - **Sub-chunks at a parent's start offset.** A markdown table that begins on
+///   its containing section's first line shares the section's `line_start` and
+///   `byte_start`; when the section is *exactly* that table with no trailing
+///   newline the `content_hash` matches too — all four base fields collide.
+///   The table is the `idx`-th table of its section, so a `t{idx}` suffix
+///   separates it from the section and from sibling tables.
+/// - **Windows of one chunk.** Row-wise table windows and token-window code
+///   chunks all inherit their parent's `line_start`/`byte_start`; the window
+///   ordinal is the disambiguator (`t{idx}w{widx}` for table windows, `w{idx}`
+///   for code windows).
+///
+/// Single-sourcing the suffix here (rather than `format!("{base}:…")` at each
+/// emission site) is load-bearing for re-id: the indexing pipeline's re-id step
+/// reconstructs each chunk's id from its persisted coordinates, and the stored
+/// `Chunk::id` carries the suffix. Reconstructing the base only (the bug this
+/// closes) drops the suffix, so the re-id `old_id → new_id` map sends a
+/// suffixed id to a suffix-less one — non-injective, and distinct windows
+/// collapse onto one id. The pipeline calls this function with the SAME suffix
+/// the emission site used, so extract-time and re-id ids match byte-for-byte.
+pub fn chunk_id_suffixed(
+    path_display: &str,
+    line_start: u32,
+    byte_start: u32,
+    content_hash: &str,
+    suffix: &str,
+) -> String {
+    let base = chunk_id(path_display, line_start, byte_start, content_hash);
+    format!("{base}:{suffix}")
 }
 
 /// Collapse every run of ASCII/Unicode whitespace in `s` to a single space,

--- a/src/parser/markdown/tables.rs
+++ b/src/parser/markdown/tables.rs
@@ -91,11 +91,19 @@ pub(super) fn extract_table_chunks(ctx: &TableContext<'_>, chunks: &mut Vec<Chun
 
         if table_content.len() <= MAX_TABLE_CHARS {
             let table_hash = blake3::hash(table_content.as_bytes()).to_hex().to_string();
-            let table_id = super::super::chunk::chunk_id(
+            // A table that begins on its section's first line shares the
+            // section's `line_start` AND `byte_start`; when the section is
+            // exactly that table with no trailing newline the `content_hash`
+            // matches too, so the base id collides with the section's. The
+            // `t{idx}` suffix is the disambiguator (the table is the idx-th of
+            // its section). Routed through `chunk_id_suffixed` so the re-id step
+            // reconstructs the same suffixed id.
+            let table_id = super::super::chunk::chunk_id_suffixed(
                 &ctx.path.display().to_string(),
                 table_line_start,
                 table_byte_start,
                 &table_hash,
+                &format!("t{table_idx}"),
             );
             chunks.push(Chunk {
                 id: table_id,
@@ -168,16 +176,19 @@ fn emit_table_window(
     content.push('\n');
     content.push_str(&rows.join("\n"));
     let whash = blake3::hash(content.as_bytes()).to_hex().to_string();
-    // Injective base (`chunk_id`) plus a `:t{idx}w{widx}` suffix that
+    // Injective base (`chunk_id`) plus a `t{idx}w{widx}` suffix that
     // disambiguates the row-wise windows of one table (which share line_start +
-    // byte_start). Multiple tables in a section get distinct base byte_starts.
-    let base = super::super::chunk::chunk_id(
+    // byte_start with each other and with the parent section). Routed through
+    // `chunk_id_suffixed` so the re-id step reconstructs the same suffixed id;
+    // a bare `format!` here would leave the suffix outside the single-source
+    // constructor and the re-id remap would drop it.
+    let wid = super::super::chunk::chunk_id_suffixed(
         &ctx.path.display().to_string(),
         ctx.line_start,
         ctx.byte_start,
         &whash,
+        &format!("t{}w{}", ctx.table_idx, window_idx),
     );
-    let wid = format!("{}:t{}w{}", base, ctx.table_idx, window_idx);
     chunks.push(Chunk {
         id: wid,
         file: ctx.path.to_path_buf(),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -16,7 +16,7 @@ pub mod l5x;
 pub mod markdown;
 pub mod types;
 
-pub use chunk::{canonical_hash_fallback, chunk_id, collapse_whitespace};
+pub use chunk::{canonical_hash_fallback, chunk_id, chunk_id_suffixed, collapse_whitespace};
 
 /// The current parser-logic version stamped onto every chunk this build
 /// extracts (`chunk::PARSER_VERSION`). Re-exported so the binary crate's

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -32,7 +32,11 @@ pub enum ParserError {
 #[derive(Debug, Clone)]
 pub struct Chunk {
     /// Unique identifier: `{file}:{line_start}:{byte_start}:{hash8}` (see
-    /// `parser::chunk::chunk_id`) or `{parent_id}:w{window_idx}` for windows.
+    /// `parser::chunk::chunk_id`), with a structural suffix for chunks that
+    /// legitimately share those base coordinates with a sibling (see
+    /// `parser::chunk::chunk_id_suffixed`): `…:t{idx}` for a markdown table,
+    /// `…:t{idx}w{widx}` for a table window, and `{parent_id}:w{window_idx}` for
+    /// a token-window code chunk.
     pub id: String,
     /// Source file path (typically absolute during indexing, stored as provided)
     pub file: PathBuf,

--- a/tests/proptest_reid_injectivity.proptest-regressions
+++ b/tests/proptest_reid_injectivity.proptest-regressions
@@ -6,3 +6,4 @@
 # everyone who runs the test benefits from these saved cases.
 cc f5f3e20b1249c22cc3752a77d0fbf149beaf980b795c78f37b656398bbba2b2b # shrinks to line_start = 0, hash = "aaaa00a0", b1 = 0, b2 = 1
 cc f613395f7c1dd9dbe26e397a56fcd34be4e12792c8f46bf9a885f905a77a27cc # shrinks to coords = [ChunkCoord { line_start: 2, byte_start: 0, content_hash: "bbbbbbbb" }, ChunkCoord { line_start: 2, byte_start: 1, content_hash: "bbbbbbbb" }]
+cc 8848b74fc5c47cd7c905a44f72ef69c1fedb32556cd3fe757ed18e5fa7cb49ce # shrinks to doc = "| h0 | h1 |\n| --- | --- |\n| r0c0 | r0c1 |"

--- a/tests/proptest_reid_injectivity.rs
+++ b/tests/proptest_reid_injectivity.rs
@@ -135,6 +135,149 @@ proptest! {
     }
 }
 
+// ── Real-parser injectivity over the MARKDOWN path ──────────────────────────
+//
+// The `chunk_coords` property above asserts injectivity over the *arithmetic*
+// of `chunk_id`, but its generator DEDUPS by `byte_start` (`coords.retain` on a
+// `seen` set) — it bakes in the assumption "no two distinct chunks of a file
+// share a start offset." That assumption is FALSE on the markdown path: a
+// no-heading (or single-heading) file emits a whole-file/section chunk at
+// `byte_start = 0, line_start = 1`, and `extract_table_chunks` then emits a
+// table chunk for a table that begins at byte 0 — SAME `byte_start`, SAME
+// `line_start`. The byte_start disambiguator collapses, and when the file is
+// *exactly* one table with no trailing newline the whole-file `content_hash`
+// also equals the table `content_hash` (the only textual difference is the
+// trailing `\n` the whole-file chunk would otherwise carry). All four base id
+// fields collide → two distinct chunks shared an id. The fix appends a `:t{idx}`
+// suffix to every table chunk (`chunk_id_suffixed`), so the table id sits below
+// the section id even when all four base fields match.
+//
+// The example suite cannot express this: it requires the precise combination
+// {no heading} × {file IS exactly one table} × {no trailing newline}, and the
+// arithmetic property's generator structurally excludes equal byte_starts.
+//
+// This property runs the REAL markdown parser over generated table-bearing
+// documents and asserts whole-file id injectivity (every chunk a distinct id).
+
+/// Generate markdown documents that stress the section/table byte_start overlap:
+/// a (possibly absent) leading heading, then a table, optionally followed by a
+/// trailing newline. Coverage claim: spans {0 heading, 1 heading} × {table at
+/// byte 0, table after a heading} × {trailing newline present/absent} × varying
+/// table widths and a leading-blank-line option — i.e. it deliberately VISITS
+/// the {no-heading} × {table-at-byte-0} × {no-trailing-newline} corner the
+/// arithmetic generator's byte_start-dedup can never reach.
+///
+/// DISTRUST: a generator that always appended a trailing `\n` would make the
+/// whole-file/table content hashes differ and hide the collision; the
+/// `trailing_nl: bool` dimension is the load-bearing axis, so it is sampled,
+/// not fixed.
+fn markdown_with_table() -> impl Strategy<Value = String> {
+    (
+        prop::option::of("[A-Za-z]{1,6}"), // optional leading heading text
+        2usize..4,                         // table column count (>=2: detector needs pipes)
+        1usize..4,                         // table data-row count
+        any::<bool>(),                     // trailing newline?
+        any::<bool>(),                     // blank line between heading and table?
+    )
+        .prop_map(|(heading, cols, rows, trailing_nl, blank)| {
+            let mut s = String::new();
+            if let Some(h) = heading {
+                s.push_str(&format!("# {h}\n"));
+                if blank {
+                    s.push('\n');
+                }
+            }
+            // Header row + separator + data rows.
+            let header: String = (0..cols).map(|c| format!(" h{c} |")).collect();
+            s.push('|');
+            s.push_str(&header);
+            s.push('\n');
+            let sep: String = (0..cols).map(|_| " --- |").collect();
+            s.push('|');
+            s.push_str(&sep);
+            s.push('\n');
+            for r in 0..rows {
+                let row: String = (0..cols).map(|c| format!(" r{r}c{c} |")).collect();
+                s.push('|');
+                s.push_str(&row);
+                s.push('\n');
+            }
+            if !trailing_nl {
+                // Drop the final newline we just appended.
+                while s.ends_with('\n') {
+                    s.pop();
+                }
+            }
+            s
+        })
+}
+
+proptest! {
+    /// REAL-PARSER INJECTIVITY (markdown): every chunk emitted for a single
+    /// markdown file must have a distinct id. The whole-file/section chunk and
+    /// a table chunk that begins at the same byte must not collide.
+    ///
+    /// Was a production bug: a no-heading file that is exactly one table with no
+    /// trailing newline yielded a whole-file chunk and a table chunk with
+    /// identical `{path}:1:0:{hash8}` ids (and the table's `parent_id` pointed
+    /// at itself), so the downstream `chunks.id` PRIMARY KEY UPSERT silently
+    /// overwrote one of the two distinct chunks. The fix salts the table id with
+    /// a `:t{idx}` suffix via `chunk_id_suffixed`. proptest shrinks straight to
+    /// the minimal table, so it re-verifies the fix. Minimal case pinned below.
+    #[test]
+    fn markdown_chunk_ids_injective_within_file(doc in markdown_with_table()) {
+        let file = write_temp(&doc, "md");
+        let parser = Parser::new().expect("init parser");
+        let chunks = parser.parse_file(file.path()).expect("parse");
+
+        let mut seen: HashSet<&str> = HashSet::with_capacity(chunks.len());
+        for c in &chunks {
+            prop_assert!(
+                seen.insert(c.id.as_str()),
+                "markdown id collision: {} reused by a second distinct chunk \
+                 (name={:?}, byte_start={}, parent_id={:?}); source:\n{}",
+                c.id, c.name, c.byte_start, c.parent_id, doc,
+            );
+        }
+    }
+}
+
+/// Minimal falsifier pin (production bug, not a too-strong property): a
+/// no-heading markdown file that is EXACTLY one table with no trailing newline
+/// emits a whole-file chunk and a table chunk with the SAME id. Both have
+/// `line_start = 1`, `byte_start = 0`, and — because the only textual
+/// difference would have been the trailing `\n` — the same `content_hash`. The
+/// table chunk's `parent_id` then points at its own id.
+///
+/// The fix salts the table id with a `:t{idx}` suffix (`chunk_id_suffixed`), so
+/// the whole-file section chunk (`{path}:1:0:{hash8}`) and the table chunk
+/// (`{path}:1:0:{hash8}:t0`) no longer collide.
+#[test]
+fn markdown_whole_file_table_no_trailing_newline_ids_injective() {
+    // Exactly one 2-col table, no heading, NO trailing newline.
+    let src = "| a | b |\n|---|---|\n| 1 | 2 |";
+    let file = write_temp(src, "md");
+    let parser = Parser::new().expect("init parser");
+    let chunks = parser.parse_file(file.path()).expect("parse");
+
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut dup: Option<(String, String, String)> = None;
+    for c in &chunks {
+        if !seen.insert(c.id.clone()) {
+            dup = Some((c.id.clone(), c.name.clone(), format!("{:?}", c.parent_id)));
+        }
+    }
+    assert!(
+        dup.is_none(),
+        "whole-file chunk and table chunk share an id (injectivity violated): {dup:?}; \
+         chunks = {:?}",
+        chunks
+            .iter()
+            .map(|c| (c.id.as_str(), c.name.as_str()))
+            .collect::<Vec<_>>(),
+    );
+}
+
 // ── Real-parser pins (falsifier reproductions) ──────────────────────────────
 //
 // These are the concrete inputs the property generalizes. They run the REAL


### PR DESCRIPTION
Closes #1911. The chunk-id half of the key-design class (freshness half = #1909).

Closes chunk-id non-injectivity:
- **P1:** the markdown whole-file/section chunk and a top-of-file table chunk both legitimately sit at `(line 1, byte 0)` — when a file IS one table with no heading and no trailing newline, `blake3(file) == blake3(table)` → identical chunk_id → silent UPSERT data loss.
- **P3 (sibling):** window/table-window suffixes were appended OUTSIDE `chunk_id()`, so the re-id remap reconstructed suffix-less ids (non-injective under re-id) and the injectivity debug-assert was blind to it.

## Fix (narrow — only the table-chunk id format changes)

- New single-source `chunk_id_suffixed` (`src/parser/chunk.rs`); markdown **table chunks** gain a `:t{idx}` structural suffix → distinct from the whole-file chunk. `chunk_id` is unchanged for whole-file / heading / code chunks.
- Table + table-window suffixes now route THROUGH the constructor (window output byte-identical to before). Code windows kept as a documented exception (they split post-re-id from a final `parent_id`; routing them through the constructor would re-derive a divergent path).
- Re-id remap (`src/cli/pipeline/parsing.rs`) recovers each chunk's suffix (strip old abs-path base, re-append the new rel-path base) so extract-time and re-id ids match byte-for-byte; the injectivity assert now reads the suffix-carrying reconstructed ids — no longer blind.

## PARSER_VERSION 8 → 9 (reindex required on land)

The table-chunk id format changed for byte-identical source. Leaving the version at 8 would leave the live P1 collision un-healed on existing indexes (a fingerprint-unchanged file is never re-parsed). The bump forces a one-time re-parse; the phantom-chunk sweep then heals old ids. **After merge: `cqs index --force`** (the orchestrator does this in the batch reindex + binary reinstall). CI unaffected (fresh fixtures). Full `--tests` sweep run (global-state change): **4609 passed, 0 failed**.

## Guards (calibrated red-without/green-with)

- `tests/proptest_reid_injectivity.rs` — markdown real-parser injectivity proptest + pinned P1 seed (`markdown_whole_file_table_no_trailing_newline_ids_injective`): RED reproduces the `:1:0:hash8` collision, GREEN with the suffix.
- `parser_stage_preserves_table_window_id_suffix_through_reid` — drives a no-heading large-table file through `parser_stage`; RED (suffix dropped) without the re-id recovery, GREEN with.

## Review / gates

code-reviewer (opus): concurred on the PARSER_VERSION bump. `clippy --all-targets` / `fmt` / provenance clean.

Follow-up (filed separately): a legacy-state guard for the v8→v9 old-bytes→new-code migration path.
