### PR TITLE
fix(store): watch zero-chunk path persists candidate_edges (closes #1935)

### DIFF
--- a/src/cli/batch/handlers/dispatch_tests.rs
+++ b/src/cli/batch/handlers/dispatch_tests.rs
@@ -204,7 +204,7 @@ fn seed_ctx() -> (TempDir, BatchContext) {
             ),
         ];
         store
-            .upsert_function_calls_for_files(&function_calls)
+            .upsert_function_calls_for_files(&function_calls, &[])
             .expect("upsert calls");
     }
 

--- a/src/cli/pipeline/upsert.rs
+++ b/src/cli/pipeline/upsert.rs
@@ -1187,10 +1187,10 @@ mod tests {
             .unwrap();
         // Seed the prior call edge directly so we can prove it survives.
         store
-            .upsert_function_calls_for_files(&[(
-                PathBuf::from("drift.rs"),
-                one_call("drifty", "helper"),
-            )])
+            .upsert_function_calls_for_files(
+                &[(PathBuf::from("drift.rs"), one_call("drifty", "helper"))],
+                &[],
+            )
             .unwrap();
 
         // Precondition: the seeded chunk registers as parser-version drifted.
@@ -1367,10 +1367,10 @@ mod tests {
             .upsert_embedded_batch(&[(chunk("caller.rs", "seed", body), emb)], &[], &seed_fp)
             .unwrap();
         store
-            .upsert_function_calls_for_files(&[(
-                PathBuf::from("caller.rs"),
-                one_call("caller", "victim"),
-            )])
+            .upsert_function_calls_for_files(
+                &[(PathBuf::from("caller.rs"), one_call("caller", "victim"))],
+                &[],
+            )
             .unwrap();
         assert!(
             store.find_orphaned_function_calls().unwrap().is_empty(),

--- a/src/cli/watch/reindex.rs
+++ b/src/cli/watch/reindex.rs
@@ -362,22 +362,29 @@ pub(super) fn touch_mtime_or_warn(store: &Store, rel_path: &Path, abs_path: &Pat
 /// `find_orphaned_function_calls` registry-UNION arm — permanent if stamped).
 ///
 /// `entries` carry each zero-chunk file's project-relative path and its
-/// freshly parsed call set; `root` joins the paths for the disk read.
-/// Best-effort: a stat/read failure forfeits the skip (the file re-parses next
-/// tick) but is not fatal.
+/// freshly parsed call set; `candidate_entries` carry the same files' Lane-2
+/// candidate sites (an oversize function's cross-file bare-arg / serde
+/// candidates, which have zero chunks but real candidates). `root` joins the
+/// paths for the disk read. Both are passed through to the single parse-driven
+/// writer so the watch path persists candidates the same way the bulk
+/// pipeline's fused zero-chunk flush does. Best-effort: a stat/read failure
+/// forfeits the skip (the file re-parses next tick) but is not fatal.
 fn finalize_zero_chunk_files(
     store: &Store,
     root: &Path,
     entries: &[(PathBuf, Vec<cqs::parser::FunctionCalls>)],
+    candidate_entries: &[(PathBuf, Vec<cqs::parser::CandidateSite>)],
 ) {
     if entries.is_empty() {
         return;
     }
 
-    // Replace each zero-chunk file's function_calls from its real parsed set —
-    // the single parse-driven writer. Empty sets clear, non-empty (oversize
-    // function) sets refresh. This is the decoupled call-graph half; the chunk
-    // prune below makes no call-graph decision.
+    // Replace each zero-chunk file's function_calls AND candidate_edges from its
+    // real parsed sets — the single parse-driven writer. Empty sets clear,
+    // non-empty (oversize function) sets refresh. Candidates ride the same
+    // writer so an oversize function's cross-file candidate is PERSISTED, not
+    // cleared (the false-DEAD this path used to leave). This is the decoupled
+    // call-graph half; the chunk prune below makes no call-graph decision.
     //
     // CONDITIONAL ON SUCCESS, not just ordered: a transient replace failure
     // (e.g. SQLITE_BUSY past busy_timeout under a concurrent `cqs index
@@ -391,7 +398,7 @@ fn finalize_zero_chunk_files(
     // the designed heal trigger — the next reconcile tick reclassifies it ADDED
     // and re-finalizes idempotently. The warn is kept for telemetry; we just
     // stop committing past the failure.
-    if let Err(e) = store.upsert_function_calls_for_files(entries) {
+    if let Err(e) = store.upsert_function_calls_for_files(entries, candidate_entries) {
         tracing::warn!(
             files = entries.len(),
             error = %e,
@@ -653,14 +660,18 @@ pub(crate) fn reindex_files(
         // functions, etc.). They are all in `all_function_calls` (parse-error
         // and deleted files never landed there) WITH their real parsed call set
         // (empty for emptied files, NON-empty for oversize-function files).
-        // `finalize_zero_chunk_files` replaces their function_calls from that
-        // set, prunes their stale chunks, and stamps the v29 `file_registry`
-        // fingerprint #1774 so the next reconcile tick skips them instead of
-        // re-parsing to zero chunks every 30 s. Without this early-return
-        // finalize, an all-empty batch would never reach the per-file path below.
+        // `finalize_zero_chunk_files` replaces their function_calls AND
+        // candidate_edges from those sets, prunes their stale chunks, and stamps
+        // the v29 `file_registry` fingerprint so the next reconcile tick skips
+        // them instead of re-parsing to zero chunks every 30 s. Without this
+        // early-return finalize, an all-empty batch would never reach the
+        // per-file path below. Candidates ride along so an oversize function's
+        // cross-file candidate persists rather than being cleared.
         let zero_chunk_entries: Vec<(PathBuf, Vec<cqs::parser::FunctionCalls>)> =
             all_function_calls.into_iter().collect();
-        finalize_zero_chunk_files(store, root, &zero_chunk_entries);
+        let zero_chunk_candidates: Vec<(PathBuf, Vec<cqs::parser::CandidateSite>)> =
+            all_candidate_edges.into_iter().collect();
+        finalize_zero_chunk_files(store, root, &zero_chunk_entries, &zero_chunk_candidates);
         return Ok((0, Vec::new()));
     }
 
@@ -945,19 +956,26 @@ pub(crate) fn reindex_files(
     // Any file that parsed to ZERO chunks is in `all_function_calls` but NOT
     // in `by_file` (the per-file upsert loop above only ran for files with at
     // least one chunk). `finalize_zero_chunk_files` handles each: it REPLACES
-    // its function_calls from the freshly parsed call set (the partial route's
-    // share of the single parse-driven writer — empty set clears an emptied
-    // file's edges; NON-empty set refreshes an oversize-function file's edges,
-    // which have zero chunks but real calls), prunes its stale chunks, and
-    // stamps the v29 `file_registry` reconcile fingerprint #1774 so the next
+    // its function_calls AND candidate_edges from the freshly parsed sets (the
+    // partial route's share of the single parse-driven writer — empty set
+    // clears an emptied file's edges; NON-empty set refreshes an
+    // oversize-function file's edges, which have zero chunks but real calls
+    // and may carry cross-file candidates), prunes its stale chunks, and
+    // stamps the v29 `file_registry` reconcile fingerprint so the next
     // reconcile tick skips it. The chunk-carrying files already wrote their
-    // function_calls in the fused per-file tx and stamped their fingerprint
-    // inline (`set_file_fingerprint`), which shadows into the registry too.
+    // function_calls + candidate_edges in the fused per-file tx and stamped
+    // their fingerprint inline (`set_file_fingerprint`), which shadows into the
+    // registry too.
     let zero_chunk_entries: Vec<(PathBuf, Vec<cqs::parser::FunctionCalls>)> = all_function_calls
         .into_iter()
         .filter(|(rel_path, _)| !by_file.contains_key(rel_path))
         .collect();
-    finalize_zero_chunk_files(store, root, &zero_chunk_entries);
+    let zero_chunk_candidates: Vec<(PathBuf, Vec<cqs::parser::CandidateSite>)> =
+        all_candidate_edges
+            .into_iter()
+            .filter(|(rel_path, _)| !by_file.contains_key(rel_path))
+            .collect();
+    finalize_zero_chunk_files(store, root, &zero_chunk_entries, &zero_chunk_candidates);
 
     // Upsert type edges from the earlier parse_file_all() results.
     // Type edges are soft data — separate from chunk+call atomicity.
@@ -1124,7 +1142,7 @@ mod tests {
         );
 
         // The emptied file's freshly parsed call set is EMPTY → replace clears.
-        finalize_zero_chunk_files(&store, &root, &[fz_entry("caller.rs", vec![])]);
+        finalize_zero_chunk_files(&store, &root, &[fz_entry("caller.rs", vec![])], &[]);
 
         // Full coherent end-state.
         assert!(
@@ -1188,6 +1206,7 @@ mod tests {
             &store,
             &root,
             &[fz_entry("big.rs", one_edge("big_fn", "helper"))],
+            &[],
         );
 
         // Chunks pruned (function exceeds the byte cap, no chunk row)...
@@ -1254,7 +1273,7 @@ mod tests {
 
         // caller.rs parses to zero chunks under watch (emptied → empty call
         // set) → finalize it.
-        finalize_zero_chunk_files(&store, &root, &[fz_entry("caller.rs", vec![])]);
+        finalize_zero_chunk_files(&store, &root, &[fz_entry("caller.rs", vec![])], &[]);
 
         // The orphan is gone, so victim is now dead-eligible.
         let (confident_after, _) = store.find_dead_code(true).unwrap();
@@ -1301,7 +1320,7 @@ mod tests {
         );
 
         // Simulate the watch zero-chunk success path for this survivor.
-        finalize_zero_chunk_files(&store, &root, &[fz_entry("ghost.rs", vec![])]);
+        finalize_zero_chunk_files(&store, &root, &[fz_entry("ghost.rs", vec![])], &[]);
 
         // The ghost rows are GONE — not just the registry stamped.
         assert!(
@@ -1359,7 +1378,7 @@ mod tests {
         );
 
         // The file parses to zero chunks this tick → watch zero-chunk path runs.
-        finalize_zero_chunk_files(&store, &root, &[fz_entry("drift.rs", vec![])]);
+        finalize_zero_chunk_files(&store, &root, &[fz_entry("drift.rs", vec![])], &[]);
 
         // Second reconcile pass: the prune removed the drifted rows, so the
         // origin is no longer selected — the loop is closed.
@@ -1482,7 +1501,7 @@ mod tests {
 
         // Finalize the emptied file. The calls-replace fails; with the
         // conditional fix it returns early, forfeiting prune + stamp.
-        finalize_zero_chunk_files(&store, &root, &[fz_entry("caller.rs", vec![])]);
+        finalize_zero_chunk_files(&store, &root, &[fz_entry("caller.rs", vec![])], &[]);
 
         // PASS-AFTER assertions (fail-before would have pruned + stamped):
         assert_eq!(

--- a/src/store/calls/crud.rs
+++ b/src/store/calls/crud.rs
@@ -331,7 +331,8 @@ impl Store<ReadWrite> {
         })
     }
 
-    /// Insert function calls for multiple files in a single transaction.
+    /// Insert function calls AND low-confidence candidate edges for multiple
+    /// files in a single transaction.
     ///
     /// Mirrors the `upsert_type_edges_for_files` pattern. Calling
     /// `upsert_function_calls(file, calls)` once per file would open one
@@ -339,14 +340,36 @@ impl Store<ReadWrite> {
     /// on a 2,500-file project. Batching to one transaction matches the shape
     /// used for type edges.
     ///
+    /// `function_calls` and `candidate_edges` are BOTH file-keyed call-graph
+    /// tables refreshed wholesale per file (DELETE WHERE file = ? then INSERT
+    /// the current set). They are swept together here so the parse-driven watch
+    /// finalize path matches the bulk pipeline's fused zero-chunk flush, which
+    /// writes both. Threading `candidate_entries` lets an oversize function
+    /// (zero chunks, non-empty calls) reindexed via the watch path PERSIST a
+    /// cross-file bare-arg / serde candidate instead of having it silently
+    /// cleared — the false-DEAD on the oversize-fn × candidate × watch path.
+    ///
+    /// `candidate_entries` is matched to `entries` by normalized path: a file
+    /// present in `entries` always has its candidates cleared (Phase 1 DELETE),
+    /// and re-inserted only if it appears in `candidate_entries` with a
+    /// non-empty set. A file in `entries` but absent from `candidate_entries`
+    /// (or present with an empty set) ends with zero candidate rows — the
+    /// clear-on-empty contract. Candidates for a file NOT in `entries` are
+    /// ignored: its `function_calls` are not being refreshed, so neither are
+    /// its candidates.
+    ///
     /// Inside the single transaction:
-    /// - Batched DELETE WHERE file IN (?, ?, ?) for all files in the batch
-    ///   (chunked under the SQLite parameter limit).
-    /// - Batched multi-row INSERT for all rows from all files (5 binds per row,
-    ///   chunked under the same parameter limit).
+    /// - Phase 1: batched DELETE WHERE file IN (?, ?, ?) for `function_calls`
+    ///   AND `candidate_edges`, for all files in the batch (chunked under the
+    ///   SQLite parameter limit).
+    /// - Phase 2: batched multi-row INSERT of `function_calls` rows (6 binds
+    ///   per row, chunked under the same parameter limit).
+    /// - Phase 3: batched multi-row INSERT of `candidate_edges` rows (4 binds
+    ///   per row), for the files in `entries` that carry candidates.
     pub fn upsert_function_calls_for_files(
         &self,
         entries: &[(PathBuf, Vec<crate::parser::FunctionCalls>)],
+        candidate_entries: &[(PathBuf, Vec<crate::parser::CandidateSite>)],
     ) -> Result<(), StoreError> {
         let total_files = entries.len();
         let _span =
@@ -360,6 +383,24 @@ impl Store<ReadWrite> {
             .iter()
             .map(|(file, _)| crate::normalize_path(file))
             .collect();
+
+        // Normalized-path → candidate slice, so Phase 3 re-inserts each file's
+        // candidates under the SAME key that scoped its Phase 1 clear. Only
+        // files being refreshed (present in `entries`) are eligible; a candidate
+        // entry for an unrelated file would write a row whose `function_calls`
+        // were not touched, breaking the wholesale-per-file contract.
+        let entry_files: std::collections::HashSet<&str> =
+            file_strs.iter().map(|s| s.as_str()).collect();
+        let mut candidates_by_file: std::collections::HashMap<
+            String,
+            &[crate::parser::CandidateSite],
+        > = std::collections::HashMap::new();
+        for (file, cands) in candidate_entries {
+            let fs = crate::normalize_path(file);
+            if entry_files.contains(fs.as_str()) {
+                candidates_by_file.insert(fs, cands.as_slice());
+            }
+        }
 
         self.rt.block_on(async {
             let (_guard, mut tx) = self.begin_write().await?;
@@ -379,11 +420,12 @@ impl Store<ReadWrite> {
                 }
                 q.execute(&mut *tx).await?;
 
-                // v32: clear the same files' `candidate_edges` in the same tx.
-                // This is the parse-driven `function_calls` replace path (it does
-                // not receive candidate sites), so the symmetric action is to
-                // CLEAR — a file refreshed through here must not keep stale
-                // candidate rows a prior emit pass wrote. Same DELETE-then-INSERT
+                // Clear the same files' `candidate_edges` in the same tx. Both
+                // are file-keyed call-graph tables refreshed wholesale per file;
+                // the matching INSERT happens in Phase 3 (re-inserting only the
+                // files that carry fresh candidates). A file refreshed through
+                // here with no candidates ends with zero candidate rows — the
+                // clear-on-empty contract. Same DELETE-then-INSERT
                 // wholesale-per-file contract the other call-graph delete sites
                 // (delete_by_origin, prune_missing, the fused write) honor.
                 let cand_sql =
@@ -395,8 +437,8 @@ impl Store<ReadWrite> {
                 cq.execute(&mut *tx).await?;
             }
 
-            // Phase 2: collect all rows tagged with their file string, then
-            // batched multi-row INSERT.
+            // Phase 2: collect all function_calls rows tagged with their file
+            // string, then batched multi-row INSERT.
             let mut all_rows: Vec<(&str, &str, u32, &str, u32, &str)> = Vec::new();
             for ((_file, function_calls), file_str) in entries.iter().zip(file_strs.iter()) {
                 for fc in function_calls {
@@ -434,10 +476,50 @@ impl Store<ReadWrite> {
                 }
             }
 
+            // Phase 3: re-insert candidate_edges for the refreshed files that
+            // carry candidates, keyed by the normalized file string used for the
+            // Phase 1 clear. This is the half the watch zero-chunk finalize path
+            // was missing — without it an oversize function's cross-file
+            // candidate is cleared but never re-written, a false-DEAD. Mirrors
+            // the bulk pipeline's fused-flush candidate write.
+            let mut all_cand_rows: Vec<(&str, &str, u32, &str)> = Vec::new();
+            for file_str in &file_strs {
+                if let Some(cands) = candidates_by_file.get(file_str) {
+                    for cand in cands.iter() {
+                        all_cand_rows.push((
+                            file_str.as_str(),
+                            cand.callee_name.as_str(),
+                            cand.ref_line,
+                            cand.candidate_kind.as_str(),
+                        ));
+                    }
+                }
+            }
+
+            if !all_cand_rows.is_empty() {
+                const CAND_INSERT_BATCH: usize = max_rows_per_statement(4);
+                for batch in all_cand_rows.chunks(CAND_INSERT_BATCH) {
+                    let mut qb: sqlx::QueryBuilder<sqlx::Sqlite> = sqlx::QueryBuilder::new(
+                        "INSERT INTO candidate_edges (file, callee_name, ref_line, candidate_kind) ",
+                    );
+                    qb.push_values(
+                        batch.iter(),
+                        |mut b, (file, callee_name, ref_line, candidate_kind)| {
+                            b.push_bind(*file)
+                                .push_bind(*callee_name)
+                                .push_bind(*ref_line as i64)
+                                .push_bind(*candidate_kind);
+                        },
+                    );
+                    qb.build().execute(&mut *tx).await?;
+                }
+            }
+
             tx.commit().await?;
             tracing::info!(
                 files = total_files,
                 rows = all_rows.len(),
+                candidate_rows = all_cand_rows.len(),
                 "Batch-indexed function calls"
             );
             Ok(())

--- a/src/store/chunks/crud.rs
+++ b/src/store/chunks/crud.rs
@@ -2181,15 +2181,18 @@ mod tests {
         );
     }
 
-    /// v32 COMPLETENESS GUARD: every wholesale `function_calls` replace/delete
-    /// path must also sweep `candidate_edges` for the same files — both are
-    /// file-keyed call-graph tables refreshed wholesale per file, and a path
-    /// that refreshes one but not the other strands orphan rows. This pins the
-    /// parse-driven batch writer `upsert_function_calls_for_files` (the watch
-    /// zero-chunk finalize path): it does NOT receive candidate sites, so the
-    /// symmetric action is to CLEAR the files' candidates. Seed a candidate
-    /// directly, then run the batch writer for the same file and assert the
-    /// candidate is gone.
+    /// COMPLETENESS GUARD (clear-on-empty half): every wholesale
+    /// `function_calls` replace/delete path must also sweep `candidate_edges`
+    /// for the same files — both are file-keyed call-graph tables refreshed
+    /// wholesale per file, and a path that refreshes one but not the other
+    /// strands orphan rows. This pins the parse-driven batch writer
+    /// `upsert_function_calls_for_files` (the watch zero-chunk finalize path):
+    /// when a file is refreshed with an EMPTY candidate slice, its stale
+    /// candidate rows must be cleared. Seed a candidate directly, then run the
+    /// batch writer for the same file with NO candidates and assert the
+    /// candidate is gone. The PERSIST half (a file refreshed WITH a candidate
+    /// keeps it) is pinned by
+    /// `upsert_function_calls_for_files_persists_candidate_edges`.
     #[test]
     fn upsert_function_calls_for_files_clears_candidate_edges() {
         let (store, _dir) = setup_store();
@@ -2236,7 +2239,8 @@ mod tests {
         });
 
         // Run the parse-driven batch function_calls replace for the same file
-        // (the watch zero-chunk finalize path). It must clear the candidates.
+        // (the watch zero-chunk finalize path) with NO candidates. It must
+        // clear the seeded candidate.
         let entries = vec![(
             std::path::PathBuf::from("src/q.rs"),
             vec![FunctionCalls {
@@ -2250,7 +2254,7 @@ mod tests {
             }],
         )];
         store
-            .upsert_function_calls_for_files(&entries)
+            .upsert_function_calls_for_files(&entries, &[])
             .expect("batch function_calls replace must succeed");
 
         store.runtime().block_on(async {
@@ -2262,10 +2266,147 @@ mod tests {
                     .unwrap();
             assert_eq!(
                 n, 0,
-                "upsert_function_calls_for_files must clear the file's candidate_edges \
-                 (wholesale call-graph replace must sweep both file-keyed tables)"
+                "upsert_function_calls_for_files with no candidates must clear the file's \
+                 candidate_edges (wholesale call-graph replace must sweep both file-keyed tables)"
             );
         });
+    }
+
+    /// COMPLETENESS GUARD (persist half — the watch zero-chunk × candidate gap):
+    /// the parse-driven batch writer `upsert_function_calls_for_files` is the
+    /// store half of the WATCH zero-chunk finalize path. When an oversize
+    /// function (zero chunks, non-empty calls) is reindexed via watch and
+    /// carries a cross-file bare-arg / serde candidate, that candidate must be
+    /// PERSISTED — the watch path must mirror the bulk pipeline's fused
+    /// zero-chunk flush, which writes both `function_calls` and
+    /// `candidate_edges`. Previously this writer received no candidate sites and
+    /// only CLEARED, so the candidate was silently dropped → a possible
+    /// false-DEAD on the oversize-fn × candidate × watch-only path. This test
+    /// seeds a candidate via the fused write, then re-runs the batch writer for
+    /// the SAME file WITH a fresh candidate set, and asserts the new candidate
+    /// is persisted (not cleared). It also asserts the clear-on-empty contract
+    /// still holds for a SECOND file refreshed in the same call with NO
+    /// candidates — a wholesale replace clears one file while persisting
+    /// another. Fails on the pre-fix signature (no candidate parameter to pass).
+    #[test]
+    fn upsert_function_calls_for_files_persists_candidate_edges() {
+        let (store, _dir) = setup_store();
+
+        // Seed a STALE candidate on src/keep.rs and a stale one on src/drop.rs
+        // via the fused write (the only store-public Lane-1 candidate writer).
+        let seed_candidate = |origin: &str, callee: &str| {
+            let emb = mock_embedding(1.0);
+            let chunk = make_chunk("seed_fn", origin);
+            let pairs = [(chunk.clone(), emb)];
+            let fp = crate::store::chunks::staleness::FileFingerprint {
+                mtime: Some(1),
+                size: Some(2),
+                content_hash: Some(*blake3::hash(origin.as_bytes()).as_bytes()),
+            };
+            let candidates = vec![CandidateSite {
+                file: std::path::PathBuf::from(origin),
+                callee_name: callee.to_string(),
+                ref_line: 4,
+                candidate_kind: "bare_arg_unresolved".to_string(),
+            }];
+            store
+                .upsert_file_fused(
+                    &pairs,
+                    &[],
+                    fp.mtime,
+                    &[],
+                    std::path::Path::new(origin),
+                    &[chunk.id.as_str()],
+                    &[],
+                    &candidates,
+                    &fp,
+                )
+                .expect("seed fused write must succeed");
+        };
+        seed_candidate("src/keep.rs", "stale_callee");
+        seed_candidate("src/drop.rs", "doomed_callee");
+
+        // Both files start with exactly one candidate.
+        let count_for = |file: &str| -> i64 {
+            store.runtime().block_on(async {
+                let (n,): (i64,) =
+                    sqlx::query_as("SELECT COUNT(*) FROM candidate_edges WHERE file = ?1")
+                        .bind(file)
+                        .fetch_one(&store.pool)
+                        .await
+                        .unwrap();
+                n
+            })
+        };
+        assert_eq!(count_for("src/keep.rs"), 1, "precondition: keep.rs seeded");
+        assert_eq!(count_for("src/drop.rs"), 1, "precondition: drop.rs seeded");
+
+        // Re-finalize BOTH files via the batch writer (the watch zero-chunk
+        // path). keep.rs carries a FRESH candidate set; drop.rs carries none.
+        let entries = vec![
+            (
+                std::path::PathBuf::from("src/keep.rs"),
+                vec![FunctionCalls {
+                    name: "big_fn".to_string(),
+                    line_start: 1,
+                    calls: vec![CallSite {
+                        callee_name: "real_callee".to_string(),
+                        line_number: 2,
+                        kind: CallEdgeKind::Call,
+                    }],
+                }],
+            ),
+            (
+                std::path::PathBuf::from("src/drop.rs"),
+                vec![FunctionCalls {
+                    name: "other_fn".to_string(),
+                    line_start: 1,
+                    calls: vec![CallSite {
+                        callee_name: "real_callee".to_string(),
+                        line_number: 2,
+                        kind: CallEdgeKind::Call,
+                    }],
+                }],
+            ),
+        ];
+        let candidate_entries = vec![(
+            std::path::PathBuf::from("src/keep.rs"),
+            vec![CandidateSite {
+                file: std::path::PathBuf::from("src/keep.rs"),
+                callee_name: "fresh_callee".to_string(),
+                ref_line: 9,
+                candidate_kind: "serde_container".to_string(),
+            }],
+        )];
+        store
+            .upsert_function_calls_for_files(&entries, &candidate_entries)
+            .expect("batch function_calls replace must succeed");
+
+        // keep.rs: the stale candidate is gone, the FRESH one is persisted
+        // (DELETE-then-INSERT wholesale-per-file; the new row survives).
+        store.runtime().block_on(async {
+            let rows: Vec<(String, i64, String)> = sqlx::query_as(
+                "SELECT callee_name, ref_line, candidate_kind FROM candidate_edges \
+                 WHERE file = ?1 ORDER BY callee_name",
+            )
+            .bind("src/keep.rs")
+            .fetch_all(&store.pool)
+            .await
+            .unwrap();
+            assert_eq!(
+                rows,
+                vec![("fresh_callee".to_string(), 9, "serde_container".to_string())],
+                "watch zero-chunk finalize must PERSIST the file's fresh candidate \
+                 (not silently clear it) — mirrors the bulk fused zero-chunk flush"
+            );
+        });
+
+        // drop.rs: refreshed with no candidates → cleared (clear-on-empty).
+        assert_eq!(
+            count_for("src/drop.rs"),
+            0,
+            "a file refreshed with no candidates must have its candidate_edges cleared"
+        );
     }
 
     /// Passing `None` for file_function_calls leaves the existing

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -337,7 +337,8 @@ impl InProcessFixture {
             }
         }
         if !all_calls.is_empty() {
-            self.store.upsert_function_calls_for_files(&all_calls)?;
+            self.store
+                .upsert_function_calls_for_files(&all_calls, &[])?;
         }
         if !all_types.is_empty() {
             self.store.upsert_type_edges_for_files(&all_types)?;


### PR DESCRIPTION
## Fix: watch zero-chunk path clears candidate_edges but never writes them

Closes #1935.

**The gap (incomplete sweep across the two write paths).** The bulk index pipeline persists `candidate_edges` (the v32 low-confidence call-candidate side-table) on its fused zero-chunk flush. The **watch** zero-chunk finalize path (`finalize_zero_chunk_files` → `upsert_function_calls_for_files`) did a file-scoped DELETE of `candidate_edges` but never re-INSERTed — so an **oversize function** (zero chunks, non-empty calls) reindexed via watch, carrying a cross-file bare-arg / serde candidate, had that candidate silently dropped. Consequence is bounded: a possible false-DEAD on the narrow oversize-fn × cross-file-candidate × watch-only path (`candidate_edges` is a hints table consumed only by `cqs dead`), not data corruption.

**The fix.** Thread a candidate slice through `upsert_function_calls_for_files` (new Phase-3 INSERT keyed by the same normalized path that scopes the Phase-1 clear) and through `finalize_zero_chunk_files` + both watch call sites (all-empty early return and partial route). The file-scoped DELETE+INSERT contract is preserved — a file refreshed with zero candidates still clears.

**Test.** `upsert_function_calls_for_files_persists_candidate_edges` (`src/store/chunks/crud.rs`) — verified FAIL before / PASS after (`left: []` vs `right: [("fresh_callee", 9, "serde_container")]`); also asserts the clear-on-empty contract on a second file in the same batch.

**Third-site check:** no third gap. The other clear-without-insert sites (`delete_by_origin`, `prune_missing`) are wholesale file-removal paths where clearing without re-insert is correct.

Gates: fmt/build/`clippy --all-targets`/targeted store+watch+dead+ci_test tests green; provenance lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
