### PR TITLE
fix(dead): recompute candidate_edges under the worktree overlay (closes #1937)

### DIFF
--- a/src/cli/batch/handlers/graph.rs
+++ b/src/cli/batch/handlers/graph.rs
@@ -3097,25 +3097,27 @@ mod tests {
     }
 
     /// Seam guard (overlay × verdict-classification): a Direction-B overlay
-    /// addition whose name ALSO sits in the parent-truth `low_conf` map must
-    /// carry verdict `dead`, NOT be relabeled `low-confidence-live` and hidden
-    /// from `--verdict dead`. The addition is computed dead over the
-    /// authoritative merged graph in this worktree; the parent `low_conf` map is
-    /// stale here. RED without the `overlay_dead` bypass (verdict would be
-    /// `low-confidence-live`), GREEN with it.
+    /// addition whose name ALSO sits in the parent-truth `low_conf` HEURISTIC map
+    /// must carry verdict `dead`, NOT be relabeled `low-confidence-live` and
+    /// hidden from `--verdict dead`. The heuristic edge that put `handler` in
+    /// `low_conf` lives in the MASKED `src/edited.rs`, so it is stale here — the
+    /// merged caller graph has zero real callers AND there is no candidate
+    /// evidence, so `dead` is correct. RED without the heuristic-map skip for
+    /// `overlay_dead` (verdict would be `low-confidence-live`), GREEN with it.
+    /// (The companion `dead_overlay_addition_candidate_in_live_origin_relabels`
+    /// pins the opposite: a candidate row in an UNMASKED origin DOES relabel,
+    /// because it is a live worktree reference.)
     ///
     /// Reachability of the collision: a Direction-B addition is, by definition, a
-    /// name NOT already in the parent dead populations. A heuristic/candidate-only
-    /// callee is normally folded into the parent low-confidence-live set (so it
-    /// would be in `already` and never re-added) — UNLESS its definition is
-    /// dropped by a Phase-1 filter the addition path does NOT apply. The
-    /// entry-point filter is exactly such a gap: `find_low_confidence_live_…`
-    /// drops entry-point names (here `handler`) from its CHUNK population, but
+    /// name NOT already in the parent dead populations. A heuristic-only callee is
+    /// normally folded into the parent low-confidence-live set (so it would be in
+    /// `already` and never re-added) — UNLESS its definition is dropped by a
+    /// Phase-1 filter the addition path does NOT apply. The entry-point filter is
+    /// exactly such a gap: `find_low_confidence_live_…` drops entry-point names
+    /// (here `handler`) from its CHUNK population, but
     /// `find_low_confidence_live_names` keeps them in the `low_conf` NAME map, and
     /// `resolve_overlay_dead_candidate_def` admits them. So `handler` is absent
     /// from the parent dead set yet present in `low_conf` — the precise collision.
-    /// The Lane-3 candidate consult widens that name map further (an extra
-    /// `candidate_edges` row here), making the collision more likely.
     #[test]
     fn dead_overlay_addition_classifies_dead_despite_low_conf_collision() {
         // Parent: `handler` (an ENTRY-POINT name) is reached only by `caller` (in
@@ -3123,8 +3125,7 @@ mod tests {
         // NON-trusted, so `handler` lands in the `low_conf` NAME map. As an entry
         // point its definition is filtered out of the parent low-confidence-live
         // CHUNK population, so it is NOT in the parent dead set (Direction-B can
-        // add it). A `candidate_edges` row naming `handler` (the Lane-3 widening)
-        // co-populates the same `low_conf` map.
+        // add it). NO candidate edge: this isolates the heuristic-collision case.
         let dir = TempDir::new().expect("tempdir");
         let cqs_dir = dir.path().join(".cqs");
         std::fs::create_dir_all(&cqs_dir).expect("mkdir .cqs");
@@ -3143,7 +3144,8 @@ mod tests {
                     .expect("upsert parent chunk");
             }
             // Heuristic real caller: handler has a real edge (so it's not in the
-            // strict dead set) but no trusted edge (so it's in low_conf).
+            // strict dead set) but no trusted edge (so it's in low_conf). This edge
+            // lives in src/edited.rs, which the worktree masks below.
             let fc = FunctionCalls {
                 name: "caller".into(),
                 line_start: 1,
@@ -3156,18 +3158,6 @@ mod tests {
             store
                 .upsert_function_calls(Path::new("src/edited.rs"), &[fc])
                 .expect("upsert parent heuristic edge");
-            // Candidate-edges row naming `handler` (Lane-3 widening of low_conf).
-            store
-                .upsert_candidate_edges(
-                    Path::new("src/other.rs"),
-                    &[cqs::parser::CandidateSite {
-                        file: PathBuf::from("src/other.rs"),
-                        callee_name: "handler".into(),
-                        ref_line: 3,
-                        candidate_kind: "bare_arg_unresolved".into(),
-                    }],
-                )
-                .expect("upsert candidate edge");
         }
         let ctx = create_test_context(&cqs_dir).expect("create_test_context");
 
@@ -3195,13 +3185,95 @@ mod tests {
             "masking the sole caller must flip `handler` into the dead set: {json}"
         );
         // The seam assertion: the Direction-B addition's VERDICT must be `dead`,
-        // not `low-confidence-live` (which the stale parent low_conf map would
-        // assign, hiding it from `--verdict dead`).
+        // not `low-confidence-live` (which the stale parent low_conf HEURISTIC map
+        // would assign, hiding it from `--verdict dead`).
         assert_eq!(
             dead_verdict_for(&json, "handler").as_deref(),
             Some("dead"),
-            "an overlay-dead addition colliding with a parent candidate/heuristic name \
+            "an overlay-dead addition colliding with a parent heuristic name \
              must classify `dead`, NOT `low-confidence-live` (or `--verdict dead` hides it): {json}"
+        );
+    }
+
+    /// The candidate-recompute fix (this PR), end-to-end through `dead_overlay`: a
+    /// Direction-B addition still referenced by a `candidate_edges` row in an
+    /// UNMASKED origin relabels `low-confidence-live`, NOT `dead`. The candidate
+    /// is a LIVE worktree reference (its origin is not delta-touched, so the
+    /// mask-then-union keeps it), so the function is reached by a candidate edge
+    /// and is low-confidence-live, not genuinely dead. RED before the fix (the
+    /// blanket `overlay_dead` skip forced `dead`, ignoring the merged candidate
+    /// map); GREEN after. Calibration sibling:
+    /// `dead_overlay_addition_classifies_dead_despite_low_conf_collision` (no
+    /// candidate evidence → `dead`).
+    #[test]
+    fn dead_overlay_addition_candidate_in_live_origin_relabels() {
+        // Parent: `target` is called ONLY by `caller` (in src/edited.rs) via a
+        // TRUSTED `call` edge → live, NOT in low_conf. A `candidate_edges` row
+        // names `target` from src/live.rs — an origin the worktree does NOT touch.
+        let dir = TempDir::new().expect("tempdir");
+        let cqs_dir = dir.path().join(".cqs");
+        std::fs::create_dir_all(&cqs_dir).expect("mkdir .cqs");
+        let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
+        let mut emb = vec![0.0_f32; cqs::EMBEDDING_DIM];
+        emb[0] = 1.0;
+        let embedding = Embedding::new(emb);
+        {
+            let store = Store::open(&index_path).expect("open store");
+            store.init(&ModelInfo::default()).expect("init");
+            for (file, name) in [("src/edited.rs", "caller"), ("src/lib.rs", "target")] {
+                let mut c = make_chunk(&format!("{file}:{name}"), name);
+                c.file = PathBuf::from(file);
+                store
+                    .upsert_chunks_batch(&[(c, embedding.clone())], Some(0))
+                    .expect("upsert parent chunk");
+            }
+            // Trusted sole caller in src/edited.rs (masked below).
+            let fc = FunctionCalls {
+                name: "caller".into(),
+                line_start: 1,
+                calls: vec![CallSite {
+                    callee_name: "target".into(),
+                    line_number: 2,
+                    kind: CallEdgeKind::Call,
+                }],
+            };
+            store
+                .upsert_function_calls(Path::new("src/edited.rs"), &[fc])
+                .expect("upsert parent trusted edge");
+            // Candidate row naming `target` from an UNMASKED origin (src/live.rs).
+            store
+                .upsert_candidate_edges(
+                    Path::new("src/live.rs"),
+                    &[cqs::parser::CandidateSite {
+                        file: PathBuf::from("src/live.rs"),
+                        callee_name: "target".into(),
+                        ref_line: 3,
+                        candidate_kind: "bare_arg_unresolved".into(),
+                    }],
+                )
+                .expect("upsert candidate edge");
+        }
+        let ctx = create_test_context(&cqs_dir).expect("create_test_context");
+
+        // Worktree edits src/edited.rs and drops the trusted call to `target` →
+        // the merged caller graph has zero REAL callers, so Direction-B adds it.
+        // src/live.rs (the candidate origin) is NOT masked, so its candidate row
+        // survives the merge and relabels the addition low-confidence-live.
+        let overlay = overlay_with_edges(&[("src/edited.rs", "caller")], &[], &["src/edited.rs"]);
+        let (out, participated) =
+            dead_overlay(&ctx.store(), &ctx.root, &dead_core_args(), Some(&overlay))
+                .expect("overlay");
+        assert!(participated, "a live→dead flip must report participation");
+        let json = serde_json::to_value(&out).unwrap();
+        assert!(
+            dead_names(&json).contains(&"target".to_string()),
+            "masking the sole trusted caller must surface `target` as a Direction-B addition: {json}"
+        );
+        assert_eq!(
+            dead_verdict_for(&json, "target").as_deref(),
+            Some("low-confidence-live"),
+            "a Direction-B addition still referenced by a candidate edge in an UNMASKED \
+             origin must relabel `low-confidence-live`, not `dead`: {json}"
         );
     }
 

--- a/src/cli/batch/handlers/mod.rs
+++ b/src/cli/batch/handlers/mod.rs
@@ -135,3 +135,19 @@ fn attach_overlay_graph_marker(value: &mut serde_json::Value, marker: &str) {
         }
     }
 }
+
+#[cfg(test)]
+mod overlay_marker_tests {
+    use super::*;
+
+    /// `dead`'s overlay marker is `"full"` — the candidate-recompute strengthening
+    /// keeps the whole answer (caller graph AND candidate section) overlaid, so the
+    /// honest marker stays `"full"`, not downgraded to `"callers-only"`. Guards the
+    /// exact string `dispatch_dead` attaches on a participating overlay.
+    #[test]
+    fn dead_overlay_marker_is_full() {
+        let mut v = serde_json::json!({"dead": []});
+        attach_overlay_graph_meta_full(&mut v);
+        assert_eq!(v["_meta"]["overlay_graph"], "full");
+    }
+}

--- a/src/cli/commands/review/dead.rs
+++ b/src/cli/commands/review/dead.rs
@@ -152,10 +152,14 @@ fn is_test_only(entry: &DeadFunction) -> bool {
 /// Classify a dead entry into its verdict. Ordered, first-match-wins:
 /// test-only → low-confidence-live → known-gap → dead. `low_conf` maps a
 /// callee name to its §1-derived heuristic-caller breakdown (present only for
-/// functions reached solely by heuristic edges).
+/// functions reached solely by heuristic edges). `overlay_candidate` maps a
+/// callee name to its candidate-edge breakdown recomputed over the merged
+/// (parent+overlay) candidate graph — consulted for Direction-B additions, whose
+/// parent-truth `low_conf` is stale.
 fn classify_verdict(
     entry: &DeadFunction,
     low_conf: &std::collections::HashMap<String, cqs::store::LowConfidenceLiveInfo>,
+    overlay_candidate: &std::collections::HashMap<String, cqs::store::LowConfidenceLiveInfo>,
 ) -> (DeadVerdict, String) {
     if is_test_only(entry) {
         // Softened to claim only what the substring scan actually knows: a
@@ -167,63 +171,64 @@ fn classify_verdict(
             "origin under tests/ path or content contains '#[cfg(test)]'".to_string(),
         );
     }
-    // Direction-B overlay additions were computed dead over the authoritative
-    // merged (parent+overlay) caller graph in this worktree — they ARE dead
-    // here. The `low_conf` map is parent-graph-derived and stale under the
-    // overlay, so consulting it would relabel a genuinely-worktree-dead function
-    // `low-confidence-live` whenever its bare name collides with a parent
-    // heuristic/candidate name, hiding it from `--verdict dead`. Skip the
-    // parent-truth relabel for these; the remaining tiers (known-gap, dead) are
-    // name/path/content-derived and stay valid under the overlay.
-    //
-    // This also classifies a candidate-only addition `dead` rather than
-    // `low-confidence-live` — intentional: `candidate_edges` is parent-truth
-    // (never recomputed over the overlay), so trusting it to override the
-    // authoritative merged-`function_calls` verdict would itself be a stale
-    // claim, and the error direction (surface a possibly-dead fn vs. hide a
-    // genuinely-dead one) is the safe one for `cqs dead`.
-    if !entry.overlay_dead {
-        if let Some(info) = low_conf.get(&entry.chunk.name) {
-            // Name the exact provenance and counts rather than asserting "all
-            // callers are heuristic" generically. Two populations may contribute:
-            // heuristic `function_calls` edges and `candidate_edges` (Lane 2)
-            // references. A candidate-ONLY callee has `total == 0` and
-            // `candidate_total > 0`; render only the populations that are present so
-            // the reason never claims "0 heuristic edge(s)".
-            let mut parts: Vec<String> = Vec::new();
-            if info.total > 0 {
-                let kinds = info
-                    .kind_counts
-                    .iter()
-                    .map(|(kind, n)| format!("{kind}×{n}"))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                parts.push(format!("{} heuristic edge(s) [{}]", info.total, kinds));
-            }
-            if info.candidate_total > 0 {
-                let kinds = info
-                    .candidate_counts
-                    .iter()
-                    .map(|(kind, n)| format!("{kind}×{n}"))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                parts.push(format!(
-                    "{} candidate edge(s) [{}]",
-                    info.candidate_total, kinds
-                ));
-            }
-            let detail = if parts.is_empty() {
-                // Defensive: the name is in the map only when one population is
-                // nonzero, so this is unreachable in practice.
-                "heuristic/candidate evidence".to_string()
-            } else {
-                parts.join("; ")
-            };
-            return (
-                DeadVerdict::LowConfidenceLive,
-                format!("no trusted caller; reached only by {detail}"),
-            );
+    // Pick the liveness-evidence map for this entry. A Direction-B overlay
+    // addition (`overlay_dead`) was computed dead over the authoritative merged
+    // (parent+overlay) caller graph in this worktree, so its parent-graph-derived
+    // `low_conf` HEURISTIC breakdown is stale — consulting it would relabel a
+    // genuinely-worktree-dead function `low-confidence-live` whenever its bare
+    // name collides with a parent heuristic/candidate name, hiding it from
+    // `--verdict dead`. For these we consult only the CANDIDATE map, which is
+    // recomputed over the merged candidate graph (mask-then-union of parent +
+    // overlay `candidate_edges`), so a candidate-only addition — dead over the
+    // merged real caller graph but still referenced by a worktree candidate edge
+    // — correctly relabels `low-confidence-live`. A parent entry keeps the full
+    // parent `low_conf` breakdown (heuristic + candidate). The remaining tiers
+    // (known-gap, dead) are name/path/content-derived and stay valid for both.
+    let evidence = if entry.overlay_dead {
+        overlay_candidate
+    } else {
+        low_conf
+    };
+    if let Some(info) = evidence.get(&entry.chunk.name) {
+        // Name the exact provenance and counts rather than asserting "all
+        // callers are heuristic" generically. Two populations may contribute:
+        // heuristic `function_calls` edges and `candidate_edges` (Lane 2)
+        // references. A candidate-ONLY callee has `total == 0` and
+        // `candidate_total > 0`; render only the populations that are present so
+        // the reason never claims "0 heuristic edge(s)".
+        let mut parts: Vec<String> = Vec::new();
+        if info.total > 0 {
+            let kinds = info
+                .kind_counts
+                .iter()
+                .map(|(kind, n)| format!("{kind}×{n}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            parts.push(format!("{} heuristic edge(s) [{}]", info.total, kinds));
         }
+        if info.candidate_total > 0 {
+            let kinds = info
+                .candidate_counts
+                .iter()
+                .map(|(kind, n)| format!("{kind}×{n}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            parts.push(format!(
+                "{} candidate edge(s) [{}]",
+                info.candidate_total, kinds
+            ));
+        }
+        let detail = if parts.is_empty() {
+            // Defensive: the name is in the map only when one population is
+            // nonzero, so this is unreachable in practice.
+            "heuristic/candidate evidence".to_string()
+        } else {
+            parts.join("; ")
+        };
+        return (
+            DeadVerdict::LowConfidenceLive,
+            format!("no trusted caller; reached only by {detail}"),
+        );
     }
     if let Some(reason) = known_gap_reason(entry) {
         return (DeadVerdict::KnownGap, reason.to_string());
@@ -438,7 +443,24 @@ pub(crate) fn dead_overlay(
         false
     };
 
-    let mut output = build_dead_output(&confident, &possibly_pub, root, &low_conf);
+    // Overlay-merged candidate map (mask-then-union of parent + overlay
+    // `candidate_edges`), keyed by callee name. The verdict classifier consults
+    // it for Direction-B additions, whose parent-truth `low_conf` is stale: a
+    // candidate-only addition relabels `low-confidence-live` instead of `dead`.
+    // Empty when there is no overlay (parent entries never consult it).
+    let overlay_candidate = match overlay {
+        Some(ov) => cqs::store::build_overlay_candidate_map(store, ov)
+            .context("Failed to build overlay candidate map")?,
+        None => std::collections::HashMap::new(),
+    };
+
+    let mut output = build_dead_output(
+        &confident,
+        &possibly_pub,
+        root,
+        &low_conf,
+        &overlay_candidate,
+    );
 
     // Apply the `--verdict` filter to both lists, then recount.
     if let Some(want) = args.verdict {
@@ -459,11 +481,14 @@ pub(crate) fn dead_overlay(
 /// Build the typed dead-code report shared between CLI and batch. Each entry
 /// is classified into a [`DeadVerdict`] via the ordered `classify_verdict`;
 /// `low_conf` is the §1-derived heuristic-caller breakdown keyed by callee name.
+/// `overlay_candidate` is the overlay-merged candidate breakdown (empty without
+/// an overlay) the classifier consults for Direction-B additions.
 pub(crate) fn build_dead_output(
     confident: &[DeadFunction],
     possibly_pub: &[DeadFunction],
     root: &Path,
     low_conf: &std::collections::HashMap<String, cqs::store::LowConfidenceLiveInfo>,
+    overlay_candidate: &std::collections::HashMap<String, cqs::store::LowConfidenceLiveInfo>,
 ) -> DeadOutput {
     let _span = tracing::info_span!(
         "build_dead_output",
@@ -473,7 +498,7 @@ pub(crate) fn build_dead_output(
     .entered();
 
     let format = |d: &DeadFunction| {
-        let (verdict, reason) = classify_verdict(d, low_conf);
+        let (verdict, reason) = classify_verdict(d, low_conf, overlay_candidate);
         DeadFunctionEntry {
             name: d.chunk.name.clone(),
             file: cqs::rel_display(&d.chunk.file, root).to_string(),
@@ -679,6 +704,22 @@ mod tests {
         std::collections::HashMap::new()
     }
 
+    /// Empty overlay-merged candidate map. Parent-form classifier tests (no
+    /// overlay) pass this so the `overlay_dead` consult never fires.
+    fn no_overlay_cand() -> std::collections::HashMap<String, cqs::store::LowConfidenceLiveInfo> {
+        std::collections::HashMap::new()
+    }
+
+    /// Parent-form classify wrapper: no overlay candidate map. The bulk of the
+    /// verdict tests classify a parent entry (`overlay_dead = false`), which
+    /// never consults the overlay map, so this keeps them at two args.
+    fn classify_parent(
+        entry: &DeadFunction,
+        low_conf: &std::collections::HashMap<String, cqs::store::LowConfidenceLiveInfo>,
+    ) -> (DeadVerdict, String) {
+        classify_verdict(entry, low_conf, &no_overlay_cand())
+    }
+
     /// Low-confidence map with one heuristic-only callee `name`.
     fn low_conf_with(
         name: &str,
@@ -756,7 +797,7 @@ mod tests {
             cqs::parser::Language::Rust,
             "fn make_x() {}",
         );
-        let (v, _) = classify_verdict(&f, &no_low_conf());
+        let (v, _) = classify_parent(&f, &no_low_conf());
         assert_eq!(v, DeadVerdict::TestOnly);
     }
 
@@ -768,7 +809,7 @@ mod tests {
             cqs::parser::Language::Rust,
             "#[cfg(test)]\nmod t { fn helper() {} }",
         );
-        let (v, _) = classify_verdict(&f, &no_low_conf());
+        let (v, _) = classify_parent(&f, &no_low_conf());
         assert_eq!(v, DeadVerdict::TestOnly);
     }
 
@@ -780,7 +821,7 @@ mod tests {
             cqs::parser::Language::Rust,
             "fn cb() {}",
         );
-        let (v, reason) = classify_verdict(&f, &low_conf_with("cb"));
+        let (v, reason) = classify_parent(&f, &low_conf_with("cb"));
         assert_eq!(v, DeadVerdict::LowConfidenceLive);
         // Reason names the heuristic kinds/counts, not a generic claim.
         assert!(
@@ -803,7 +844,7 @@ mod tests {
             cqs::parser::Language::Rust,
             "fn maybe_fn() {}",
         );
-        let (v, reason) = classify_verdict(
+        let (v, reason) = classify_parent(
             &f,
             &candidate_only_low_conf("maybe_fn", "bare_arg_unresolved"),
         );
@@ -822,7 +863,7 @@ mod tests {
         );
 
         // Calibration: the SAME entry with an empty map is `dead`.
-        let (v_dead, _) = classify_verdict(&f, &no_low_conf());
+        let (v_dead, _) = classify_parent(&f, &no_low_conf());
         assert_eq!(
             v_dead,
             DeadVerdict::Dead,
@@ -831,17 +872,18 @@ mod tests {
     }
 
     /// Seam guard (overlay × verdict-classification): a Direction-B overlay
-    /// addition (`overlay_dead = true`) is computed dead over the authoritative
-    /// merged graph in this worktree, so it must classify `dead` EVEN when its
-    /// name collides with an entry in the parent-truth `low_conf` map — the map
-    /// is parent-graph-derived and stale under the overlay. The candidate
-    /// consult (Lane 3) widened that map to candidate-only bare names, making
-    /// this collision likely. Calibration: the SAME `low_conf` map applied to
-    /// the SAME name with `overlay_dead = false` (a parent entry) yields
-    /// `low-confidence-live` — see `verdict_candidate_only_callee_is_low_…`,
-    /// which is exactly this scenario minus the overlay flag. So the flag, not
-    /// the map, is what flips the verdict; without the bypass the addition would
-    /// be relabeled `low-confidence-live` and filtered out of `--verdict dead`.
+    /// addition (`overlay_dead = true`) skips the parent-truth `low_conf`
+    /// HEURISTIC map — that map is parent-graph-derived and stale under the
+    /// overlay, so a genuinely-worktree-dead function whose name collides with a
+    /// parent heuristic name must NOT be relabeled `low-confidence-live` (which
+    /// would hide it from `--verdict dead`). The overlay_dead leg here passes the
+    /// stale map as `low_conf` and an EMPTY overlay candidate map, so with no
+    /// merged-candidate evidence it classifies `dead`. Calibration: the same map
+    /// applied to the same name with `overlay_dead = false` (a parent entry, via
+    /// `classify_parent`) yields `low-confidence-live`. So the flag, not the map,
+    /// is what flips the verdict. (The companion candidate-recompute relabel — an
+    /// overlay_dead entry WITH merged-candidate evidence → low-confidence-live —
+    /// is pinned by `verdict_overlay_dead_candidate_recompute_relabels`.)
     #[test]
     fn verdict_overlay_dead_bypasses_parent_low_conf_relabel() {
         let mut f = dead_fn(
@@ -850,21 +892,26 @@ mod tests {
             cqs::parser::Language::Rust,
             "fn foo() {}",
         );
-        // Calibration RED: the parent-entry form (overlay_dead = false) collides
-        // with the parent candidate map → low-confidence-live (the bug).
+        // Calibration: the parent-entry form (overlay_dead = false) collides
+        // with the parent candidate map → low-confidence-live.
         let (v_parent, _) =
-            classify_verdict(&f, &candidate_only_low_conf("foo", "bare_arg_unresolved"));
+            classify_parent(&f, &candidate_only_low_conf("foo", "bare_arg_unresolved"));
         assert_eq!(
             v_parent,
             DeadVerdict::LowConfidenceLive,
             "calibration: a PARENT entry whose name is in the candidate map is low-confidence-live"
         );
 
-        // GREEN: mark it a Direction-B overlay addition → it must classify `dead`
-        // despite the identical colliding `low_conf` map.
+        // Mark it a Direction-B overlay addition. With the stale parent map as
+        // `low_conf` and an EMPTY overlay candidate map, it must classify `dead`:
+        // the parent heuristic map is skipped and there is no merged-candidate
+        // evidence.
         f.overlay_dead = true;
-        let (v, reason) =
-            classify_verdict(&f, &candidate_only_low_conf("foo", "bare_arg_unresolved"));
+        let (v, reason) = classify_verdict(
+            &f,
+            &candidate_only_low_conf("foo", "bare_arg_unresolved"),
+            &no_overlay_cand(),
+        );
         assert_eq!(
             v,
             DeadVerdict::Dead,
@@ -877,15 +924,70 @@ mod tests {
         );
     }
 
-    /// The overlay-dead bypass is scoped to the parent-truth `low_conf` relabel
-    /// only: a Direction-B addition that is GENUINELY test-only (origin under
-    /// `tests/`) still classifies `test-only`, and a known-gap origin still
-    /// classifies `known-gap`. Those tiers are name/path/content-derived and stay
-    /// valid under the overlay — only the parent-graph-derived `low_conf` map is
-    /// stale, so only it is bypassed.
+    /// The candidate-recompute fix (this PR): a Direction-B overlay addition
+    /// (`overlay_dead = true`) that IS named in the overlay-merged candidate map
+    /// — a function dead over the merged real caller graph but still referenced
+    /// by a worktree candidate edge — relabels `low-confidence-live`, not `dead`.
+    /// RED before the fix: the classifier forced `dead` for every `overlay_dead`
+    /// entry (the blanket `!overlay_dead` skip), ignoring any candidate evidence.
+    /// Calibration: the SAME entry with an EMPTY overlay candidate map is `dead`
+    /// (see `verdict_overlay_dead_bypasses_parent_low_conf_relabel`), so the
+    /// merged-candidate consult is exactly what flips the verdict.
+    #[test]
+    fn verdict_overlay_dead_candidate_recompute_relabels() {
+        let mut f = dead_fn(
+            "maybe_overlay_fn",
+            "src/lib.rs",
+            cqs::parser::Language::Rust,
+            "fn maybe_overlay_fn() {}",
+        );
+        f.overlay_dead = true;
+
+        // The overlay-merged candidate map names this entry (a candidate-only
+        // reference the confident extractor declined to resolve). The parent
+        // `low_conf` map is empty — the relabel must come from the overlay map.
+        let (v, reason) = classify_verdict(
+            &f,
+            &no_low_conf(),
+            &candidate_only_low_conf("maybe_overlay_fn", "bare_arg_unresolved"),
+        );
+        assert_eq!(
+            v,
+            DeadVerdict::LowConfidenceLive,
+            "an overlay-dead entry named in the overlay-merged candidate map must \
+             relabel low-confidence-live, not dead"
+        );
+        assert!(
+            reason.contains("candidate edge") && reason.contains("bare_arg_unresolved"),
+            "reason must name the merged candidate kind/count: {reason}"
+        );
+        assert!(
+            !reason.contains("heuristic edge"),
+            "candidate-only relabel must NOT claim heuristic edges: {reason}"
+        );
+
+        // Calibration: an EMPTY overlay candidate map leaves the same entry dead.
+        let (v_dead, _) = classify_verdict(&f, &no_low_conf(), &no_overlay_cand());
+        assert_eq!(
+            v_dead,
+            DeadVerdict::Dead,
+            "without the merged-candidate consult, the same overlay-dead entry is dead"
+        );
+    }
+
+    /// Tier ordering holds for a Direction-B addition: a GENUINELY test-only
+    /// origin (under `tests/`) still classifies `test-only`, and a known-gap
+    /// origin (with no candidate evidence) still classifies `known-gap`.
+    /// test-only is checked BEFORE the candidate consult, so it wins even when
+    /// the entry is named in the overlay-merged candidate map. known-gap is
+    /// checked AFTER the candidate consult (the documented order is
+    /// `test-only → low-confidence-live → known-gap → dead`), so it survives only
+    /// when there is no candidate evidence — the candidate consult, like the
+    /// parent `low_conf` consult, intentionally outranks known-gap.
     #[test]
     fn verdict_overlay_dead_still_honors_test_only_and_known_gap() {
-        // test-only: origin under tests/ → TestOnly even when overlay_dead.
+        // test-only: origin under tests/ → TestOnly even when overlay_dead and
+        // named in the overlay candidate map (test-only is checked first).
         let mut t = dead_fn(
             "helper",
             "tests/support.rs",
@@ -895,15 +997,19 @@ mod tests {
         t.overlay_dead = true;
         let (vt, _) = classify_verdict(
             &t,
+            &no_low_conf(),
             &candidate_only_low_conf("helper", "bare_arg_unresolved"),
         );
         assert_eq!(
             vt,
             DeadVerdict::TestOnly,
-            "an overlay-dead test-helper must stay test-only (bypass is scoped to low_conf)"
+            "an overlay-dead test-helper must stay test-only (test-only beats the candidate consult)"
         );
 
-        // known-gap: a served-asset JS handler → KnownGap even when overlay_dead.
+        // known-gap: a served-asset JS handler with NO candidate evidence →
+        // KnownGap even when overlay_dead. (With candidate evidence the
+        // documented order relabels it low-confidence-live first — same as a
+        // parent known-gap entry that also has a heuristic edge.)
         let mut k = dead_fn(
             "onClick",
             "src/serve/assets/app.js",
@@ -911,14 +1017,11 @@ mod tests {
             "function onClick() {}",
         );
         k.overlay_dead = true;
-        let (vk, _) = classify_verdict(
-            &k,
-            &candidate_only_low_conf("onClick", "bare_arg_unresolved"),
-        );
+        let (vk, _) = classify_verdict(&k, &no_low_conf(), &no_overlay_cand());
         assert_eq!(
             vk,
             DeadVerdict::KnownGap,
-            "an overlay-dead served-asset handler must stay known-gap (bypass is scoped to low_conf)"
+            "an overlay-dead served-asset handler with no candidate evidence must stay known-gap"
         );
     }
 
@@ -930,7 +1033,7 @@ mod tests {
             cqs::parser::Language::JavaScript,
             "function onClick() {}",
         );
-        let (v, _) = classify_verdict(&f, &no_low_conf());
+        let (v, _) = classify_parent(&f, &no_low_conf());
         assert_eq!(v, DeadVerdict::KnownGap);
     }
 
@@ -946,7 +1049,7 @@ mod tests {
             cqs::parser::Language::JavaScript,
             "function buildBundle() {}",
         );
-        let (v, _) = classify_verdict(&f, &no_low_conf());
+        let (v, _) = classify_parent(&f, &no_low_conf());
         assert_eq!(
             v,
             DeadVerdict::Dead,
@@ -969,7 +1072,7 @@ mod tests {
         );
         // The map carries it because the store query found a heuristic edge and
         // no trusted edge; the doc edge was ignored.
-        let (v, _) = classify_verdict(&f, &low_conf_with("doc_mentioned"));
+        let (v, _) = classify_parent(&f, &low_conf_with("doc_mentioned"));
         assert_eq!(v, DeadVerdict::LowConfidenceLive);
     }
 
@@ -981,7 +1084,7 @@ mod tests {
             cqs::parser::Language::Python,
             "def __aenter__(self): ...",
         );
-        let (v, _) = classify_verdict(&f, &no_low_conf());
+        let (v, _) = classify_parent(&f, &no_low_conf());
         assert_eq!(v, DeadVerdict::KnownGap);
     }
 
@@ -993,7 +1096,7 @@ mod tests {
             cqs::parser::Language::Rust,
             "fn genuinely_dead() {}",
         );
-        let (v, _) = classify_verdict(&f, &no_low_conf());
+        let (v, _) = classify_parent(&f, &no_low_conf());
         assert_eq!(v, DeadVerdict::Dead);
     }
 
@@ -1006,7 +1109,7 @@ mod tests {
             cqs::parser::Language::Rust,
             "fn make_x() {}",
         );
-        let (v, _) = classify_verdict(&f, &low_conf_with("make_x"));
+        let (v, _) = classify_parent(&f, &low_conf_with("make_x"));
         assert_eq!(v, DeadVerdict::TestOnly);
     }
 
@@ -1035,7 +1138,13 @@ mod tests {
     fn dead_verdict_serialized_on_entry() {
         let low = no_low_conf();
         let f = dead_fn("x", "src/lib.rs", cqs::parser::Language::Rust, "fn x() {}");
-        let out = build_dead_output(&[f], &[], std::path::Path::new("."), &low);
+        let out = build_dead_output(
+            &[f],
+            &[],
+            std::path::Path::new("."),
+            &low,
+            &no_overlay_cand(),
+        );
         let json = serde_json::to_value(&out).unwrap();
         assert_eq!(json["dead"][0]["verdict"], "dead");
         assert!(json["dead"][0].get("verdict_reason").is_some());

--- a/src/cli/worktree_overlay_build.rs
+++ b/src/cli/worktree_overlay_build.rs
@@ -491,4 +491,187 @@ mod tests {
             "overlay1 (rebuilt after the notes update) carries the +0.5 boost"
         );
     }
+
+    /// End-to-end candidate-recompute under the overlay: a parent-LIVE function
+    /// `target` (real `call` edge from `caller` in `src/lib.rs`) loses that edge
+    /// in the worktree (the worktree's `src/lib.rs` no longer calls it), so it is
+    /// a Direction-B addition (`overlay_dead`). A worktree-NEW file
+    /// `src/feature.rs` references `target` as a bare fn-pointer argument
+    /// (`register(target)`) — a `bare_arg_unresolved` `candidate_edges` row the
+    /// confident extractor declines to resolve, landing in the OVERLAY store.
+    /// The verdict classifier must consult the overlay-merged candidate map and
+    /// relabel `target` `low-confidence-live`, NOT `dead` — the bug this fixes.
+    /// The `_meta.overlay_graph` marker stays `"full"` (the candidate section is
+    /// now overlaid too), gated on participation, which a Direction-B addition
+    /// raises. Mirrors `build_overlay_indexes_dirty_delta` for the real-overlay
+    /// scaffolding; cold-loads the embedder, so `slow-tests`.
+    #[test]
+    fn overlay_candidate_recompute_relabels_low_confidence_live() {
+        use cqs::embedder::ModelConfig;
+        use cqs::store::{DeadConfidence, ReadOnly};
+
+        let embedder = match cqs::Embedder::new_cpu(ModelConfig::resolve(None, None)) {
+            Ok(e) => e,
+            Err(e) => {
+                eprintln!("Skipping overlay candidate-recompute e2e: embedder init failed: {e}");
+                return;
+            }
+        };
+        let parser = CqParser::new().expect("parser");
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let parent = tmp.path().join("parent");
+        std::fs::create_dir_all(parent.join("src")).unwrap();
+        // Parent: `caller` makes a real `call` edge to `target`, so `target` is
+        // LIVE in the parent index.
+        std::fs::write(
+            parent.join("src/lib.rs"),
+            "pub fn target() -> i32 { 1 }\npub fn caller() -> i32 { target() }\n",
+        )
+        .unwrap();
+        git(&parent, &["init", "-q", "-b", "main"]);
+        git(&parent, &["config", "user.email", "t@e.com"]);
+        git(&parent, &["config", "user.name", "T"]);
+        git(&parent, &["add", "-A"]);
+        git(&parent, &["commit", "-q", "-m", "init"]);
+
+        let wt = tmp.path().join("wt");
+        git(
+            &parent,
+            &["worktree", "add", "-q", "-b", "lane", wt.to_str().unwrap()],
+        );
+
+        // Worktree edit: `caller` no longer calls `target` — its only real-caller
+        // edge lived in `src/lib.rs` (now masked + re-served from the overlay
+        // without the call), so the merged real caller graph has zero callers for
+        // `target` → it becomes a Direction-B addition.
+        std::fs::write(
+            wt.join("src/lib.rs"),
+            "pub fn target() -> i32 { 1 }\npub fn caller() -> i32 { 0 }\n",
+        )
+        .unwrap();
+        // Worktree-new file: a bare fn-pointer arg `target` the confident pass
+        // drops (cross-file, not defined here) → a `bare_arg_unresolved`
+        // candidate naming `target`, landing in the overlay store.
+        std::fs::write(
+            wt.join("src/feature.rs"),
+            "fn register(_f: fn() -> i32) {}\npub fn use_it() { register(target); }\n",
+        )
+        .unwrap();
+
+        let parent = dunce::canonicalize(&parent).unwrap_or(parent);
+        let wt = dunce::canonicalize(&wt).unwrap_or(wt);
+
+        // Build the parent index ON DISK so it can be re-opened ReadOnly (the
+        // dead-overlay core takes a `Store<ReadOnly>`). Index parent `src/lib.rs`
+        // through the real pipeline so the parent's `caller→target` call edge and
+        // `target`'s def chunk are present.
+        let parent_db = parent.join("parent-index.db");
+        {
+            let parent_store = Store::open(&parent_db).expect("open parent store");
+            let parent_model =
+                ModelInfo::new(&embedder.model_config().repo, embedder.embedding_dim());
+            parent_store.init(&parent_model).expect("init parent store");
+            crate::cli::watch::overlay_reindex_files(
+                &parent,
+                &parent_store,
+                &[std::path::PathBuf::from("src/lib.rs")],
+                &parser,
+                &embedder,
+                None,
+                /* quiet */ true,
+            )
+            .expect("index parent files");
+        }
+        let parent_store_ro = Store::<ReadOnly>::open_readonly(&parent_db).expect("reopen parent");
+
+        // Parent-truth sanity: `target` is NOT dead (it has a real caller).
+        let parent_only = crate::cli::commands::dead_overlay(
+            &parent_store_ro,
+            &parent,
+            &crate::cli::commands::DeadArgs {
+                include_pub: true,
+                min_confidence: DeadConfidence::Low,
+                verdict: None,
+            },
+            None,
+        )
+        .expect("parent-only dead")
+        .0;
+        assert!(
+            !parent_only.dead.iter().any(|e| e.name == "target"),
+            "parent-truth: `target` has a real caller and must not be dead: {:?}",
+            parent_only.dead.iter().map(|e| &e.name).collect::<Vec<_>>()
+        );
+
+        // Build the worktree overlay against the on-disk parent store.
+        let overlay = {
+            let parent_store_for_build = Store::open(&parent_db).expect("open parent for build");
+            build_overlay(
+                &wt,
+                &parent,
+                &parser,
+                &embedder,
+                &parent_store_for_build,
+                None,
+            )
+            .expect("build_overlay")
+            .expect("non-clean worktree yields Some(overlay)")
+        };
+
+        // The candidate landed in the overlay store (the KEY FACT this fix rests
+        // on): `target` is named in the overlay's `candidate_edges`.
+        let overlay_cands = overlay
+            .store
+            .candidate_edge_contributions()
+            .expect("overlay candidate contributions");
+        assert!(
+            overlay_cands.iter().any(|(name, _, _)| name == "target"),
+            "the worktree candidate edge must land in the overlay store: {overlay_cands:?}"
+        );
+
+        // Run the overlay-aware dead core: `apply_dead_overlay` adds `target` as a
+        // Direction-B `overlay_dead` entry, and `build_dead_output` consults the
+        // overlay-merged candidate map → `low-confidence-live`.
+        let (output, participated) = crate::cli::commands::dead_overlay(
+            &parent_store_ro,
+            &parent,
+            &crate::cli::commands::DeadArgs {
+                include_pub: true,
+                min_confidence: DeadConfidence::Low,
+                verdict: None,
+            },
+            Some(&overlay),
+        )
+        .expect("overlay dead");
+
+        let entry = output
+            .dead
+            .iter()
+            .find(|e| e.name == "target")
+            .unwrap_or_else(|| {
+                panic!(
+                    "`target` must surface as a Direction-B addition: {:?}",
+                    output.dead.iter().map(|e| &e.name).collect::<Vec<_>>()
+                )
+            });
+        assert_eq!(
+            entry.verdict, "low-confidence-live",
+            "a candidate-only Direction-B addition must relabel low-confidence-live, not dead: \
+             {entry:?}"
+        );
+        assert!(
+            entry.verdict_reason.contains("candidate edge")
+                && entry.verdict_reason.contains("bare_arg_unresolved"),
+            "reason must name the merged candidate kind/count: {}",
+            entry.verdict_reason
+        );
+
+        // Participation is true (a Direction-B addition changed the set), which is
+        // what gates the honest `_meta.overlay_graph = "full"` marker.
+        assert!(
+            participated,
+            "a Direction-B addition must report overlay participation (gates the `full` marker)"
+        );
+    }
 }

--- a/src/store/calls/dead_code.rs
+++ b/src/store/calls/dead_code.rs
@@ -301,6 +301,32 @@ impl<Mode> Store<Mode> {
         })
     }
 
+    /// Raw per-row `candidate_edges` contributions: `(callee_name, candidate_kind,
+    /// reference-origin file)` for every candidate row in this store. The `file`
+    /// column is the CALLER/reference origin (where the bare-name / macro-arg /
+    /// serde linkage appears), symmetric to `function_calls.file` — so it is the
+    /// masking key for the worktree-overlay merge ([`build_overlay_candidate_map`]),
+    /// which masks parent rows whose reference origin is delta-touched and unions
+    /// the overlay store's rows. Unlike [`Store::find_low_confidence_live_names`]'s
+    /// pre-aggregated candidate arm, this exposes the row-level `file` the merge
+    /// needs and applies NO trusted-edge exclusion: the merge consults this map
+    /// only to relabel a function already computed dead over the merged caller
+    /// graph (zero real callers, so zero trusted callers by construction), where a
+    /// parent trusted edge — if any — lived in a masked origin and is no longer
+    /// authoritative.
+    pub fn candidate_edge_contributions(
+        &self,
+    ) -> Result<Vec<(String, String, String)>, StoreError> {
+        let _span = tracing::info_span!("candidate_edge_contributions").entered();
+        self.rt.block_on(async {
+            let rows: Vec<(String, String, String)> =
+                sqlx::query_as("SELECT callee_name, candidate_kind, file FROM candidate_edges")
+                    .fetch_all(&self.pool)
+                    .await?;
+            Ok(rows)
+        })
+    }
+
     /// Phase 1: Query all callable chunks with no callers in the call graph.
     /// Returns lightweight metadata without content/doc to minimize memory.
     ///
@@ -1045,9 +1071,11 @@ pub fn apply_dead_overlay<M>(
 
         // Newly dead. `Medium` is the honest floor — the file-activity recompute
         // `score_confidence` runs for the parent set is not re-run here.
-        // `overlay_dead`: computed dead over the authoritative merged graph in
-        // this worktree, so verdict classification must not relabel it via the
-        // parent-truth `low_conf` map (stale under the overlay).
+        // `overlay_dead`: computed dead over the authoritative merged caller graph
+        // in this worktree, so verdict classification skips the stale parent-truth
+        // `low_conf` HEURISTIC breakdown for it and instead consults the
+        // overlay-merged CANDIDATE map (`build_overlay_candidate_map`) — a
+        // candidate-only addition still relabels `low-confidence-live`.
         let dead_fn = DeadFunction {
             chunk: def,
             confidence: DeadConfidence::Medium,
@@ -1074,6 +1102,87 @@ pub fn apply_dead_overlay<M>(
     }
 
     Ok(participated)
+}
+
+/// Build the overlay-merged candidate map keyed by callee name, mirroring
+/// [`crate::worktree_overlay::WorktreeOverlay::merge_callers`]'s mask-then-union.
+/// The map carries ONLY the candidate-edge fields of [`LowConfidenceLiveInfo`]
+/// (`candidate_total` + `candidate_counts`); the heuristic-edge fields stay zero
+/// because the candidate graph is the only population recomputed over the overlay
+/// here.
+///
+/// A `candidate_edges` row's `file` column is the CALLER/reference origin
+/// (symmetric to `function_calls.file`), so the merge is the same single-key mask
+/// plus union the caller-graph merge uses:
+///
+/// 1. **Mask**: drop every parent candidate row whose reference origin is in
+///    `masked_origins` — that file's references may have changed or vanished in
+///    the worktree, so its parent rows are no longer authoritative.
+/// 2. **Union**: add every overlay candidate row. Every chunk in the overlay
+///    store comes from a masked origin, so every overlay candidate row's
+///    reference origin is masked too — the mask above already removed any parent
+///    counterpart, so the union cannot double-count.
+///
+/// The result is the candidate references the parent had minus the suspect
+/// (masked-origin) ones, plus the worktree's fresh view of those same origins.
+/// `cqs dead`'s verdict classifier consults this for a Direction-B addition so a
+/// candidate-only overlay-dead entry — a function dead over the merged real
+/// caller graph but still referenced by a worktree candidate edge — relabels
+/// `low-confidence-live` instead of `dead`.
+pub fn build_overlay_candidate_map<M>(
+    store: &Store<M>,
+    overlay: &crate::worktree_overlay::WorktreeOverlay,
+) -> Result<std::collections::HashMap<String, LowConfidenceLiveInfo>, StoreError> {
+    let _span = tracing::info_span!(
+        "build_overlay_candidate_map",
+        masked = overlay.masked_origins.len()
+    )
+    .entered();
+
+    // Reference-origin paths normalized the same way `masked_origins` are stored,
+    // so a parent row's `file` and the mask set are comparable string-for-string.
+    let masked: std::collections::HashSet<String> = overlay
+        .masked_origins
+        .iter()
+        .map(|p| crate::normalize_path(p))
+        .collect();
+
+    // Mask parent rows whose reference origin is delta-touched, then union the
+    // overlay store's rows (every one of which is from a masked origin).
+    let mut merged: Vec<(String, String)> = store
+        .candidate_edge_contributions()?
+        .into_iter()
+        .filter(|(_, _, file)| !masked.contains(&crate::normalize_path(std::path::Path::new(file))))
+        .map(|(name, kind, _)| (name, kind))
+        .collect();
+    merged.extend(
+        overlay
+            .store
+            .candidate_edge_contributions()?
+            .into_iter()
+            .map(|(name, kind, _)| (name, kind)),
+    );
+
+    // Aggregate into per-callee candidate counts (heuristic fields left zero).
+    let mut out: std::collections::HashMap<String, LowConfidenceLiveInfo> =
+        std::collections::HashMap::new();
+    let mut per_kind: std::collections::HashMap<(String, String), u64> =
+        std::collections::HashMap::new();
+    for (name, kind) in merged {
+        let info = out.entry(name.clone()).or_default();
+        info.candidate_total += 1;
+        *per_kind.entry((name, kind)).or_default() += 1;
+    }
+    for ((name, kind), n) in per_kind {
+        if let Some(info) = out.get_mut(&name) {
+            info.candidate_counts.push((kind, n));
+        }
+    }
+    // Stable kind order for deterministic reason strings.
+    for info in out.values_mut() {
+        info.candidate_counts.sort();
+    }
+    Ok(out)
 }
 
 #[cfg(test)]

--- a/src/store/calls/mod.rs
+++ b/src/store/calls/mod.rs
@@ -34,6 +34,11 @@ pub use dead_code::is_dead_doc_path;
 // merged caller graph — single source, no surface drift.
 pub use dead_code::apply_dead_overlay;
 
+// Re-export the worktree-overlay candidate-map merge so the verdict classifier
+// relabels a candidate-only Direction-B addition `low-confidence-live` over the
+// merged candidate graph — same mask-then-union as the caller-graph merge.
+pub use dead_code::build_overlay_candidate_map;
+
 use std::path::PathBuf;
 use std::sync::LazyLock;
 
@@ -53,11 +58,13 @@ pub struct DeadFunction {
     pub confidence: DeadConfidence,
     /// Set only by `apply_dead_overlay` Direction B: this entry was computed
     /// dead over the authoritative merged (parent+overlay) caller graph in this
-    /// worktree, not read off the parent dead set. Verdict classification must
-    /// not relabel it via the parent-truth `low_conf` heuristic-caller map — that
-    /// map is parent-graph-derived and stale under the overlay, so a
+    /// worktree, not read off the parent dead set. Verdict classification skips
+    /// the parent-truth `low_conf` heuristic-caller map for it — that map is
+    /// parent-graph-derived and stale under the overlay, so a
     /// genuinely-worktree-dead function whose name collides with a parent
-    /// candidate/heuristic name would otherwise be hidden from `--verdict dead`.
+    /// heuristic name would otherwise be hidden from `--verdict dead`. It instead
+    /// consults the overlay-merged CANDIDATE map (`build_overlay_candidate_map`),
+    /// so a candidate-only addition still relabels `low-confidence-live`.
     /// Internal-only; entries reach user-facing JSON as `DeadFunctionEntry`.
     #[serde(skip)]
     pub overlay_dead: bool,

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -185,6 +185,11 @@ pub use calls::is_dead_doc_path;
 /// Shared by the `cqs dead` core and the lib-level `cqs ci` analysis.
 pub use calls::apply_dead_overlay;
 
+/// Worktree-overlay candidate-map merge (mask-then-union over the merged
+/// candidate graph). Lets the verdict classifier relabel a candidate-only
+/// Direction-B addition `low-confidence-live`.
+pub use calls::build_overlay_candidate_map;
+
 /// Confidence level for dead code detection.
 pub use calls::DeadConfidence;
 


### PR DESCRIPTION
## Fix: recompute candidate_edges under the worktree overlay

Closes #1937.

Under the worktree overlay, `cqs dead`'s Direction-B additions classify `dead` via the `overlay_dead` bypass — which correctly skips the *stale heuristic* low-confidence relabel (the parent function_calls graph is wrong over the merged caller set). But the candidate map was parent-truth only, so a **candidate-only Direction-B addition** (dead over the merged *real* caller graph, yet referenced by a *worktree* candidate edge) was wrongly reported `dead` instead of `low-confidence-live`.

**Fix — a pure read-merge, no new overlay plumbing** (the worktree's candidate emits already land in `overlay.store`):
- New `build_overlay_candidate_map` (`store/calls/dead_code.rs`) mirrors `merge_callers`'s mask-then-union: mask parent `candidate_edges` rows whose reference origin is delta-touched, union the overlay store's rows. Backed by a new `candidate_edge_contributions` reader.
- The verdict classifier consults the overlay-merged candidate map for `overlay_dead` entries (still skipping the stale heuristic map): a candidate-only addition relabels `low-confidence-live`; a genuinely-dead addition stays `dead`.
- `_meta.overlay_graph` stays `"full"` — the fix *strengthens* the full claim (the candidate section is now overlaid too), it doesn't narrow it.

**Tests (fail-before / pass-after):**
- unit verdict: `verdict_overlay_dead_candidate_recompute_relabels` (+ parent-form tests repointed through a `classify_parent` wrapper)
- store/dead split: `dead_overlay_addition_classifies_dead_despite_low_conf_collision` (heuristic collision stays dead) + `dead_overlay_addition_candidate_in_live_origin_relabels`
- slow e2e: `overlay_candidate_recompute_relabels_low_confidence_live` (real git worktree → `build_overlay` → `dead_overlay`)
- marker guard: `dead_overlay_marker_is_full`

Regression sweeps green (dead_code 22, candidate 62, ci 10, overlay 63). Gates: fmt / `clippy --all-targets` / targeted tests / provenance lint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
