### PR TITLE
feat(dead) L3: cqs dead consults candidate_edges (+ overlay seam fix) — candidate-edge campaign

### DIFF
--- a/src/cli/batch/handlers/analysis.rs
+++ b/src/cli/batch/handlers/analysis.rs
@@ -376,6 +376,101 @@ mod parity_tests {
         assert_eq!(dispatched, core_val, "dispatch_dead must equal dead_core");
     }
 
+    /// Seed a context whose index holds a candidate-ONLY callee `maybe_fn`
+    /// (zero `function_calls` edges, one `candidate_edges` row) so the
+    /// candidate-edge consult (Lane 3) has something to flip. Returns the temp
+    /// dir (kept alive) and the context.
+    fn seed_candidate_only_ctx() -> (TempDir, crate::cli::batch::BatchContext) {
+        use cqs::parser::CandidateSite;
+        let dir = TempDir::new().expect("tempdir");
+        let cqs_dir = dir.path().join(".cqs");
+        std::fs::create_dir_all(&cqs_dir).expect("mkdir .cqs");
+        let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
+
+        let mut emb_vec = vec![0.0_f32; cqs::EMBEDDING_DIM];
+        emb_vec[0] = 1.0;
+        let embedding = Embedding::new(emb_vec);
+
+        {
+            let store = Store::open(&index_path).expect("open store");
+            store.init(&ModelInfo::default()).expect("init");
+            let chunks = vec![(make_chunk("src/lib.rs:1:maybe_fn", "maybe_fn"), embedding)];
+            store.upsert_chunks_batch(&chunks, Some(0)).expect("upsert");
+            // A `candidate_edges` row naming `maybe_fn`: the consult must relabel
+            // it `low-confidence-live` instead of `dead`.
+            store
+                .upsert_candidate_edges(
+                    std::path::Path::new("src/caller.rs"),
+                    &[CandidateSite {
+                        file: std::path::PathBuf::from("src/caller.rs"),
+                        callee_name: "maybe_fn".to_string(),
+                        ref_line: 9,
+                        candidate_kind: "bare_arg_unresolved".to_string(),
+                    }],
+                )
+                .expect("upsert candidate");
+        }
+        let ctx = create_test_context(&cqs_dir).expect("ctx");
+        (dir, ctx)
+    }
+
+    /// CLI==daemon parity on a candidate-bearing fixture: a candidate-only callee
+    /// surfaces as `low-confidence-live` (not `dead`) on BOTH surfaces, and the
+    /// daemon JSON byte-equals the core. Fixture-grounded so a both-sides-empty
+    /// or both-sides-wrong-verdict regression still fails.
+    #[test]
+    fn parity_dead_candidate_only_low_confidence_live() {
+        let (_dir, ctx) = seed_candidate_only_ctx();
+        let view = ctx.build_view(None);
+
+        let core = crate::cli::commands::dead_core(
+            &view.store(),
+            &view.root,
+            &crate::cli::commands::DeadArgs {
+                include_pub: false,
+                min_confidence: DeadConfidence::Low,
+                verdict: None,
+            },
+        )
+        .expect("dead_core");
+        let core_val = serde_json::to_value(&core).expect("serialize core");
+
+        // Fixture-grounded: `maybe_fn` is present and classified
+        // `low-confidence-live` (the candidate consult flipped it from `dead`),
+        // with the candidate kind named in the reason.
+        let entry = core_val["dead"]
+            .as_array()
+            .unwrap_or_else(|| panic!("dead core must carry a dead array: {core_val}"))
+            .iter()
+            .find(|d| d["name"] == "maybe_fn")
+            .unwrap_or_else(|| panic!("candidate-only `maybe_fn` must surface: {core_val}"));
+        assert_eq!(
+            entry["verdict"], "low-confidence-live",
+            "candidate-only callee must be low-confidence-live, not dead: {entry}"
+        );
+        let reason = entry["verdict_reason"].as_str().unwrap_or("");
+        assert!(
+            reason.contains("candidate edge") && reason.contains("bare_arg_unresolved"),
+            "reason must name the candidate kind: {reason}"
+        );
+
+        let dispatched = super::dispatch_dead(
+            &view,
+            &crate::cli::args::DeadArgs {
+                include_pub: false,
+                min_confidence: DeadConfidence::Low,
+                verdict: None,
+                overlay: Default::default(),
+            },
+        )
+        .expect("dispatch_dead");
+
+        assert_eq!(
+            dispatched, core_val,
+            "dispatch_dead must equal dead_core on a candidate-bearing fixture"
+        );
+    }
+
     /// `dispatch_health` equals `serde_json::to_value(health_core(...))` (parity
     /// by construction). The fixture-grounded assert pins that the seeded chunk
     /// is counted, guarding against both sides reporting an empty index.

--- a/src/cli/batch/handlers/graph.rs
+++ b/src/cli/batch/handlers/graph.rs
@@ -3071,6 +3071,138 @@ mod tests {
             dead_names(&json).contains(&"lonely".to_string()),
             "masking the sole caller must flip `lonely` dead: {json}"
         );
