### PR TITLE
feat(candidate-edges) L1: candidate_edges side-table foundation (schema 31->32)

### DIFF
--- a/src/cli/pipeline/upsert.rs
+++ b/src/cli/pipeline/upsert.rs
@@ -228,6 +228,9 @@ pub(super) fn store_stage(
             origin.as_path(),
             &live_refs,
             function_calls,
+            // v32 candidate_edges: empty until a later parser-emit lane produces
+            // candidate sites. An empty slice clears the file's candidates.
+            &[],
             fp,
         ) {
             Ok(_) => {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -26,8 +26,8 @@ pub fn parser_version() -> u32 {
     chunk::PARSER_VERSION
 }
 pub use types::{
-    CallEdgeKind, CallSite, Chunk, ChunkType, ChunkTypeRefs, FieldStyle, FunctionCalls, Language,
-    ParserError, SignatureStyle, TypeEdgeKind, TypeRef,
+    CallEdgeKind, CallSite, CandidateSite, Chunk, ChunkType, ChunkTypeRefs, FieldStyle,
+    FunctionCalls, Language, ParserError, SignatureStyle, TypeEdgeKind, TypeRef,
 };
 
 use once_cell::sync::OnceCell;

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -308,6 +308,28 @@ pub struct FunctionCalls {
     pub calls: Vec<CallSite>,
 }
 
+/// A low-confidence call-graph candidate extracted from code.
+///
+/// Sibling of [`CallSite`], carried in a SEPARATE collection alongside
+/// `Vec<CallSite>` so it can never be folded into the `function_calls` table.
+/// Candidates land in the `candidate_edges` side-table (callee-name-keyed,
+/// never joined by callers/callees/impact), so a candidate is invisible to the
+/// caller graph by construction — it cannot become a false caller, and it
+/// cannot move a callee into the wrong dead tier the way a new
+/// [`CallEdgeKind`] variant would (that enum's `is_real_caller` is the
+/// complement of `doc_reference`, so any new kind defaults to "real caller").
+#[derive(Debug, Clone)]
+pub struct CandidateSite {
+    /// Source file the candidate reference lives in.
+    pub file: PathBuf,
+    /// Name of the symbol the candidate points at.
+    pub callee_name: String,
+    /// Line number of the reference (1-indexed).
+    pub ref_line: u32,
+    /// Candidate provenance string (the kind of low-confidence reference).
+    pub candidate_kind: String,
+}
+
 /// Classification of how a type is referenced in code.
 /// Used for type-level dependency tracking.
 /// Stored as string in SQLite `type_edges.edge_kind` column.

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -1,4 +1,10 @@
--- cq index schema v31 (see src/store/helpers/mod.rs::CURRENT_SCHEMA_VERSION; v22+v23+v24+v25+v26+v27+v28+v29+v30+v31 columns annotated inline below)
+-- cq index schema v32 (see src/store/helpers/mod.rs::CURRENT_SCHEMA_VERSION; v22+v23+v24+v25+v26+v27+v28+v29+v30+v31+v32 columns annotated inline below)
+-- v32: candidate_edges side-table (file, callee_name, ref_line, candidate_kind)
+--      for low-confidence call-graph candidates that must NOT surface as
+--      callers. SEPARATE table, not a function_calls.edge_kind value — the graph
+--      queries SELECT every function_calls row for a callee with no kind
+--      exclusion, so a candidate stored there reads as a false caller. Empty on
+--      migrate; populated by a later parser-emit pass.
 -- v31: file_registry.parse_failed_parser_version INTEGER (nullable) — drift
 --      loop-breaker. A version-drifted file that cannot parse records the
 --      parser version it failed at; origins_with_parser_drift excludes origins
@@ -174,6 +180,23 @@ CREATE TABLE IF NOT EXISTS function_calls (
 CREATE INDEX IF NOT EXISTS idx_fcalls_file ON function_calls(file);
 CREATE INDEX IF NOT EXISTS idx_fcalls_caller ON function_calls(caller_name);
 CREATE INDEX IF NOT EXISTS idx_fcalls_callee ON function_calls(callee_name);
+
+-- v32: low-confidence call-graph candidates that must NOT surface as callers.
+-- Deliberately a SEPARATE table, not a function_calls.edge_kind value: the
+-- callers/callees/impact queries SELECT every function_calls row for a callee
+-- with no kind exclusion, so a candidate stored there would read as a false
+-- caller, and CallEdgeKind::is_real_caller (the complement of doc_reference)
+-- would put the callee in the wrong dead tier. This table is callee-name-keyed
+-- and is never joined by a graph query, so a candidate is invisible to the
+-- caller graph by construction. Empty until a parser-emit pass populates it.
+CREATE TABLE IF NOT EXISTS candidate_edges (
+    file TEXT NOT NULL,            -- source file path the candidate reference lives in
+    callee_name TEXT NOT NULL,     -- symbol the candidate points at
+    ref_line INTEGER NOT NULL,     -- 1-indexed line of the reference
+    candidate_kind TEXT NOT NULL   -- candidate provenance string
+);
+CREATE INDEX IF NOT EXISTS idx_candidate_edges_callee ON candidate_edges(callee_name);
+CREATE INDEX IF NOT EXISTS idx_candidate_edges_file ON candidate_edges(file);
 
 -- Type dependency edges: which chunks reference which types (Phase 2b)
 -- Source is chunk-level for precise dependency tracking.

--- a/src/store/calls/crud.rs
+++ b/src/store/calls/crud.rs
@@ -74,6 +74,54 @@ pub(crate) async fn write_function_calls_in_tx(
     Ok(())
 }
 
+/// Shared in-tx helper for writing the file-level `candidate_edges` side-table.
+///
+/// Sibling of [`write_function_calls_in_tx`]. `candidate_edges` holds
+/// low-confidence call-graph candidates that must NOT surface as callers; it is
+/// a SEPARATE table (never a `function_calls.edge_kind` value) and is never
+/// joined by a graph query, so a candidate is invisible to the caller graph by
+/// construction. Like `function_calls`, the table is file-keyed and refreshed
+/// wholesale per file (DELETE WHERE file = ? then INSERT the current set), so it
+/// is folded into the same per-file transaction as the chunks/FTS/calls write to
+/// keep the tables from drifting into an asymmetric committed state.
+///
+/// `file_str` MUST be the normalized origin path (call `crate::normalize_path`
+/// at the call site, once); it scopes both the DELETE and every inserted row's
+/// `file` column so they cannot disagree.
+pub(crate) async fn write_candidate_edges_in_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    file_str: &str,
+    candidates: &[crate::parser::CandidateSite],
+) -> Result<(), StoreError> {
+    sqlx::query("DELETE FROM candidate_edges WHERE file = ?1")
+        .bind(file_str)
+        .execute(&mut **tx)
+        .await?;
+
+    if !candidates.is_empty() {
+        use crate::store::helpers::sql::max_rows_per_statement;
+        const INSERT_BATCH: usize = max_rows_per_statement(4);
+        for batch in candidates.chunks(INSERT_BATCH) {
+            let mut query_builder: sqlx::QueryBuilder<sqlx::Sqlite> = sqlx::QueryBuilder::new(
+                "INSERT INTO candidate_edges (file, callee_name, ref_line, candidate_kind) ",
+            );
+            query_builder.push_values(batch.iter(), |mut b, cand| {
+                b.push_bind(file_str)
+                    .push_bind(&cand.callee_name)
+                    .push_bind(cand.ref_line as i64)
+                    .push_bind(&cand.candidate_kind);
+            });
+            query_builder.build().execute(&mut **tx).await?;
+        }
+        tracing::info!(
+            file = %file_str,
+            candidates = candidates.len(),
+            "Indexed candidate edges"
+        );
+    }
+    Ok(())
+}
+
 impl Store<ReadWrite> {
     /// Insert or replace call sites for a chunk
     pub fn upsert_calls(
@@ -305,6 +353,21 @@ impl Store<ReadWrite> {
                     q = q.bind(fs);
                 }
                 q.execute(&mut *tx).await?;
+
+                // v32: clear the same files' `candidate_edges` in the same tx.
+                // This is the parse-driven `function_calls` replace path (it does
+                // not receive candidate sites), so the symmetric action is to
+                // CLEAR — a file refreshed through here must not keep stale
+                // candidate rows a prior emit pass wrote. Same DELETE-then-INSERT
+                // wholesale-per-file contract the other call-graph delete sites
+                // (delete_by_origin, prune_missing, the fused write) honor.
+                let cand_sql =
+                    format!("DELETE FROM candidate_edges WHERE file IN ({})", placeholders);
+                let mut cq = sqlx::query(sqlx::AssertSqlSafe(cand_sql.as_str()));
+                for fs in chunk {
+                    cq = cq.bind(fs);
+                }
+                cq.execute(&mut *tx).await?;
             }
 
             // Phase 2: collect all rows tagged with their file string, then

--- a/src/store/calls/mod.rs
+++ b/src/store/calls/mod.rs
@@ -19,6 +19,11 @@ mod test_map;
 // file-level call-graph write into the same per-file transaction.
 pub(crate) use crud::write_function_calls_in_tx;
 
+// Re-export the in-tx candidate_edges writer (the call-graph candidate
+// side-table) so the same per-file fused write can fold it in alongside
+// function_calls.
+pub(crate) use crud::write_candidate_edges_in_tx;
+
 // Re-export the doc-shaped-origin predicate so the worktree-overlay dead path
 // (in the binary crate) can apply the same doc-path admissibility the
 // dead-candidate SQL applies — single source for both views.

--- a/src/store/chunks/crud.rs
+++ b/src/store/chunks/crud.rs
@@ -778,6 +778,16 @@ impl Store<ReadWrite> {
                 .execute(&mut *tx)
                 .await?;
 
+            // v32: the `candidate_edges` side-table is also file-keyed with no FK
+            // to chunks, so the wholesale file-removal path must delete its rows
+            // for the same origin — otherwise a deleted file leaves orphan
+            // candidate rows behind (a later consumer would read stale candidates
+            // for a file that no longer exists).
+            sqlx::query("DELETE FROM candidate_edges WHERE file = ?1")
+                .bind(&origin_str)
+                .execute(&mut *tx)
+                .await?;
+
             // Prune the v29 `file_registry` fingerprint for this origin #1774.
             // `delete_by_origin` is the wholesale file-removal path (watch
             // delete event, model swap, slot teardown), so the persisted
@@ -1209,6 +1219,7 @@ impl Store<ReadWrite> {
             None,
             &[],
             None,
+            None,
         )
     }
 
@@ -1249,6 +1260,7 @@ impl Store<ReadWrite> {
             file_function_calls,
             &[],
             None,
+            None,
         )
     }
 
@@ -1272,6 +1284,11 @@ impl Store<ReadWrite> {
     /// write. `prune_file`/`live_ids` follow the same contract as the other fused
     /// methods (empty `live_ids` + `Some(origin)` = the file was emptied; every
     /// chunk for the origin is pruned). `fingerprint` is always `Some` here.
+    ///
+    /// `file_candidate_edges` is the v32 call-graph candidate side-table for the
+    /// file, folded into the same tx as `function_calls`. An empty slice clears
+    /// the file's candidates (DELETE WHERE file = ?), which is the common case
+    /// until a parser-emit pass (a later lane) produces candidate sites.
     #[allow(clippy::too_many_arguments)]
     pub fn upsert_file_fused(
         &self,
@@ -1282,6 +1299,7 @@ impl Store<ReadWrite> {
         prune_file: &std::path::Path,
         live_ids: &[&str],
         file_function_calls: &[crate::parser::FunctionCalls],
+        file_candidate_edges: &[crate::parser::CandidateSite],
         fingerprint: &crate::store::chunks::staleness::FileFingerprint,
     ) -> Result<usize, StoreError> {
         self.upsert_chunks_calls_and_prune_inner(
@@ -1293,6 +1311,7 @@ impl Store<ReadWrite> {
             Some(file_function_calls),
             sentinel,
             Some(fingerprint),
+            Some(file_candidate_edges),
         )
     }
 
@@ -1319,11 +1338,24 @@ impl Store<ReadWrite> {
         // path passes `None` and keeps its own post-tx best-effort stamp.
         // `prune_file` must be `Some` so the stamp has an origin to key on.
         fingerprint: Option<&crate::store::chunks::staleness::FileFingerprint>,
+        // v32: when `Some`, write the file's `candidate_edges` (the call-graph
+        // candidate side-table) in the SAME tx as function_calls, folded in
+        // right after the function_calls write so the two file-keyed call-graph
+        // tables commit together. Requires `prune_file` to scope the DELETE,
+        // same as `file_function_calls`. Empty/`None` is the common case until a
+        // parser-emit pass (a later lane) produces candidate sites.
+        file_candidate_edges: Option<&[crate::parser::CandidateSite]>,
     ) -> Result<usize, StoreError> {
         if fingerprint.is_some() {
             debug_assert!(
                 prune_file.is_some(),
                 "in-tx fingerprint stamp requires prune_file to supply the origin"
+            );
+        }
+        if file_candidate_edges.is_some() {
+            debug_assert!(
+                prune_file.is_some(),
+                "file_candidate_edges requires prune_file to scope the DELETE"
             );
         }
         let _span = tracing::info_span!(
@@ -1334,6 +1366,7 @@ impl Store<ReadWrite> {
             prune = prune_file.is_some(),
             live_count = live_ids.len(),
             file_function_calls = file_function_calls.is_some(),
+            file_candidate_edges = file_candidate_edges.is_some(),
             stamp = fingerprint.is_some()
         )
         .entered();
@@ -1554,6 +1587,16 @@ impl Store<ReadWrite> {
             if let (Some(file), Some(fcs)) = (prune_file, file_function_calls) {
                 let file_str = crate::normalize_path(file);
                 crate::store::calls::write_function_calls_in_tx(&mut tx, &file_str, fcs).await?;
+            }
+
+            // v32: fold the file-level `candidate_edges` write into the same tx,
+            // right after function_calls. Both are file-keyed call-graph tables
+            // refreshed wholesale per file; committing them together keeps them
+            // from drifting into an asymmetric state. candidate_edges is never
+            // joined by a graph query, so it cannot surface as a false caller.
+            if let (Some(file), Some(cands)) = (prune_file, file_candidate_edges) {
+                let file_str = crate::normalize_path(file);
+                crate::store::calls::write_candidate_edges_in_tx(&mut tx, &file_str, cands).await?;
             }
 
             // #1835: stamp the reconcile fingerprint LAST and INSIDE the same tx
@@ -1782,7 +1825,7 @@ impl Store<ReadWrite> {
 #[cfg(test)]
 mod tests {
     use super::super::test_utils::make_chunk;
-    use crate::parser::{CallEdgeKind, CallSite, FunctionCalls};
+    use crate::parser::{CallEdgeKind, CallSite, CandidateSite, FunctionCalls};
     use crate::test_helpers::{mock_embedding, setup_store};
 
     /// `upsert_chunks_calls_and_prune_with_file_calls` must write
@@ -1874,6 +1917,7 @@ mod tests {
                 std::path::Path::new("src/f.rs"),
                 &[chunk.id.as_str()],
                 &[],
+                &[],
                 &fp,
             )
             .expect("fused write must succeed");
@@ -1925,6 +1969,7 @@ mod tests {
                 std::path::Path::new("src/z.rs"),
                 &[], // empty live set → prune all chunks for the origin
                 &fcs,
+                &[],
                 &fp,
             )
             .expect("zero-chunk fused write must succeed");
@@ -1947,6 +1992,190 @@ mod tests {
             store.find_orphaned_function_calls().unwrap().is_empty(),
             "zero-chunk fused write must not leave orphaned function_calls"
         );
+    }
+
+    /// v32 `candidate_edges`: the fused write folds the candidate side-table
+    /// into the same per-file tx and round-trips a row (file/callee_name/
+    /// ref_line/candidate_kind). The candidate is written to its OWN table — it
+    /// must NOT appear in `function_calls`, so `get_callers_full` for the same
+    /// callee name returns nothing (the side-table is never joined by the graph
+    /// queries, so a candidate can never surface as a false caller).
+    #[test]
+    fn upsert_file_fused_writes_candidate_edges_separate_from_callers() {
+        let (store, _dir) = setup_store();
+        let emb = mock_embedding(1.0);
+        let chunk = make_chunk("real_fn", "src/c.rs");
+        let pairs = [(chunk.clone(), emb)];
+        let fp = crate::store::chunks::staleness::FileFingerprint {
+            mtime: Some(7),
+            size: Some(11),
+            content_hash: Some(*blake3::hash(b"cand").as_bytes()),
+        };
+
+        let candidates = vec![CandidateSite {
+            file: std::path::PathBuf::from("src/c.rs"),
+            callee_name: "maybe_callee".to_string(),
+            ref_line: 9,
+            candidate_kind: "unresolved".to_string(),
+        }];
+
+        store
+            .upsert_file_fused(
+                &pairs,
+                &[],
+                fp.mtime,
+                &[],
+                std::path::Path::new("src/c.rs"),
+                &[chunk.id.as_str()],
+                &[],
+                &candidates,
+                &fp,
+            )
+            .expect("fused write with candidate edges must succeed");
+
+        // The candidate row round-trips from candidate_edges.
+        store.runtime().block_on(async {
+            let rows: Vec<(String, String, i64, String)> = sqlx::query_as(
+                "SELECT file, callee_name, ref_line, candidate_kind \
+                 FROM candidate_edges WHERE callee_name = ?1",
+            )
+            .bind("maybe_callee")
+            .fetch_all(&store.pool)
+            .await
+            .unwrap();
+            assert_eq!(rows.len(), 1, "exactly one candidate row must be stored");
+            assert_eq!(rows[0].0, "src/c.rs");
+            assert_eq!(rows[0].1, "maybe_callee");
+            assert_eq!(rows[0].2, 9);
+            assert_eq!(rows[0].3, "unresolved");
+        });
+
+        // The candidate must NOT leak into the caller graph — get_callers_full
+        // for the candidate's callee name finds nothing (it lives in a table the
+        // graph queries never join).
+        let callers = store
+            .get_callers_full("maybe_callee")
+            .expect("get_callers_full");
+        assert!(
+            callers.is_empty(),
+            "a candidate edge must never surface as a caller; got {:?}",
+            callers.iter().map(|c| &c.name).collect::<Vec<_>>()
+        );
+
+        // Re-running the fused write with an EMPTY candidate slice clears the
+        // file's candidates (DELETE-then-INSERT wholesale per file).
+        store
+            .upsert_file_fused(
+                &pairs,
+                &[],
+                fp.mtime,
+                &[],
+                std::path::Path::new("src/c.rs"),
+                &[chunk.id.as_str()],
+                &[],
+                &[],
+                &fp,
+            )
+            .expect("fused rewrite with no candidates must succeed");
+        store.runtime().block_on(async {
+            let (n,): (i64,) =
+                sqlx::query_as("SELECT COUNT(*) FROM candidate_edges WHERE file = ?1")
+                    .bind("src/c.rs")
+                    .fetch_one(&store.pool)
+                    .await
+                    .unwrap();
+            assert_eq!(
+                n, 0,
+                "empty candidate slice must clear the file's candidates"
+            );
+        });
+    }
+
+    /// v32 COMPLETENESS GUARD: every wholesale `function_calls` replace/delete
+    /// path must also sweep `candidate_edges` for the same files — both are
+    /// file-keyed call-graph tables refreshed wholesale per file, and a path
+    /// that refreshes one but not the other strands orphan rows. This pins the
+    /// parse-driven batch writer `upsert_function_calls_for_files` (the watch
+    /// zero-chunk finalize path): it does NOT receive candidate sites, so the
+    /// symmetric action is to CLEAR the files' candidates. Seed a candidate
+    /// directly, then run the batch writer for the same file and assert the
+    /// candidate is gone.
+    #[test]
+    fn upsert_function_calls_for_files_clears_candidate_edges() {
+        let (store, _dir) = setup_store();
+
+        // Seed a candidate row for src/q.rs via the fused write (the only
+        // store-public path that writes candidate_edges in Lane 1).
+        let emb = mock_embedding(1.0);
+        let chunk = make_chunk("seed_fn", "src/q.rs");
+        let pairs = [(chunk.clone(), emb)];
+        let fp = crate::store::chunks::staleness::FileFingerprint {
+            mtime: Some(1),
+            size: Some(2),
+            content_hash: Some(*blake3::hash(b"q").as_bytes()),
+        };
+        let candidates = vec![CandidateSite {
+            file: std::path::PathBuf::from("src/q.rs"),
+            callee_name: "ghost_callee".to_string(),
+            ref_line: 4,
+            candidate_kind: "unresolved".to_string(),
+        }];
+        store
+            .upsert_file_fused(
+                &pairs,
+                &[],
+                fp.mtime,
+                &[],
+                std::path::Path::new("src/q.rs"),
+                &[chunk.id.as_str()],
+                &[],
+                &candidates,
+                &fp,
+            )
+            .expect("seed fused write must succeed");
+
+        // Sanity: the candidate exists.
+        store.runtime().block_on(async {
+            let (n,): (i64,) =
+                sqlx::query_as("SELECT COUNT(*) FROM candidate_edges WHERE file = ?1")
+                    .bind("src/q.rs")
+                    .fetch_one(&store.pool)
+                    .await
+                    .unwrap();
+            assert_eq!(n, 1, "candidate must be seeded before the batch replace");
+        });
+
+        // Run the parse-driven batch function_calls replace for the same file
+        // (the watch zero-chunk finalize path). It must clear the candidates.
+        let entries = vec![(
+            std::path::PathBuf::from("src/q.rs"),
+            vec![FunctionCalls {
+                name: "seed_fn".to_string(),
+                line_start: 1,
+                calls: vec![CallSite {
+                    callee_name: "real_callee".to_string(),
+                    line_number: 2,
+                    kind: CallEdgeKind::Call,
+                }],
+            }],
+        )];
+        store
+            .upsert_function_calls_for_files(&entries)
+            .expect("batch function_calls replace must succeed");
+
+        store.runtime().block_on(async {
+            let (n,): (i64,) =
+                sqlx::query_as("SELECT COUNT(*) FROM candidate_edges WHERE file = ?1")
+                    .bind("src/q.rs")
+                    .fetch_one(&store.pool)
+                    .await
+                    .unwrap();
+            assert_eq!(
+                n, 0,
+                "upsert_function_calls_for_files must clear the file's candidate_edges \
+                 (wholesale call-graph replace must sweep both file-keyed tables)"
+            );
+        });
     }
 
     /// Passing `None` for file_function_calls leaves the existing

--- a/src/store/chunks/staleness.rs
+++ b/src/store/chunks/staleness.rs
@@ -314,6 +314,19 @@ async fn delete_origins_in_tx(
         }
         calls_stmt.execute(&mut **tx).await?;
 
+        // v32: the `candidate_edges` side-table is file-keyed too, so the same
+        // wholesale prune must drop its rows for the removed origins — otherwise
+        // a deleted/gitignored file leaves orphan candidate rows behind.
+        let candidate_query = format!(
+            "DELETE FROM candidate_edges WHERE file IN ({})",
+            placeholder_str
+        );
+        let mut candidate_stmt = sqlx::query(sqlx::AssertSqlSafe(candidate_query.as_str()));
+        for origin in batch {
+            candidate_stmt = candidate_stmt.bind(origin);
+        }
+        candidate_stmt.execute(&mut **tx).await?;
+
         // Prune the v29 `file_registry` fingerprint for the same origins
         // #1774. These origins are being removed wholesale (file gone from
         // disk / now gitignored), so the persisted zero-chunk fingerprint must

--- a/src/store/helpers/mod.rs
+++ b/src/store/helpers/mod.rs
@@ -177,7 +177,14 @@ pub(crate) fn bm25_ordering_expr() -> String {
 ///   until its content changes. Without it a PARSER_VERSION bump re-queues an
 ///   unparseable file every reconcile tick forever (the mtime touch heals only
 ///   the fingerprint predicate, not drift).
-pub const CURRENT_SCHEMA_VERSION: i32 = 31;
+/// - v32: candidate_edges side-table (file, callee_name, ref_line,
+///   candidate_kind) for low-confidence call-graph candidates that must NOT
+///   surface as callers. A SEPARATE table, not a function_calls.edge_kind value:
+///   the graph queries SELECT every function_calls row for a callee with no kind
+///   exclusion, so a candidate stored there would read as a false caller. This
+///   table is callee-name-keyed and never joined by a graph query. Empty on
+///   migrate; no PARSER_VERSION bump (nothing emits rows yet).
+pub const CURRENT_SCHEMA_VERSION: i32 = 32;
 
 /// Default model name for metadata checks (used by test-only `check_model_version`).
 /// Canonical definition is `embedder::DEFAULT_MODEL_REPO`.

--- a/src/store/migrations.rs
+++ b/src/store/migrations.rs
@@ -401,6 +401,7 @@ const MIGRATIONS: &[(i32, i32, MigrationFn)] = &[
     (28, 29, |c| Box::pin(migrate_v28_to_v29(c))),
     (29, 30, |c| Box::pin(migrate_v29_to_v30(c))),
     (30, 31, |c| Box::pin(migrate_v30_to_v31(c))),
+    (31, 32, |c| Box::pin(migrate_v31_to_v32(c))),
 ];
 
 /// Run a single migration step
@@ -1248,6 +1249,56 @@ async fn migrate_v30_to_v31(conn: &mut sqlx::SqliteConnection) -> Result<(), Sto
     Ok(())
 }
 
+/// v31 → v32: add the `candidate_edges` side-table for low-confidence call-graph
+/// candidates that must NOT surface as callers.
+///
+/// A SEPARATE table — deliberately NOT a new `function_calls.edge_kind` value.
+/// Every callers/callees/impact query SELECTs `function_calls` rows for a callee
+/// with no kind exclusion, so a candidate stored there would read as a false
+/// caller; and `CallEdgeKind::is_real_caller` is the complement of
+/// `doc_reference`, so a new kind would default to "real caller" and put the
+/// callee in the wrong dead tier. This table is callee-name-keyed and is never
+/// joined by a graph query, so a candidate is invisible to the caller graph by
+/// construction.
+///
+/// Created EMPTY on migrate (additive). The columns mirror what a candidate site
+/// carries: `file` (source path), `callee_name` (the symbol the candidate points
+/// at), `ref_line` (1-indexed line of the reference), and `candidate_kind` (the
+/// candidate's provenance string). Indexes on `callee_name` and `file` match the
+/// two access patterns a future consumer/cleanup path needs (callee-name lookup
+/// and per-file delete-on-reindex). No PARSER_VERSION bump: nothing emits rows
+/// into this table yet, so no re-extraction is required.
+async fn migrate_v31_to_v32(conn: &mut sqlx::SqliteConnection) -> Result<(), StoreError> {
+    let _span = tracing::info_span!("migrate_v31_to_v32").entered();
+
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS candidate_edges (
+            file TEXT NOT NULL,
+            callee_name TEXT NOT NULL,
+            ref_line INTEGER NOT NULL,
+            candidate_kind TEXT NOT NULL
+        )",
+    )
+    .execute(&mut *conn)
+    .await?;
+
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_candidate_edges_callee ON candidate_edges(callee_name)",
+    )
+    .execute(&mut *conn)
+    .await?;
+    sqlx::query("CREATE INDEX IF NOT EXISTS idx_candidate_edges_file ON candidate_edges(file)")
+        .execute(&mut *conn)
+        .await?;
+
+    tracing::info!(
+        "Migrated to v32: candidate_edges side-table (callee-name-keyed; never \
+         joined by callers/callees/impact). Empty on migrate; populated by a \
+         later parser-emit pass. No PARSER_VERSION bump — nothing writes rows yet."
+    );
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1280,7 +1331,7 @@ mod tests {
     #[test]
     fn test_current_schema_version_documented() {
         // Ensure the current version matches what we document
-        assert_eq!(CURRENT_SCHEMA_VERSION, 31);
+        assert_eq!(CURRENT_SCHEMA_VERSION, 32);
     }
 
     #[test]
@@ -4779,6 +4830,170 @@ mod tests {
         });
     }
 
+    /// Build a v31-shaped DB: a `function_calls` table (with the v30 edge_kind
+    /// column) but NO `candidate_edges` side-table. Schema version stamped 31.
+    /// Minimal — just enough for the v31→v32 step, which only CREATEs a new
+    /// table and does not depend on prior shape.
+    async fn setup_v31_schema(db_path: &std::path::Path) -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(
+                sqlx::sqlite::SqliteConnectOptions::new()
+                    .filename(db_path)
+                    .create_if_missing(true)
+                    .foreign_keys(true),
+            )
+            .await
+            .unwrap();
+        sqlx::query("CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE function_calls (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                file TEXT NOT NULL,
+                caller_name TEXT NOT NULL,
+                caller_line INTEGER NOT NULL,
+                callee_name TEXT NOT NULL,
+                call_line INTEGER NOT NULL,
+                edge_kind TEXT NOT NULL DEFAULT 'call'
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query("INSERT INTO metadata (key, value) VALUES ('schema_version', '31')")
+            .execute(&pool)
+            .await
+            .unwrap();
+        pool
+    }
+
+    /// v31 → v32 creates the `candidate_edges` side-table. After the migration a
+    /// row can be inserted and read back, and the side-table is SEPARATE from
+    /// `function_calls` (a candidate is never a function_calls row).
+    #[test]
+    fn test_migrate_v31_to_v32_creates_candidate_edges() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+
+        rt.block_on(async {
+            let pool = setup_v31_schema(&db_path).await;
+
+            // No candidate_edges table before the migration.
+            let pre: Option<(String,)> = sqlx::query_as(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='candidate_edges'",
+            )
+            .fetch_optional(&pool)
+            .await
+            .unwrap();
+            assert!(pre.is_none(), "candidate_edges must not exist pre-v32");
+
+            let pool = migrate(pool, &db_path, 31, 32).await.unwrap();
+
+            // The table exists and a row round-trips.
+            sqlx::query(
+                "INSERT INTO candidate_edges (file, callee_name, ref_line, candidate_kind) \
+                 VALUES ('src/a.rs', 'maybe_fn', 12, 'unresolved')",
+            )
+            .execute(&pool)
+            .await
+            .unwrap();
+            let (file, callee, line, kind): (String, String, i64, String) = sqlx::query_as(
+                "SELECT file, callee_name, ref_line, candidate_kind \
+                 FROM candidate_edges WHERE callee_name = 'maybe_fn'",
+            )
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            assert_eq!(
+                (file.as_str(), callee.as_str(), line, kind.as_str()),
+                ("src/a.rs", "maybe_fn", 12, "unresolved")
+            );
+
+            // It is empty after migrate (additive, no backfill).
+            let pool2 = setup_v31_schema(&dir.path().join("empty.db")).await;
+            let pool2 = migrate(pool2, &dir.path().join("empty.db"), 31, 32)
+                .await
+                .unwrap();
+            let (n,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM candidate_edges")
+                .fetch_one(&pool2)
+                .await
+                .unwrap();
+            assert_eq!(n, 0, "candidate_edges must be empty on migrate");
+        });
+    }
+
+    /// Fresh-create (schema.sql) and migrated (v31 → v32) must produce the same
+    /// `candidate_edges` shape (same columns, same indexes). The headline
+    /// `test_fresh_init_equals_full_migration_from_v10` covers this structurally
+    /// too, but a focused per-step check names the exact divergent surface.
+    #[test]
+    fn test_v32_fresh_create_matches_migrated_shape() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        rt.block_on(async {
+            // Fresh: apply schema.sql and read the candidate_edges DDL + indexes.
+            let fresh = SqlitePoolOptions::new()
+                .max_connections(1)
+                .connect_with(
+                    sqlx::sqlite::SqliteConnectOptions::new()
+                        .filename(":memory:")
+                        .foreign_keys(true),
+                )
+                .await
+                .unwrap();
+            for stmt in crate::store::split_sql_statements(include_str!("../schema.sql")) {
+                if stmt.is_empty() {
+                    continue;
+                }
+                sqlx::query(sqlx::AssertSqlSafe(stmt.as_str()))
+                    .execute(&fresh)
+                    .await
+                    .unwrap();
+            }
+            let fresh_idx: Vec<(String,)> = sqlx::query_as(
+                "SELECT name FROM sqlite_master WHERE type='index' \
+                 AND tbl_name='candidate_edges' ORDER BY name",
+            )
+            .fetch_all(&fresh)
+            .await
+            .unwrap();
+            let fresh_idx: Vec<String> = fresh_idx.into_iter().map(|(n,)| n).collect();
+            assert!(
+                fresh_idx.contains(&"idx_candidate_edges_callee".to_string())
+                    && fresh_idx.contains(&"idx_candidate_edges_file".to_string()),
+                "fresh candidate_edges must carry both indexes, got: {fresh_idx:?}"
+            );
+
+            // Migrated: build v31, migrate to v32, read the same.
+            let dir = tempfile::tempdir().unwrap();
+            let db_path = dir.path().join("test.db");
+            let pool = setup_v31_schema(&db_path).await;
+            let pool = migrate(pool, &db_path, 31, 32).await.unwrap();
+            let mig_idx: Vec<(String,)> = sqlx::query_as(
+                "SELECT name FROM sqlite_master WHERE type='index' \
+                 AND tbl_name='candidate_edges' ORDER BY name",
+            )
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+            let mig_idx: Vec<String> = mig_idx.into_iter().map(|(n,)| n).collect();
+            assert_eq!(
+                fresh_idx, mig_idx,
+                "fresh vs migrated candidate_edges index set must match"
+            );
+        });
+    }
+
     /// FROZEN-ARTIFACT full-chain guard (legacy-state / version-null shape).
     ///
     /// Every other migration test in this module hand-builds a *minimal*
@@ -4791,7 +5006,7 @@ mod tests {
     /// silently depends on the *real* predecessor shape — or a default backfill
     /// that's wrong for the *oldest* rows — would pass every per-step test yet
     /// crash a real user's v10 DB on upgrade. No fixture built by current code
-    /// can construct a v10 DB: current `init()` writes the v31 schema. The only
+    /// can construct a v10 DB: current `init()` writes the v32 schema. The only
     /// way to reach this shape is to freeze the historical DDL, which is what
     /// this test does — the v10 `CREATE TABLE`s are copied verbatim from git
     /// commit 73cca226 (`feat: Migrate to sqlx async SQLite + schema v10`).
@@ -5085,10 +5300,25 @@ mod tests {
                 "file_registry must carry the v31 column after the full chain"
             );
 
+            // candidate_edges (v32) exists and is empty after the chain (additive,
+            // no backfill); a row can be inserted with its four columns.
+            sqlx::query(
+                "INSERT INTO candidate_edges (file, callee_name, ref_line, candidate_kind) \
+                 VALUES ('src/x.rs', 'cand_fn', 3, 'unresolved')",
+            )
+            .execute(&pool)
+            .await
+            .expect("candidate_edges must exist with its four columns after the full chain");
+
             // Tables created mid-chain exist (type_edges v11, sparse_vectors
-            // v16, llm_summaries v13/v16). A missing one means a step's
-            // `IF NOT EXISTS` masked a real ordering bug.
-            for tbl in ["type_edges", "sparse_vectors", "llm_summaries"] {
+            // v16, llm_summaries v13/v16, candidate_edges v32). A missing one
+            // means a step's `IF NOT EXISTS` masked a real ordering bug.
+            for tbl in [
+                "type_edges",
+                "sparse_vectors",
+                "llm_summaries",
+                "candidate_edges",
+            ] {
                 let present: Option<(String,)> = sqlx::query_as(
                     "SELECT name FROM sqlite_master WHERE type='table' AND name = ?1",
                 )
@@ -5113,7 +5343,7 @@ mod tests {
     // `ALTER TABLE … ADD COLUMN … DEFAULT` drifts from `schema.sql`'s column
     // definition (wrong type, wrong default, missing NOT NULL) would leave
     // migrated DBs structurally different from fresh ones, and no fresh-state
-    // fixture can catch it: current `init()` only ever writes the v31 schema,
+    // fixture can catch it: current `init()` only ever writes the v32 schema,
     // so the migrated-from-v10 shape is unreachable except by replaying the
     // frozen historical DDL through the live migration chain.
     // ========================================================================
@@ -5448,7 +5678,7 @@ mod tests {
     /// default or type differs between the migrate path and the fresh path is
     /// the straggler this catches — it would silently diverge migrated DBs from
     /// fresh ones, and no born-at-HEAD fixture can construct the migrated shape
-    /// (current `init()` only ever writes v31).
+    /// (current `init()` only ever writes v32).
     ///
     /// Calibration (proving the guard bites): temporarily changing the v30
     /// migration's `edge_kind` default from `'call'` to `'xcall'`, OR

--- a/tests/store_test.rs
+++ b/tests/store_test.rs
@@ -17,7 +17,7 @@ fn test_store_init() {
     let stats = store.stats().unwrap();
     assert_eq!(stats.total_chunks, 0);
     assert_eq!(stats.total_files, 0);
-    assert_eq!(stats.schema_version, 31); // v31: file_registry.parse_failed_parser_version drift loop-breaker
+    assert_eq!(stats.schema_version, 32); // v32: candidate_edges side-table (call-graph candidates that must not surface as callers)
     assert_eq!(stats.model_name, cqs::embedder::DEFAULT_MODEL_REPO);
 }
 
@@ -1178,7 +1178,7 @@ fn test_open_readonly_on_initialized_store() {
     let ro = cqs::store::Store::open_readonly(&db_path).unwrap();
     let stats = ro.stats().unwrap();
     assert_eq!(stats.total_chunks, 0);
-    assert_eq!(stats.schema_version, 31);
+    assert_eq!(stats.schema_version, 32);
     assert_eq!(stats.model_name, cqs::embedder::DEFAULT_MODEL_REPO);
 }
 


### PR DESCRIPTION
**Lane 1 of the candidate-edge campaign** (unblocks the #1818 / #1788 / #1573 cross-file & container residuals) — the schema/store foundation. Schema **31→32**.

Adds a **separate `candidate_edges(file, callee_name, ref_line, candidate_kind)` side-table** (+ callee/file indexes) — NOT a new `edge_kind`. Rationale: graph queries (`get_callers_full`/`callees`/`impact`) SELECT every `function_calls` row for a callee with no kind exclusion, and `is_real_caller = !doc_reference` is complement-default — so a candidate `edge_kind` would leak as a false caller and into the wrong dead tier. The side-table is callee-name-keyed and never joined by a graph query → candidate references can suppress false-DEAD (Lane 3) **without ever surfacing as a false caller, by construction** (pinned by a test asserting `get_callers_full` stays empty).

- `migrate_v31_to_v32` (additive, empty on migrate); `CURRENT_SCHEMA_VERSION` 31→32; `schema.sql` DDL byte-matched to the migration (the #1905 `test_fresh_init_equals_full_migration_from_v10` guard stays green); v10→v32 chain test extended.
- `CandidateSite` type — a separate collection alongside `Vec<CallSite>`; no `CallEdgeKind` value added.
- crud `write_candidate_edges_in_tx`, folded into the per-file fused write (same transaction as `function_calls`).
- **Incomplete-sweep straggler fixed (code-reviewer catch):** the watch zero-chunk finalize path (`upsert_function_calls_for_files`) deleted `function_calls` but not `candidate_edges`. All four wholesale call-graph delete/replace sites (fused write, that path, `delete_by_origin`, `prune_missing`) now sweep BOTH tables.
- PARSER_VERSION untouched (9 — emit is Lane 2); `query.rs`/`dead_code.rs`/callers untouched (Lane 3).

Full `--tests` sweep: **4652 passed, 0 failed**. code-reviewer (opus) APPROVE. No emit/consumption yet → no reindex for this lane. Lanes 2 (parser-emit) + 3 (dead-consults) follow; one reindex at the end.