+        // The flip must also carry the `dead` verdict (no collision here, but the
+        // sibling `dead_overlay_addition_classifies_dead_despite_candidate_collision`
+        // exercises the parent-low_conf-collision case).
+        assert_eq!(
+            dead_verdict_for(&json, "lonely").as_deref(),
+            Some("dead"),
+            "a Direction-B addition must classify `dead`: {json}"
+        );
+    }
+
+    /// Map a name → its `verdict` string across a dead output's `dead` +
+    /// `possibly_dead_pub` lists (None if the name is absent from both).
+    fn dead_verdict_for(out: &serde_json::Value, name: &str) -> Option<String> {
+        for key in ["dead", "possibly_dead_pub"] {
+            if let Some(arr) = out[key].as_array() {
+                for d in arr {
+                    if d["name"].as_str() == Some(name) {
+                        return Some(d["verdict"].as_str().unwrap_or("").to_string());
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// Seam guard (overlay × verdict-classification): a Direction-B overlay
+    /// addition whose name ALSO sits in the parent-truth `low_conf` map must
+    /// carry verdict `dead`, NOT be relabeled `low-confidence-live` and hidden
+    /// from `--verdict dead`. The addition is computed dead over the
+    /// authoritative merged graph in this worktree; the parent `low_conf` map is
+    /// stale here. RED without the `overlay_dead` bypass (verdict would be
+    /// `low-confidence-live`), GREEN with it.
+    ///
+    /// Reachability of the collision: a Direction-B addition is, by definition, a
+    /// name NOT already in the parent dead populations. A heuristic/candidate-only
+    /// callee is normally folded into the parent low-confidence-live set (so it
+    /// would be in `already` and never re-added) — UNLESS its definition is
+    /// dropped by a Phase-1 filter the addition path does NOT apply. The
+    /// entry-point filter is exactly such a gap: `find_low_confidence_live_…`
+    /// drops entry-point names (here `handler`) from its CHUNK population, but
+    /// `find_low_confidence_live_names` keeps them in the `low_conf` NAME map, and
+    /// `resolve_overlay_dead_candidate_def` admits them. So `handler` is absent
+    /// from the parent dead set yet present in `low_conf` — the precise collision.
+    /// The Lane-3 candidate consult widens that name map further (an extra
+    /// `candidate_edges` row here), making the collision more likely.
+    #[test]
+    fn dead_overlay_addition_classifies_dead_despite_low_conf_collision() {
+        // Parent: `handler` (an ENTRY-POINT name) is reached only by `caller` (in
+        // src/edited.rs) via a MACRO-HEURISTIC edge — a real caller but
+        // NON-trusted, so `handler` lands in the `low_conf` NAME map. As an entry
+        // point its definition is filtered out of the parent low-confidence-live
+        // CHUNK population, so it is NOT in the parent dead set (Direction-B can
+        // add it). A `candidate_edges` row naming `handler` (the Lane-3 widening)
+        // co-populates the same `low_conf` map.
+        let dir = TempDir::new().expect("tempdir");
+        let cqs_dir = dir.path().join(".cqs");
+        std::fs::create_dir_all(&cqs_dir).expect("mkdir .cqs");
+        let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
+        let mut emb = vec![0.0_f32; cqs::EMBEDDING_DIM];
+        emb[0] = 1.0;
+        let embedding = Embedding::new(emb);
+        {
+            let store = Store::open(&index_path).expect("open store");
+            store.init(&ModelInfo::default()).expect("init");
+            for (file, name) in [("src/edited.rs", "caller"), ("src/lib.rs", "handler")] {
+                let mut c = make_chunk(&format!("{file}:{name}"), name);
+                c.file = PathBuf::from(file);
+                store
+                    .upsert_chunks_batch(&[(c, embedding.clone())], Some(0))
+                    .expect("upsert parent chunk");
+            }
+            // Heuristic real caller: handler has a real edge (so it's not in the
+            // strict dead set) but no trusted edge (so it's in low_conf).
+            let fc = FunctionCalls {
+                name: "caller".into(),
+                line_start: 1,
+                calls: vec![CallSite {
+                    callee_name: "handler".into(),
+                    line_number: 2,
+                    kind: CallEdgeKind::MacroHeuristic,
+                }],
+            };
+            store
+                .upsert_function_calls(Path::new("src/edited.rs"), &[fc])
+                .expect("upsert parent heuristic edge");
+            // Candidate-edges row naming `handler` (Lane-3 widening of low_conf).
+            store
+                .upsert_candidate_edges(
+                    Path::new("src/other.rs"),
+                    &[cqs::parser::CandidateSite {
+                        file: PathBuf::from("src/other.rs"),
+                        callee_name: "handler".into(),
+                        ref_line: 3,
+                        candidate_kind: "bare_arg_unresolved".into(),
+                    }],
+                )
+                .expect("upsert candidate edge");
+        }
+        let ctx = create_test_context(&cqs_dir).expect("create_test_context");
+
+        // Baseline (no overlay): `handler` is absent from the dead set entirely
+        // (real heuristic caller keeps it out of the strict set; the entry-point
+        // filter keeps it out of the low-confidence-live chunk population).
+        let (base, _) =
+            dead_overlay(&ctx.store(), &ctx.root, &dead_core_args(), None).expect("base");
+        let base_json = serde_json::to_value(&base).unwrap();
+        assert!(
+            !dead_names(&base_json).contains(&"handler".to_string()),
+            "baseline: handler must be absent from the dead set with no overlay: {base_json}"
+        );
+
+        // Worktree edits src/edited.rs and drops the call to `handler` →
+        // Direction-B adds it dead over the merged graph.
+        let overlay = overlay_with_edges(&[("src/edited.rs", "caller")], &[], &["src/edited.rs"]);
+        let (out, participated) =
+            dead_overlay(&ctx.store(), &ctx.root, &dead_core_args(), Some(&overlay))
+                .expect("overlay");
+        assert!(participated, "a live→dead flip must report participation");
+        let json = serde_json::to_value(&out).unwrap();
+        assert!(
+            dead_names(&json).contains(&"handler".to_string()),
+            "masking the sole caller must flip `handler` into the dead set: {json}"
+        );
+        // The seam assertion: the Direction-B addition's VERDICT must be `dead`,
+        // not `low-confidence-live` (which the stale parent low_conf map would
+        // assign, hiding it from `--verdict dead`).
+        assert_eq!(
+            dead_verdict_for(&json, "handler").as_deref(),
+            Some("dead"),
+            "an overlay-dead addition colliding with a parent candidate/heuristic name \
+             must classify `dead`, NOT `low-confidence-live` (or `--verdict dead` hides it): {json}"
+        );
     }
 
     /// No-overlay parity fence: `dead_overlay(.., None)` equals `dead_core`.

--- a/src/cli/commands/review/dead.rs
+++ b/src/cli/commands/review/dead.rs
@@ -168,20 +168,44 @@ fn classify_verdict(
         );
     }
     if let Some(info) = low_conf.get(&entry.chunk.name) {
-        // Name the heuristic kinds and counts rather than asserting "all
-        // callers are heuristic" generically.
-        let kinds = info
-            .kind_counts
-            .iter()
-            .map(|(kind, n)| format!("{kind}×{n}"))
-            .collect::<Vec<_>>()
-            .join(", ");
+        // Name the exact provenance and counts rather than asserting "all
+        // callers are heuristic" generically. Two populations may contribute:
+        // heuristic `function_calls` edges and `candidate_edges` (Lane 2)
+        // references. A candidate-ONLY callee has `total == 0` and
+        // `candidate_total > 0`; render only the populations that are present so
+        // the reason never claims "0 heuristic edge(s)".
+        let mut parts: Vec<String> = Vec::new();
+        if info.total > 0 {
+            let kinds = info
+                .kind_counts
+                .iter()
+                .map(|(kind, n)| format!("{kind}×{n}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            parts.push(format!("{} heuristic edge(s) [{}]", info.total, kinds));
+        }
+        if info.candidate_total > 0 {
+            let kinds = info
+                .candidate_counts
+                .iter()
+                .map(|(kind, n)| format!("{kind}×{n}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            parts.push(format!(
+                "{} candidate edge(s) [{}]",
+                info.candidate_total, kinds
+            ));
+        }
+        let detail = if parts.is_empty() {
+            // Defensive: the name is in the map only when one population is
+            // nonzero, so this is unreachable in practice.
+            "heuristic/candidate evidence".to_string()
+        } else {
+            parts.join("; ")
+        };
         return (
             DeadVerdict::LowConfidenceLive,
-            format!(
-                "no trusted caller; reached only by {} heuristic edge(s) [{}]",
-                info.total, kinds
-            ),
+            format!("no trusted caller; reached only by {detail}"),
         );
     }
     if let Some(reason) = known_gap_reason(entry) {
@@ -648,6 +672,28 @@ mod tests {
             cqs::store::LowConfidenceLiveInfo {
                 total: 1,
                 kind_counts: vec![("macro_heuristic".to_string(), 1)],
+                candidate_total: 0,
+                candidate_counts: vec![],
+            },
+        );
+        m
+    }
+
+    /// Low-confidence map with one CANDIDATE-ONLY callee `name`: zero heuristic
+    /// `function_calls` edges, one `candidate_edges` (Lane 2) reference of
+    /// `kind`. Models the candidate-edge campaign Lane-3 flip.
+    fn candidate_only_low_conf(
+        name: &str,
+        kind: &str,
+    ) -> std::collections::HashMap<String, cqs::store::LowConfidenceLiveInfo> {
+        let mut m = std::collections::HashMap::new();
+        m.insert(
+            name.to_string(),
+            cqs::store::LowConfidenceLiveInfo {
+                total: 0,
+                kind_counts: vec![],
+                candidate_total: 1,
+                candidate_counts: vec![(kind.to_string(), 1)],
             },
         );
         m
@@ -722,6 +768,47 @@ mod tests {
         assert!(
             reason.contains("macro_heuristic") && reason.contains("heuristic edge"),
             "reason should name heuristic kinds: {reason}"
+        );
+    }
+
+    /// A candidate-ONLY callee (zero heuristic `function_calls` edges, present
+    /// only in `candidate_edges`) classifies `low-confidence-live`, and the
+    /// reason names the candidate kind/count — NOT a generic "0 heuristic
+    /// edge(s)" claim. Calibration: an empty `low_conf` map would classify the
+    /// same entry `dead` (see `verdict_dead_residue`), so the consult is what
+    /// flips the verdict.
+    #[test]
+    fn verdict_candidate_only_callee_is_low_confidence_live() {
+        let f = dead_fn(
+            "maybe_fn",
+            "src/lib.rs",
+            cqs::parser::Language::Rust,
+            "fn maybe_fn() {}",
+        );
+        let (v, reason) = classify_verdict(
+            &f,
+            &candidate_only_low_conf("maybe_fn", "bare_arg_unresolved"),
+        );
+        assert_eq!(
+            v,
+            DeadVerdict::LowConfidenceLive,
+            "candidate-only callee must be low-confidence-live, not dead"
+        );
+        assert!(
+            reason.contains("candidate edge") && reason.contains("bare_arg_unresolved"),
+            "reason must name the candidate kind/count, not a generic heuristic claim: {reason}"
+        );
+        assert!(
+            !reason.contains("heuristic edge"),
+            "candidate-only reason must NOT claim heuristic edges (it has zero): {reason}"
+        );
+
+        // Calibration: the SAME entry with an empty map is `dead`.
+        let (v_dead, _) = classify_verdict(&f, &no_low_conf());
+        assert_eq!(
+            v_dead,
+            DeadVerdict::Dead,
+            "without the candidate consult, the same entry would be dead"
         );
     }
 

--- a/src/cli/commands/review/dead.rs
+++ b/src/cli/commands/review/dead.rs
@@ -167,46 +167,63 @@ fn classify_verdict(
             "origin under tests/ path or content contains '#[cfg(test)]'".to_string(),
         );
     }
-    if let Some(info) = low_conf.get(&entry.chunk.name) {
-        // Name the exact provenance and counts rather than asserting "all
-        // callers are heuristic" generically. Two populations may contribute:
-        // heuristic `function_calls` edges and `candidate_edges` (Lane 2)
-        // references. A candidate-ONLY callee has `total == 0` and
-        // `candidate_total > 0`; render only the populations that are present so
-        // the reason never claims "0 heuristic edge(s)".
-        let mut parts: Vec<String> = Vec::new();
-        if info.total > 0 {
-            let kinds = info
-                .kind_counts
-                .iter()
-                .map(|(kind, n)| format!("{kind}×{n}"))
-                .collect::<Vec<_>>()
-                .join(", ");
-            parts.push(format!("{} heuristic edge(s) [{}]", info.total, kinds));
+    // Direction-B overlay additions were computed dead over the authoritative
+    // merged (parent+overlay) caller graph in this worktree — they ARE dead
+    // here. The `low_conf` map is parent-graph-derived and stale under the
+    // overlay, so consulting it would relabel a genuinely-worktree-dead function
+    // `low-confidence-live` whenever its bare name collides with a parent
+    // heuristic/candidate name, hiding it from `--verdict dead`. Skip the
+    // parent-truth relabel for these; the remaining tiers (known-gap, dead) are
+    // name/path/content-derived and stay valid under the overlay.
+    //
+    // This also classifies a candidate-only addition `dead` rather than
+    // `low-confidence-live` — intentional: `candidate_edges` is parent-truth
+    // (never recomputed over the overlay), so trusting it to override the
+    // authoritative merged-`function_calls` verdict would itself be a stale
+    // claim, and the error direction (surface a possibly-dead fn vs. hide a
+    // genuinely-dead one) is the safe one for `cqs dead`.
+    if !entry.overlay_dead {
+        if let Some(info) = low_conf.get(&entry.chunk.name) {
+            // Name the exact provenance and counts rather than asserting "all
+            // callers are heuristic" generically. Two populations may contribute:
+            // heuristic `function_calls` edges and `candidate_edges` (Lane 2)
+            // references. A candidate-ONLY callee has `total == 0` and
+            // `candidate_total > 0`; render only the populations that are present so
+            // the reason never claims "0 heuristic edge(s)".
+            let mut parts: Vec<String> = Vec::new();
+            if info.total > 0 {
+                let kinds = info
+                    .kind_counts
+                    .iter()
+                    .map(|(kind, n)| format!("{kind}×{n}"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                parts.push(format!("{} heuristic edge(s) [{}]", info.total, kinds));
+            }
+            if info.candidate_total > 0 {
+                let kinds = info
+                    .candidate_counts
+                    .iter()
+                    .map(|(kind, n)| format!("{kind}×{n}"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                parts.push(format!(
+                    "{} candidate edge(s) [{}]",
+                    info.candidate_total, kinds
+                ));
+            }
+            let detail = if parts.is_empty() {
+                // Defensive: the name is in the map only when one population is
+                // nonzero, so this is unreachable in practice.
+                "heuristic/candidate evidence".to_string()
+            } else {
+                parts.join("; ")
+            };
+            return (
+                DeadVerdict::LowConfidenceLive,
+                format!("no trusted caller; reached only by {detail}"),
+            );
         }
-        if info.candidate_total > 0 {
-            let kinds = info
-                .candidate_counts
-                .iter()
-                .map(|(kind, n)| format!("{kind}×{n}"))
-                .collect::<Vec<_>>()
-                .join(", ");
-            parts.push(format!(
-                "{} candidate edge(s) [{}]",
-                info.candidate_total, kinds
-            ));
-        }
-        let detail = if parts.is_empty() {
-            // Defensive: the name is in the map only when one population is
-            // nonzero, so this is unreachable in practice.
-            "heuristic/candidate evidence".to_string()
-        } else {
-            parts.join("; ")
-        };
-        return (
-            DeadVerdict::LowConfidenceLive,
-            format!("no trusted caller; reached only by {detail}"),
-        );
     }
     if let Some(reason) = known_gap_reason(entry) {
         return (DeadVerdict::KnownGap, reason.to_string());
@@ -727,6 +744,7 @@ mod tests {
                 vendored: false,
             },
             confidence: DeadConfidence::High,
+            overlay_dead: false,
         }
     }
 
@@ -809,6 +827,98 @@ mod tests {
             v_dead,
             DeadVerdict::Dead,
             "without the candidate consult, the same entry would be dead"
+        );
+    }
+
+    /// Seam guard (overlay × verdict-classification): a Direction-B overlay
+    /// addition (`overlay_dead = true`) is computed dead over the authoritative
+    /// merged graph in this worktree, so it must classify `dead` EVEN when its
+    /// name collides with an entry in the parent-truth `low_conf` map — the map
+    /// is parent-graph-derived and stale under the overlay. The candidate
+    /// consult (Lane 3) widened that map to candidate-only bare names, making
+    /// this collision likely. Calibration: the SAME `low_conf` map applied to
+    /// the SAME name with `overlay_dead = false` (a parent entry) yields
+    /// `low-confidence-live` — see `verdict_candidate_only_callee_is_low_…`,
+    /// which is exactly this scenario minus the overlay flag. So the flag, not
+    /// the map, is what flips the verdict; without the bypass the addition would
+    /// be relabeled `low-confidence-live` and filtered out of `--verdict dead`.
+    #[test]
+    fn verdict_overlay_dead_bypasses_parent_low_conf_relabel() {
+        let mut f = dead_fn(
+            "foo",
+            "src/lib.rs",
+            cqs::parser::Language::Rust,
+            "fn foo() {}",
+        );
+        // Calibration RED: the parent-entry form (overlay_dead = false) collides
+        // with the parent candidate map → low-confidence-live (the bug).
+        let (v_parent, _) =
+            classify_verdict(&f, &candidate_only_low_conf("foo", "bare_arg_unresolved"));
+        assert_eq!(
+            v_parent,
+            DeadVerdict::LowConfidenceLive,
+            "calibration: a PARENT entry whose name is in the candidate map is low-confidence-live"
+        );
+
+        // GREEN: mark it a Direction-B overlay addition → it must classify `dead`
+        // despite the identical colliding `low_conf` map.
+        f.overlay_dead = true;
+        let (v, reason) =
+            classify_verdict(&f, &candidate_only_low_conf("foo", "bare_arg_unresolved"));
+        assert_eq!(
+            v,
+            DeadVerdict::Dead,
+            "an overlay-dead addition must classify `dead`, NOT be relabeled by the stale \
+             parent low_conf map (or it is filtered out of `--verdict dead`)"
+        );
+        assert!(
+            reason.contains("no callers"),
+            "overlay-dead reason must be the plain dead reason, not a low-conf relabel: {reason}"
+        );
+    }
+
+    /// The overlay-dead bypass is scoped to the parent-truth `low_conf` relabel
+    /// only: a Direction-B addition that is GENUINELY test-only (origin under
+    /// `tests/`) still classifies `test-only`, and a known-gap origin still
+    /// classifies `known-gap`. Those tiers are name/path/content-derived and stay
+    /// valid under the overlay — only the parent-graph-derived `low_conf` map is
+    /// stale, so only it is bypassed.
+    #[test]
+    fn verdict_overlay_dead_still_honors_test_only_and_known_gap() {
+        // test-only: origin under tests/ → TestOnly even when overlay_dead.
+        let mut t = dead_fn(
+            "helper",
+            "tests/support.rs",
+            cqs::parser::Language::Rust,
+            "fn helper() {}",
+        );
+        t.overlay_dead = true;
+        let (vt, _) = classify_verdict(
+            &t,
+            &candidate_only_low_conf("helper", "bare_arg_unresolved"),
+        );
+        assert_eq!(
+            vt,
+            DeadVerdict::TestOnly,
+            "an overlay-dead test-helper must stay test-only (bypass is scoped to low_conf)"
+        );
+
+        // known-gap: a served-asset JS handler → KnownGap even when overlay_dead.
+        let mut k = dead_fn(
+            "onClick",
+            "src/serve/assets/app.js",
+            cqs::parser::Language::JavaScript,
+            "function onClick() {}",
+        );
+        k.overlay_dead = true;
+        let (vk, _) = classify_verdict(
+            &k,
+            &candidate_only_low_conf("onClick", "bare_arg_unresolved"),
+        );
+        assert_eq!(
+            vk,
+            DeadVerdict::KnownGap,
+            "an overlay-dead served-asset handler must stay known-gap (bypass is scoped to low_conf)"
         );
     }
 

--- a/src/store/calls/crud.rs
+++ b/src/store/calls/crud.rs
@@ -306,6 +306,31 @@ impl Store<ReadWrite> {
         })
     }
 
+    /// Insert the file's low-confidence `candidate_edges` (Lane 2), wholesale.
+    ///
+    /// Symmetric sibling of [`Store::upsert_function_calls`]: refreshes one
+    /// file's candidate set (DELETE WHERE file = ? then INSERT the current rows)
+    /// in its own transaction. `file` is normalized once at the call site so the
+    /// DELETE scope and the inserted rows' `file` column cannot disagree.
+    /// Candidates are a SEPARATE table never joined by a graph query, so writing
+    /// here can never pollute the caller graph; they feed only the `cqs dead`
+    /// low-confidence-live consult.
+    pub fn upsert_candidate_edges(
+        &self,
+        file: &Path,
+        candidates: &[crate::parser::CandidateSite],
+    ) -> Result<(), StoreError> {
+        let _span =
+            tracing::info_span!("upsert_candidate_edges", count = candidates.len()).entered();
+        let file_str = crate::normalize_path(file);
+        self.rt.block_on(async {
+            let (_guard, mut tx) = self.begin_write().await?;
+            write_candidate_edges_in_tx(&mut tx, &file_str, candidates).await?;
+            tx.commit().await?;
+            Ok(())
+        })
+    }
+
     /// Insert function calls for multiple files in a single transaction.
     ///
     /// Mirrors the `upsert_type_edges_for_files` pattern. Calling

--- a/src/store/calls/dead_code.rs
+++ b/src/store/calls/dead_code.rs
@@ -882,7 +882,13 @@ impl<Mode> Store<Mode> {
 
             let chunk = ChunkSummary::from(ChunkRow::from_light_chunk(light, content, doc));
 
-            let dead_fn = DeadFunction { chunk, confidence };
+            let dead_fn = DeadFunction {
+                chunk,
+                confidence,
+                // Parent-set entry, not an overlay recompute — verdict
+                // classification keeps the full ordered tiers (incl. low_conf).
+                overlay_dead: false,
+            };
 
             if is_pub && !include_pub {
                 possibly_dead_pub.push(dead_fn);
@@ -1039,9 +1045,13 @@ pub fn apply_dead_overlay<M>(
 
         // Newly dead. `Medium` is the honest floor — the file-activity recompute
         // `score_confidence` runs for the parent set is not re-run here.
+        // `overlay_dead`: computed dead over the authoritative merged graph in
+        // this worktree, so verdict classification must not relabel it via the
+        // parent-truth `low_conf` map (stale under the overlay).
         let dead_fn = DeadFunction {
             chunk: def,
             confidence: DeadConfidence::Medium,
+            overlay_dead: true,
         };
         if dead_fn.confidence < min_confidence {
             continue;

--- a/src/store/calls/dead_code.rs
+++ b/src/store/calls/dead_code.rs
@@ -212,15 +212,23 @@ impl<Mode> Store<Mode> {
     /// (not heuristic) nor disqualifies (not trusted) a callee, so a function
     /// reached only by a doc reference plus a macro edge still surfaces.
     ///
-    /// This returns the heuristic-caller BREAKDOWN (kind + count per callee)
-    /// used to render the `low-confidence-live` verdict reason string. The
-    /// matching CHUNK population is fetched by
-    /// [`Store::find_low_confidence_live_functions`] (same heuristic-only
-    /// predicate) and unioned into the `cqs dead` report by `dead_core`;
-    /// `fetch_uncalled_functions` holds the disjoint strict zero-edge contract,
-    /// so the two populations never overlap. The kind-sets are generated from
-    /// `CallEdgeKind` rather than a lexical comparison, so a new kind cannot
-    /// drift out of sync.
+    /// This returns the low-confidence-live BREAKDOWN (kind + count per callee)
+    /// used to render the `low-confidence-live` verdict reason string. It folds
+    /// TWO populations into the same map, both restricted to callees with NO
+    /// trusted `function_calls` edge:
+    /// * heuristic `function_calls` edges (`macro_heuristic` / `fn_pointer`) →
+    ///   `total` + `kind_counts`,
+    /// * `candidate_edges` (Lane 2) references → `candidate_total` +
+    ///   `candidate_counts`.
+    ///
+    /// The matching CHUNK population is fetched by
+    /// [`Store::find_low_confidence_live_functions`] (same predicate) and unioned
+    /// into the `cqs dead` report by `dead_core`; `fetch_uncalled_functions`
+    /// holds the disjoint strict zero-evidence contract, so the two populations
+    /// never overlap. The `function_calls` kind-sets are generated from
+    /// `CallEdgeKind` rather than a lexical comparison, so a new edge kind cannot
+    /// drift out of sync; candidate kinds are reported transparently from the
+    /// side-table rows so a new Lane-2 kind surfaces with no query change.
     pub fn find_low_confidence_live_names(
         &self,
     ) -> Result<std::collections::HashMap<String, LowConfidenceLiveInfo>, StoreError> {
@@ -231,7 +239,7 @@ impl<Mode> Store<Mode> {
         // trusted edge. Grouping by kind too lets the verdict reason name the
         // heuristic kinds and their counts. The outer trusted-edge exclusion is
         // applied per callee via the windowed SUM in the HAVING-style subquery.
-        let sql = format!(
+        let heuristic_sql = format!(
             "SELECT callee_name, edge_kind, COUNT(*) AS n
              FROM function_calls
              WHERE edge_kind IN ({heuristic})
@@ -242,21 +250,52 @@ impl<Mode> Store<Mode> {
                )
              GROUP BY callee_name, edge_kind"
         );
+        // Per (callee, candidate kind) count over the `candidate_edges`
+        // side-table (Lane 2), restricted to callees with NO trusted
+        // `function_calls` edge. A callee that already has a trusted edge is
+        // genuinely live and must NOT be relabeled low-confidence-live, so the
+        // same trusted-exclusion subquery gates the candidate counts. A
+        // candidate-only callee has zero `function_calls` rows, so the
+        // `NOT EXISTS` (rather than the heuristic query's `IN` over a
+        // function_calls-derived set) is what admits it.
+        let candidate_sql = format!(
+            "SELECT callee_name, candidate_kind, COUNT(*) AS n
+             FROM candidate_edges ce
+             WHERE NOT EXISTS (
+                   SELECT 1 FROM function_calls fc
+                   WHERE fc.callee_name = ce.callee_name
+                     AND fc.edge_kind IN ({trusted}) LIMIT 1
+               )
+             GROUP BY callee_name, candidate_kind"
+        );
         self.rt.block_on(async {
-            let rows: Vec<(String, String, i64)> =
-                sqlx::query_as(sqlx::AssertSqlSafe(sql.as_str()))
-                    .fetch_all(&self.pool)
-                    .await?;
             let mut out: std::collections::HashMap<String, LowConfidenceLiveInfo> =
                 std::collections::HashMap::new();
-            for (name, kind, n) in rows {
+
+            let heuristic_rows: Vec<(String, String, i64)> =
+                sqlx::query_as(sqlx::AssertSqlSafe(heuristic_sql.as_str()))
+                    .fetch_all(&self.pool)
+                    .await?;
+            for (name, kind, n) in heuristic_rows {
                 let info = out.entry(name).or_default();
                 info.total += n.max(0) as u64;
                 info.kind_counts.push((kind, n.max(0) as u64));
             }
+
+            let candidate_rows: Vec<(String, String, i64)> =
+                sqlx::query_as(sqlx::AssertSqlSafe(candidate_sql.as_str()))
+                    .fetch_all(&self.pool)
+                    .await?;
+            for (name, kind, n) in candidate_rows {
+                let info = out.entry(name).or_default();
+                info.candidate_total += n.max(0) as u64;
+                info.candidate_counts.push((kind, n.max(0) as u64));
+            }
+
             // Stable kind order for deterministic reason strings.
             for info in out.values_mut() {
                 info.kind_counts.sort();
+                info.candidate_counts.sort();
             }
             Ok(out)
         })
@@ -295,6 +334,16 @@ impl<Mode> Store<Mode> {
         // via `fetch_heuristic_only_callees` and relabels it
         // `low-confidence-live` — an additive overlay on the `dead` surface only,
         // never a mutation of this shared candidate set.
+        //
+        // A `candidate_edges` (Lane 2) reference is also NOT real death: a bare
+        // fn-pointer / macro arg or a serde container/with-module linkage that
+        // the confident extractor declined to resolve into a `function_calls`
+        // edge still points at this function. So a callee PRESENT in
+        // `candidate_edges` is excluded here (it is low-confidence-live, surfaced
+        // by `fetch_heuristic_only_callees`) — the truly-dead set requires zero
+        // real `function_calls` edges AND zero candidate references. This keeps
+        // truly-dead and low-confidence-live DISJOINT with candidates added: a
+        // candidate-only callee leaves this set and enters the other.
         let real_callers = crate::parser::CallEdgeKind::real_caller_kinds_sql();
         let sql = format!(
             "SELECT c.id, c.origin, c.language, c.chunk_type, c.name, c.signature,
@@ -306,21 +355,33 @@ impl<Mode> Store<Mode> {
                AND NOT EXISTS (SELECT 1 FROM function_calls fc \
                                WHERE fc.callee_name = c.name \
                                  AND fc.edge_kind IN ({real_callers}) LIMIT 1)
+               AND NOT EXISTS (SELECT 1 FROM candidate_edges ce \
+                               WHERE ce.callee_name = c.name LIMIT 1)
                AND c.parent_id IS NULL
              ORDER BY c.origin, c.line_start"
         );
         Self::light_chunks_from_query(&sql, &self.pool).await
     }
 
-    /// Phase 1 (low-confidence-live): query callable chunks reached by ≥1
-    /// heuristic edge (`macro_heuristic`, `fn_pointer`) and NO trusted edge
-    /// (`call`, `serde_callback`). Same Tier-1 noise filters as
+    /// Phase 1 (low-confidence-live): query callable chunks that have NO trusted
+    /// edge (`call`, `serde_callback`) and at least one of: a heuristic
+    /// `function_calls` edge (`macro_heuristic` / `fn_pointer`), OR a
+    /// `candidate_edges` (Lane 2) reference. A candidate-ONLY callee — zero
+    /// `function_calls` edges, present only in the side-table — enters here via
+    /// the candidate `EXISTS` arm. Same Tier-1 noise filters as
     /// `fetch_uncalled_functions` (Property exclusion, doc-path exclusion,
     /// top-level only). The heuristic and trusted kind-sets are generated from
     /// `CallEdgeKind` (single source), so a new edge kind updates both surfaces
     /// at once. `doc_reference` edges are inert: they neither qualify (not
     /// heuristic) nor disqualify (not trusted), matching
     /// [`Store::find_low_confidence_live_names`].
+    ///
+    /// Disjointness with `fetch_uncalled_functions` (truly-dead) is preserved
+    /// with candidates added: truly-dead requires zero real `function_calls`
+    /// edges AND zero candidate references; this set requires (heuristic edge OR
+    /// candidate) AND zero trusted edge. The two predicates are mutually
+    /// exclusive — a callee with any candidate is excluded from truly-dead and
+    /// admitted here, with no overlap.
     async fn fetch_heuristic_only_callees(&self) -> Result<Vec<LightChunk>, StoreError> {
         let callable = ChunkType::callable_sql_list();
         let doc_path_excludes = dead_doc_path_excludes_sql();
@@ -333,9 +394,11 @@ impl<Mode> Store<Mode> {
              WHERE c.chunk_type IN ({callable})
                AND c.chunk_type != 'property'
                {doc_path_excludes}
-               AND EXISTS (SELECT 1 FROM function_calls fc \
-                           WHERE fc.callee_name = c.name \
-                             AND fc.edge_kind IN ({heuristic}) LIMIT 1)
+               AND (EXISTS (SELECT 1 FROM function_calls fc \
+                            WHERE fc.callee_name = c.name \
+                              AND fc.edge_kind IN ({heuristic}) LIMIT 1)
+                    OR EXISTS (SELECT 1 FROM candidate_edges ce \
+                               WHERE ce.callee_name = c.name LIMIT 1))
                AND NOT EXISTS (SELECT 1 FROM function_calls fc \
                                WHERE fc.callee_name = c.name \
                                  AND fc.edge_kind IN ({trusted}) LIMIT 1)
@@ -514,23 +577,45 @@ impl<Mode> Store<Mode> {
         Ok(filtered)
     }
 
-    /// Phase 1.6: drop Rust functions that are referenced only as serde
-    /// string callbacks. serde's derive macros accept function paths as
-    /// attribute string literals:
+    /// Phase 1.6: drop Rust functions referenced only by the serde-callback keys
+    /// the parser's confident pass and Lane-2 candidate emit do NOT cover —
+    /// `skip_serializing` / `skip_deserializing`, plus `with = "..."`. serde's
+    /// derive macros accept function paths as attribute string literals:
     ///
     /// ```ignore
-    /// #[serde(default = "default_ref_weight")]
-    /// #[serde(skip_serializing_if = "is_zero_u32")]
-    /// #[serde(serialize_with = "crate::serialize_path_normalized")]
+    /// #[serde(skip_serializing = "is_zero_u32")]
+    /// #[serde(skip_deserializing = "always_zero")]
     /// #[serde(with = "some::module")]
     /// ```
+    ///
+    /// **Retirement (candidate-edge campaign Lane 3).** This pass was the sole
+    /// backstop for every serde-callback key. Now that the parser emits
+    /// `function_calls` edges (FIELD-level `default` / `serialize_with` /
+    /// `deserialize_with` / `skip_serializing_if` / `getter` / `with` → a
+    /// `serde_callback` edge) AND `candidate_edges` (CONTAINER-level callbacks →
+    /// `serde_container`; `with = "module"` inner fns → `serde_with_module`),
+    /// and `fetch_uncalled_functions` excludes any callee present in
+    /// `candidate_edges`, those callbacks never reach this filter — their callee
+    /// is gone from the dead-candidate list before Phase 1.6 runs. So those keys
+    /// were RETIRED from the regex below.
+    ///
+    /// **What remains, and why (no dead-code coverage lost):**
+    /// - `skip_serializing` / `skip_deserializing` — NOT in the parser's
+    ///   `SERDE_CALLBACK_RE`, so neither the confident pass nor the candidate
+    ///   pass emits anything for them. This filter is their only keep-alive.
+    /// - `with` — retained as a deliberate same-name keep: a `with = "module"`
+    ///   linkage whose terminal segment (`module`) happens to also be a real
+    ///   function name in the corpus stays live here even on a path/index state
+    ///   where the per-file candidate emit did not record it. The confident pass
+    ///   already keeps the field-level case; this preserves the corpus-wide
+    ///   backstop for the terminal-name match.
     ///
     /// The derived (de)serializer calls these at runtime, but the reference
     /// lives in an attribute string the call-graph walker never resolves into
     /// an edge. So the callbacks look uncalled. This pass scans every chunk's
-    /// content for serde-shaped attribute strings, extracts the terminal path
-    /// segment of each (`crate::a::b::f` → `f`), and drops any Rust function
-    /// candidate whose name matches.
+    /// content for the remaining serde-shaped attribute strings, extracts the
+    /// terminal path segment of each (`crate::a::b::f` → `f`), and drops any Rust
+    /// function candidate whose name matches.
     ///
     /// Contract details (mirrors `filter_invoked_macros`):
     /// - **Functions only.** serde callbacks are free functions / associated
@@ -571,15 +656,21 @@ impl<Mode> Store<Mode> {
             return Ok(candidates);
         }
 
-        // Matches serde-shaped callback attributes and captures the quoted
-        // path: `default = "..."`, `with = "..."`, `serialize_with = "..."`,
-        // `deserialize_with = "..."`, `skip_serializing_if = "..."`,
-        // `bound = "..."` is excluded (it names types/where-clauses, not fns).
+        // Matches ONLY the serde-callback keys the parser emit does not cover
+        // (the rest were retired in Lane 3 — see this fn's doc comment):
+        // `skip_serializing = "..."`, `skip_deserializing = "..."`, and
+        // `with = "..."` (the corpus-wide same-name backstop). `default` /
+        // `serialize_with` / `deserialize_with` / `skip_serializing_if` /
+        // `getter` are now covered by confident `serde_callback` edges +
+        // `serde_container` candidates, so they are intentionally absent.
+        // `skip_serializing_if` must NOT be re-added: it shares a prefix with
+        // `skip_serializing`, but the `\s*=` anchor keeps them disjoint (a
+        // `skip_serializing_if = "x"` has `_if` between the key and `=`, so it
+        // never matches the bare `skip_serializing` alternative). `bound = "..."`
+        // stays excluded (it names types/where-clauses, not fns).
         static SERDE_CALLBACK_RE: LazyLock<Regex> = LazyLock::new(|| {
-            Regex::new(
-                r#"(?:default|with|serialize_with|deserialize_with|skip_serializing_if|skip_serializing|skip_deserializing|getter)\s*=\s*"([^"]+)""#,
-            )
-            .expect("hardcoded serde-callback regex")
+            Regex::new(r#"(?:with|skip_serializing|skip_deserializing)\s*=\s*"([^"]+)""#)
+                .expect("hardcoded serde-callback regex")
         });
 
         let mut dropped: std::collections::HashSet<usize> = std::collections::HashSet::new();
@@ -1530,16 +1621,43 @@ mod tests {
         }
     }
 
-    /// A function referenced only via `#[serde(default = "name")]` is reached
-    /// by the derive-generated deserializer, not a syntactic call. It must be
-    /// dropped from dead candidates when another chunk's content names it in a
-    /// serde attribute.
+    /// Helper: seed a confident `serde_callback` `function_calls` edge naming
+    /// `callee` (terminal segment), as the parser's `extract_serde_callback_calls`
+    /// pass emits for a FIELD-level serde callback. This is the post-Lane-3
+    /// keep-alive mechanism for `default` / `serialize_with` / `deserialize_with`
+    /// / `skip_serializing_if` / `getter` — they were retired from
+    /// `filter_serde_callbacks` because the parser now records them as edges.
+    fn seed_serde_callback_edge(
+        store: &Store<crate::store::ReadWrite>,
+        caller_file: &str,
+        callee: &str,
+    ) {
+        use crate::parser::{CallEdgeKind, CallSite, FunctionCalls};
+        store
+            .upsert_function_calls(
+                std::path::Path::new(caller_file),
+                &[FunctionCalls {
+                    name: "__serde_derive__".to_string(),
+                    line_start: 1,
+                    calls: vec![CallSite {
+                        callee_name: callee.to_string(),
+                        line_number: 1,
+                        kind: CallEdgeKind::SerdeCallback,
+                    }],
+                }],
+            )
+            .unwrap();
+    }
+
+    /// FIELD-level `#[serde(default = "name")]` is kept live by the parser's
+    /// confident `serde_callback` edge (a trusted real-caller), NOT by
+    /// `filter_serde_callbacks` — `default` was retired from the filter in
+    /// Lane 3. Seeding that edge keeps the callback out of the dead set.
     #[test]
-    fn test_serde_default_callback_dropped_from_dead() {
+    fn test_serde_default_callback_kept_live_by_edge() {
         let (store, _dir) = setup_store();
         let emb = crate::embedder::Embedding::new(vec![0.0; crate::EMBEDDING_DIM]);
 
-        // The callback function — never called with `()`.
         let cb = rust_fn_chunk(
             "src/config.rs:1",
             "src/config.rs",
@@ -1547,16 +1665,9 @@ mod tests {
             "fn default_ref_weight() -> f32 { 1.0 }",
         );
         store.upsert_chunk(&cb, &emb, Some(1)).unwrap();
-
-        // A struct chunk whose field references it via serde attribute.
-        let user = rust_fn_chunk(
-            "src/config.rs:10",
-            "src/config.rs",
-            "RefConfig",
-            "#[derive(serde::Deserialize)] struct RefConfig { \
-             #[serde(default = \"default_ref_weight\")] weight: f32 }",
-        );
-        store.upsert_chunk(&user, &emb, Some(1)).unwrap();
+        // The confident pass would emit this serde_callback edge for the
+        // field-level `#[serde(default = "default_ref_weight")]`.
+        seed_serde_callback_edge(&store, "src/config.rs", "default_ref_weight");
 
         let (confident, possibly_pub) = store.find_dead_code(true).unwrap();
         let names: Vec<&str> = confident
@@ -1566,14 +1677,16 @@ mod tests {
             .collect();
         assert!(
             !names.contains(&"default_ref_weight"),
-            "serde default callback must be filtered from dead candidates: {names:?}"
+            "field-level serde default callback must stay live via the \
+             serde_callback edge (filter coverage retired in Lane 3): {names:?}"
         );
     }
 
-    /// `skip_serializing_if = "is_zero_u32"` is a predicate callback. Same
-    /// contract as `default`.
+    /// FIELD-level `skip_serializing_if = "is_zero_u32"` is a predicate callback,
+    /// kept live by the confident `serde_callback` edge (retired from the filter
+    /// in Lane 3).
     #[test]
-    fn test_serde_skip_serializing_if_callback_dropped() {
+    fn test_serde_skip_serializing_if_callback_kept_live_by_edge() {
         let (store, _dir) = setup_store();
         let emb = crate::embedder::Embedding::new(vec![0.0; crate::EMBEDDING_DIM]);
 
@@ -1584,15 +1697,7 @@ mod tests {
             "fn is_zero_u32(v: &u32) -> bool { *v == 0 }",
         );
         store.upsert_chunk(&cb, &emb, Some(1)).unwrap();
-
-        let user = rust_fn_chunk(
-            "src/model.rs:5",
-            "src/model.rs",
-            "Model",
-            "#[derive(serde::Serialize)] struct Model { \
-             #[serde(skip_serializing_if = \"is_zero_u32\")] count: u32 }",
-        );
-        store.upsert_chunk(&user, &emb, Some(1)).unwrap();
+        seed_serde_callback_edge(&store, "src/model.rs", "is_zero_u32");
 
         let (confident, possibly_pub) = store.find_dead_code(true).unwrap();
         let names: Vec<&str> = confident
@@ -1602,15 +1707,17 @@ mod tests {
             .collect();
         assert!(
             !names.contains(&"is_zero_u32"),
-            "serde skip_serializing_if callback must be filtered: {names:?}"
+            "field-level serde skip_serializing_if callback must stay live via \
+             the serde_callback edge (filter coverage retired in Lane 3): {names:?}"
         );
     }
 
-    /// Path-qualified callbacks (`serialize_with = "crate::a::b::f"`) resolve
-    /// to a function keyed by its bare terminal segment. The filter must match
-    /// on `f`, not the full path.
+    /// Path-qualified `serialize_with = "crate::a::b::f"` resolves to the bare
+    /// terminal segment `f` — the parser's confident pass emits a `serde_callback`
+    /// edge keyed by the terminal segment, keeping `f` live (retired from the
+    /// filter in Lane 3).
     #[test]
-    fn test_serde_path_qualified_callback_matches_terminal_segment() {
+    fn test_serde_path_qualified_callback_kept_live_by_terminal_edge() {
         let (store, _dir) = setup_store();
         let emb = crate::embedder::Embedding::new(vec![0.0; crate::EMBEDDING_DIM]);
 
@@ -1621,13 +1728,99 @@ mod tests {
             "pub fn serialize_path_normalized() {}",
         );
         store.upsert_chunk(&cb, &emb, Some(1)).unwrap();
+        // The confident pass keys the edge by the terminal segment.
+        seed_serde_callback_edge(&store, "src/ref.rs", "serialize_path_normalized");
 
+        let (confident, possibly_pub) = store.find_dead_code(true).unwrap();
+        let names: Vec<&str> = confident
+            .iter()
+            .chain(possibly_pub.iter())
+            .map(|d| d.chunk.name.as_str())
+            .collect();
+        assert!(
+            !names.contains(&"serialize_path_normalized"),
+            "path-qualified serde callback must stay live via the terminal-keyed \
+             serde_callback edge (filter coverage retired in Lane 3): {names:?}"
+        );
+    }
+
+    /// CONTAINER-level serde callbacks are now kept live by a `serde_container`
+    /// `candidate_edges` row (Lane 2 emit), relabeling the callback
+    /// `low-confidence-live` instead of leaving it for the filter. Retiring the
+    /// container-level keys from `filter_serde_callbacks` loses no coverage.
+    #[test]
+    fn test_serde_container_callback_kept_live_by_candidate() {
+        use crate::parser::CandidateSite;
+        let (store, _dir) = setup_store();
+        let emb = crate::embedder::Embedding::new(vec![0.0; crate::EMBEDDING_DIM]);
+
+        let cb = rust_fn_chunk(
+            "src/cfg.rs:1",
+            "src/cfg.rs",
+            "container_default",
+            "fn container_default() {}",
+        );
+        store.upsert_chunk(&cb, &emb, Some(1)).unwrap();
+        // The Lane-2 emit records the container-level callback as a candidate.
+        store
+            .upsert_candidate_edges(
+                std::path::Path::new("src/cfg.rs"),
+                &[CandidateSite {
+                    file: std::path::PathBuf::from("src/cfg.rs"),
+                    callee_name: "container_default".to_string(),
+                    ref_line: 1,
+                    candidate_kind: "serde_container".to_string(),
+                }],
+            )
+            .unwrap();
+
+        // Truly-dead set excludes it; low-confidence-live set includes it.
+        let (confident, possibly_pub) = store.find_dead_code(true).unwrap();
+        let dead_names: Vec<&str> = confident
+            .iter()
+            .chain(possibly_pub.iter())
+            .map(|d| d.chunk.name.as_str())
+            .collect();
+        assert!(
+            !dead_names.contains(&"container_default"),
+            "container-level serde callback must leave the truly-dead set via the \
+             serde_container candidate: {dead_names:?}"
+        );
+        let (low, low_pub) = store.find_low_confidence_live_functions(true).unwrap();
+        let low_names: Vec<&str> = low
+            .iter()
+            .chain(low_pub.iter())
+            .map(|d| d.chunk.name.as_str())
+            .collect();
+        assert!(
+            low_names.contains(&"container_default"),
+            "container-level serde callback must enter low-confidence-live: {low_names:?}"
+        );
+    }
+
+    /// `skip_serializing` / `skip_deserializing` are NOT emitted by the parser
+    /// (absent from its `SERDE_CALLBACK_RE`), so `filter_serde_callbacks` is
+    /// still their only keep-alive — these keys were KEPT in the filter regex.
+    #[test]
+    fn test_serde_skip_serializing_still_filtered() {
+        let (store, _dir) = setup_store();
+        let emb = crate::embedder::Embedding::new(vec![0.0; crate::EMBEDDING_DIM]);
+
+        let cb = rust_fn_chunk(
+            "src/h.rs:1",
+            "src/h.rs",
+            "skip_predicate",
+            "fn skip_predicate() -> bool { true }",
+        );
+        store.upsert_chunk(&cb, &emb, Some(1)).unwrap();
+        // No edge, no candidate — the filter's content scan is the only thing
+        // that can keep it alive.
         let user = rust_fn_chunk(
-            "src/ref.rs:5",
-            "src/ref.rs",
-            "RefSpec",
-            "#[derive(serde::Serialize)] struct RefSpec { \
-             #[serde(serialize_with = \"crate::serialize_path_normalized\")] path: PathBuf }",
+            "src/m.rs:5",
+            "src/m.rs",
+            "M",
+            "#[derive(serde::Serialize)] struct M { \
+             #[serde(skip_serializing = \"skip_predicate\")] x: u32 }",
         );
         store.upsert_chunk(&user, &emb, Some(1)).unwrap();
 
@@ -1638,8 +1831,45 @@ mod tests {
             .map(|d| d.chunk.name.as_str())
             .collect();
         assert!(
-            !names.contains(&"serialize_path_normalized"),
-            "path-qualified serde callback must match by terminal segment: {names:?}"
+            !names.contains(&"skip_predicate"),
+            "skip_serializing callback must still be filtered — KEPT in the regex \
+             because the parser does not emit it: {names:?}"
+        );
+    }
+
+    /// `with = "module"` is KEPT in the filter regex as the corpus-wide same-name
+    /// backstop: a function whose name matches the `with`-path terminal segment
+    /// stays live via the content scan even with no edge/candidate seeded.
+    #[test]
+    fn test_serde_with_module_same_name_still_filtered() {
+        let (store, _dir) = setup_store();
+        let emb = crate::embedder::Embedding::new(vec![0.0; crate::EMBEDDING_DIM]);
+
+        let cb = rust_fn_chunk(
+            "src/codec.rs:1",
+            "src/codec.rs",
+            "my_codec",
+            "fn my_codec() {}",
+        );
+        store.upsert_chunk(&cb, &emb, Some(1)).unwrap();
+        let user = rust_fn_chunk(
+            "src/m.rs:5",
+            "src/m.rs",
+            "M",
+            "#[derive(serde::Serialize)] struct M { \
+             #[serde(with = \"my_codec\")] x: u32 }",
+        );
+        store.upsert_chunk(&user, &emb, Some(1)).unwrap();
+
+        let (confident, possibly_pub) = store.find_dead_code(true).unwrap();
+        let names: Vec<&str> = confident
+            .iter()
+            .chain(possibly_pub.iter())
+            .map(|d| d.chunk.name.as_str())
+            .collect();
+        assert!(
+            !names.contains(&"my_codec"),
+            "with = \"module\" same-name keep must stay in the filter (KEPT in Lane 3): {names:?}"
         );
     }
 
@@ -1799,6 +2029,251 @@ mod tests {
         assert!(
             !names.contains(&"genuinely_called"),
             "a function reached by a real `call` edge must stay live: {names:?}"
+        );
+    }
+
+    // ===== candidate_edges consult (Lane 3) =====
+
+    /// A callee with ZERO `function_calls` edges but PRESENT in `candidate_edges`
+    /// (a candidate-ONLY callee) must LEAVE the truly-dead set
+    /// (`find_dead_code`) and ENTER the low-confidence-live set
+    /// (`find_low_confidence_live_functions`). Calibration: without the candidate
+    /// row the same function is truly-dead — the consult is what flips it.
+    #[test]
+    fn test_candidate_only_callee_flips_dead_to_low_confidence_live() {
+        use crate::parser::CandidateSite;
+        let (store, _dir) = setup_store();
+        let emb = crate::embedder::Embedding::new(vec![0.0; crate::EMBEDDING_DIM]);
+
+        // The candidate-only callee — invoked by nothing in `function_calls`.
+        let cand = rust_fn_chunk("src/a.rs:1", "src/a.rs", "maybe_fn", "fn maybe_fn() {}");
+        store.upsert_chunk(&cand, &emb, Some(1)).unwrap();
+
+        // CALIBRATION: before any candidate row, `maybe_fn` is truly-dead and
+        // absent from the low-confidence-live set.
+        let (dead0, dead_pub0) = store.find_dead_code(true).unwrap();
+        let dead0_names: Vec<&str> = dead0
+            .iter()
+            .chain(dead_pub0.iter())
+            .map(|d| d.chunk.name.as_str())
+            .collect();
+        assert!(
+            dead0_names.contains(&"maybe_fn"),
+            "without a candidate row `maybe_fn` must be truly-dead: {dead0_names:?}"
+        );
+        let (low0, low_pub0) = store.find_low_confidence_live_functions(true).unwrap();
+        let low0_names: Vec<&str> = low0
+            .iter()
+            .chain(low_pub0.iter())
+            .map(|d| d.chunk.name.as_str())
+            .collect();
+        assert!(
+            !low0_names.contains(&"maybe_fn"),
+            "without a candidate row `maybe_fn` must NOT be low-confidence-live: {low0_names:?}"
+        );
+
+        // Add a `candidate_edges` row naming `maybe_fn` (a bare fn-pointer arg
+        // the confident extractor declined to resolve).
+        store
+            .upsert_candidate_edges(
+                std::path::Path::new("src/b.rs"),
+                &[CandidateSite {
+                    file: std::path::PathBuf::from("src/b.rs"),
+                    callee_name: "maybe_fn".to_string(),
+                    ref_line: 7,
+                    candidate_kind: "bare_arg_unresolved".to_string(),
+                }],
+            )
+            .unwrap();
+
+        // FLIP: `maybe_fn` leaves truly-dead and enters low-confidence-live.
+        let (dead1, dead_pub1) = store.find_dead_code(true).unwrap();
+        let dead1_names: Vec<&str> = dead1
+            .iter()
+            .chain(dead_pub1.iter())
+            .map(|d| d.chunk.name.as_str())
+            .collect();
+        assert!(
+            !dead1_names.contains(&"maybe_fn"),
+            "a candidate-only callee must LEAVE the truly-dead set: {dead1_names:?}"
+        );
+        let (low1, low_pub1) = store.find_low_confidence_live_functions(true).unwrap();
+        let low1_names: Vec<&str> = low1
+            .iter()
+            .chain(low_pub1.iter())
+            .map(|d| d.chunk.name.as_str())
+            .collect();
+        assert!(
+            low1_names.contains(&"maybe_fn"),
+            "a candidate-only callee must ENTER the low-confidence-live set: {low1_names:?}"
+        );
+
+        // The breakdown names the candidate kind/count.
+        let info = store.find_low_confidence_live_names().unwrap();
+        let maybe = info
+            .get("maybe_fn")
+            .expect("maybe_fn must be in the low-confidence-live breakdown");
+        assert_eq!(
+            maybe.total, 0,
+            "candidate-only callee has zero heuristic edges"
+        );
+        assert_eq!(maybe.candidate_total, 1, "one candidate reference");
+        assert_eq!(
+            maybe.candidate_counts,
+            vec![("bare_arg_unresolved".to_string(), 1)],
+            "candidate kind/count must be named"
+        );
+    }
+
+    /// Disjointness invariant, EXTENDED with candidates: the truly-dead set
+    /// (`find_dead_code`) and the low-confidence-live set
+    /// (`find_low_confidence_live_functions`) must never share a name when both a
+    /// candidate-only callee AND a genuinely-dead function are present. A
+    /// candidate-only callee belongs to exactly the low set; a no-edge no-candidate
+    /// function belongs to exactly the dead set; their intersection is empty.
+    #[test]
+    fn test_dead_and_low_confidence_live_disjoint_with_candidates() {
+        use crate::parser::CandidateSite;
+        let (store, _dir) = setup_store();
+        let emb = crate::embedder::Embedding::new(vec![0.0; crate::EMBEDDING_DIM]);
+
+        // Candidate-only callee → low set.
+        let cand = rust_fn_chunk(
+            "src/a.rs:1",
+            "src/a.rs",
+            "candidate_fn",
+            "fn candidate_fn() {}",
+        );
+        store.upsert_chunk(&cand, &emb, Some(1)).unwrap();
+        // Genuinely-dead function: no edges, no candidate → dead set.
+        let dead_fn = rust_fn_chunk(
+            "src/a.rs:5",
+            "src/a.rs",
+            "truly_dead_fn",
+            "fn truly_dead_fn() {}",
+        );
+        store.upsert_chunk(&dead_fn, &emb, Some(1)).unwrap();
+
+        store
+            .upsert_candidate_edges(
+                std::path::Path::new("src/b.rs"),
+                &[CandidateSite {
+                    file: std::path::PathBuf::from("src/b.rs"),
+                    callee_name: "candidate_fn".to_string(),
+                    ref_line: 3,
+                    candidate_kind: "macro_arg_unresolved".to_string(),
+                }],
+            )
+            .unwrap();
+
+        let (dead, dead_pub) = store.find_dead_code(true).unwrap();
+        let dead_names: std::collections::HashSet<&str> = dead
+            .iter()
+            .chain(dead_pub.iter())
+            .map(|d| d.chunk.name.as_str())
+            .collect();
+        let (low, low_pub) = store.find_low_confidence_live_functions(true).unwrap();
+        let low_names: std::collections::HashSet<&str> = low
+            .iter()
+            .chain(low_pub.iter())
+            .map(|d| d.chunk.name.as_str())
+            .collect();
+
+        // Membership: each function is in exactly the right set.
+        assert!(
+            dead_names.contains("truly_dead_fn") && !low_names.contains("truly_dead_fn"),
+            "no-edge no-candidate fn must be ONLY in the dead set"
+        );
+        assert!(
+            low_names.contains("candidate_fn") && !dead_names.contains("candidate_fn"),
+            "candidate-only fn must be ONLY in the low-confidence-live set"
+        );
+        // Disjointness: the two sets share no name.
+        let overlap: Vec<&&str> = dead_names.intersection(&low_names).collect();
+        assert!(
+            overlap.is_empty(),
+            "truly-dead and low-confidence-live must stay disjoint with candidates added: {overlap:?}"
+        );
+    }
+
+    /// A callee with a TRUSTED `function_calls` edge AND a `candidate_edges` row
+    /// is genuinely live: it must be in NEITHER set. Fences the candidate
+    /// consult from resurrecting a function the trusted edge already proves live,
+    /// and from leaking it into low-confidence-live.
+    #[test]
+    fn test_candidate_with_trusted_edge_is_neither_dead_nor_low_conf() {
+        use crate::parser::{CallEdgeKind, CallSite, CandidateSite, FunctionCalls};
+        let (store, _dir) = setup_store();
+        let emb = crate::embedder::Embedding::new(vec![0.0; crate::EMBEDDING_DIM]);
+
+        let target = rust_fn_chunk(
+            "src/a.rs:1",
+            "src/a.rs",
+            "live_target",
+            "fn live_target() {}",
+        );
+        store.upsert_chunk(&target, &emb, Some(1)).unwrap();
+        let caller = rust_fn_chunk(
+            "src/b.rs:1",
+            "src/b.rs",
+            "caller_fn",
+            "fn caller_fn() { live_target(); }",
+        );
+        store.upsert_chunk(&caller, &emb, Some(1)).unwrap();
+
+        // A trusted `call` edge to `live_target`.
+        store
+            .upsert_function_calls(
+                std::path::Path::new("src/b.rs"),
+                &[FunctionCalls {
+                    name: "caller_fn".to_string(),
+                    line_start: 1,
+                    calls: vec![CallSite {
+                        callee_name: "live_target".to_string(),
+                        line_number: 1,
+                        kind: CallEdgeKind::Call,
+                    }],
+                }],
+            )
+            .unwrap();
+        // AND a candidate row naming the same callee.
+        store
+            .upsert_candidate_edges(
+                std::path::Path::new("src/b.rs"),
+                &[CandidateSite {
+                    file: std::path::PathBuf::from("src/b.rs"),
+                    callee_name: "live_target".to_string(),
+                    ref_line: 2,
+                    candidate_kind: "bare_arg_unresolved".to_string(),
+                }],
+            )
+            .unwrap();
+
+        let (dead, dead_pub) = store.find_dead_code(true).unwrap();
+        let dead_names: Vec<&str> = dead
+            .iter()
+            .chain(dead_pub.iter())
+            .map(|d| d.chunk.name.as_str())
+            .collect();
+        assert!(
+            !dead_names.contains(&"live_target"),
+            "a trusted-called fn must not be dead even with a candidate row: {dead_names:?}"
+        );
+        let (low, low_pub) = store.find_low_confidence_live_functions(true).unwrap();
+        let low_names: Vec<&str> = low
+            .iter()
+            .chain(low_pub.iter())
+            .map(|d| d.chunk.name.as_str())
+            .collect();
+        assert!(
+            !low_names.contains(&"live_target"),
+            "a trusted-called fn must not be low-confidence-live even with a candidate row: {low_names:?}"
+        );
+        // The breakdown must also exclude it (trusted edge gates the candidate count).
+        let info = store.find_low_confidence_live_names().unwrap();
+        assert!(
+            !info.contains_key("live_target"),
+            "trusted-called callee must be absent from the low-confidence-live breakdown"
         );
     }
 }

--- a/src/store/calls/mod.rs
+++ b/src/store/calls/mod.rs
@@ -76,17 +76,31 @@ impl DeadConfidence {
     }
 }
 
-/// Heuristic-caller breakdown for a `low-confidence-live` callee: the total
-/// number of heuristic edges reaching it plus the per-kind counts. Lets the
-/// `cqs dead` verdict reason name the heuristic kinds and their counts instead
-/// of asserting a generic "all callers are heuristic" claim. Produced by
+/// Low-confidence-liveness evidence for a callee with NO trusted caller: the
+/// heuristic-edge breakdown (from `function_calls`) AND the candidate-edge
+/// breakdown (from the `candidate_edges` side-table, Lane 2). Either population
+/// alone is enough to relabel a zero-trusted-caller function
+/// `low-confidence-live` instead of `dead`; both feed the `cqs dead` verdict
+/// reason so it can name the exact provenance and counts rather than a generic
+/// "all callers are heuristic" claim. Produced by
 /// [`Store::find_low_confidence_live_names`].
 #[derive(Debug, Clone, Default)]
 pub struct LowConfidenceLiveInfo {
     /// Total heuristic edges reaching this callee (no trusted edge exists).
     pub total: u64,
-    /// `(edge_kind string, count)` pairs, sorted for deterministic reasons.
+    /// `(edge_kind string, count)` pairs from `function_calls`, sorted for
+    /// deterministic reasons.
     pub kind_counts: Vec<(String, u64)>,
+    /// Total `candidate_edges` (Lane 2) references naming this callee (no trusted
+    /// edge exists). A nonzero value with `total == 0` is a candidate-ONLY callee
+    /// — zero `function_calls` edges, present only in the side-table.
+    pub candidate_total: u64,
+    /// `(candidate_kind string, count)` pairs from `candidate_edges`, sorted for
+    /// deterministic reasons. Kinds are the Lane-2 provenance strings
+    /// (`bare_arg_unresolved` / `macro_arg_unresolved` / `serde_container` /
+    /// `serde_with_module`), reported transparently so a new candidate kind
+    /// surfaces without a query change.
+    pub candidate_counts: Vec<(String, u64)>,
 }
 
 impl std::fmt::Display for DeadConfidence {

--- a/src/store/calls/mod.rs
+++ b/src/store/calls/mod.rs
@@ -51,6 +51,16 @@ pub struct DeadFunction {
     pub chunk: ChunkSummary,
     /// How confident we are that this function is dead
     pub confidence: DeadConfidence,
+    /// Set only by `apply_dead_overlay` Direction B: this entry was computed
+    /// dead over the authoritative merged (parent+overlay) caller graph in this
+    /// worktree, not read off the parent dead set. Verdict classification must
+    /// not relabel it via the parent-truth `low_conf` heuristic-caller map — that
+    /// map is parent-graph-derived and stale under the overlay, so a
+    /// genuinely-worktree-dead function whose name collides with a parent
+    /// candidate/heuristic name would otherwise be hidden from `--verdict dead`.
+    /// Internal-only; entries reach user-facing JSON as `DeadFunctionEntry`.
+    #[serde(skip)]
+    pub overlay_dead: bool,
 }
 
 /// Confidence level for dead code detection.


### PR DESCRIPTION
**Lane 3 of the candidate-edge campaign** — `cqs dead` consults `candidate_edges`, with the seam-audit fix-round folded in. The campaign's consumer side.

## Consult (3 fns in `dead_code.rs`)
`fetch_uncalled_functions` (a candidate-only callee LEAVES truly-dead), `fetch_heuristic_only_callees` (ENTERS low-conf-live via a candidate arm), `find_low_confidence_live_names` (candidate kind/count breakdown). `LowConfidenceLiveInfo` extended (`candidate_total` + `candidate_counts`; not forked). Disjointness preserved + pinned (truly-dead ∩ low-conf-live = ∅ with candidates). Both surfaces (CLI `dead` + daemon `dispatch_dead`) via the store-side consult; byte-equal parity test. callers/callees/impact untouched (the side-table is never joined). `filter_serde_callbacks` narrowed (retired the now-covered field-level keys; kept `skip_serializing`/`skip_deserializing`/`with` — no coverage lost, code-reviewer-verified).

## Seam-audit catch + fix (the magnet discipline, vindicated again)
A seam-audit found a composition bug the full suite + code-reviewer APPROVE both missed: in a WORKTREE, `apply_dead_overlay` Direction-B adds a genuine worktree-death, but `dead_overlay` then classified it with the **parent-truth** `low_conf` map → a function truly dead in the worktree, whose bare name collides with a parent candidate/heuristic name, got relabeled `low-confidence-live` and **filtered out of `--verdict dead`**. The candidate consult widened the name-set, making the collision likely. **Fix:** a `DeadFunction.overlay_dead` flag; Direction-B additions (authoritatively dead over the merged graph) bypass the parent-truth low_conf relabel → classify `dead`. (Bypass over re-derive: Direction-B additions have zero real callers in the merged graph, so re-derive yields ∅ anyway — they agree, bypass is cheaper.) The seam-auditor CLEARED the name-keying over-suppression hypothesis with evidence (the real-edge check is already bare-name-keyed; no callee-origin column exists).

## Guards
Candidate-only callee → low-confidence-live (calibrated); disjointness invariant test; CLI==daemon parity; the overlay Direction-B blind test now asserts the VERDICT (`dead`, not just the name) with the exact candidate-name collision (RED without the fix, GREEN with).

Full `--tests` sweep: **4669 passed, 0 failed**. Two code-reviewers (opus) APPROVE (consult + seam fix). PARSER_VERSION 10 unchanged (no parser change here). Residual filed: candidate-only additions under the overlay classify `dead` (`candidate_edges` not yet recomputed under the overlay — overlay-phase-2 territory).

After this lands: the campaign reindex (PARSER_VERSION 9→10 populates `candidate_edges`) closes #1818 / #1788 / #1573.
