### PR TITLE
fix(dead): #[test] fns classify test-only not dead (#1573 Tier 4) + close #1944

### DIFF
--- a/src/cli/commands/review/dead.rs
+++ b/src/cli/commands/review/dead.rs
@@ -131,12 +131,21 @@ fn known_gap_reason(entry: &DeadFunction) -> Option<&'static str> {
         .map(|rule| rule.reason)
 }
 
-/// Whether a dead entry is test-only: origin under a `tests/` path segment, or
-/// the chunk content sits inside a `#[cfg(test)]` module. The content scan is a
-/// substring check — false-positive-friendly in the safe direction (a comment
-/// mentioning `#[cfg(test)]` keeps the function classified test-only, which only
-/// moves it OUT of the actionable `dead` list).
+/// Whether a dead entry is test-only: the chunk is tagged `ChunkType::Test`, its
+/// origin is under a `tests/` path segment, or the chunk content sits inside a
+/// `#[cfg(test)]` module. The content scan is a substring check —
+/// false-positive-friendly in the safe direction (a comment mentioning
+/// `#[cfg(test)]` keeps the function classified test-only, which only moves it
+/// OUT of the actionable `dead` list).
 fn is_test_only(entry: &DeadFunction) -> bool {
+    // Chunk-type tag: the parser already classifies a `#[test]` function as
+    // `ChunkType::Test`. A bare `#[test]` fn's byte range carries only the
+    // `#[test]` attribute — the enclosing `#[cfg(test)]` lives on the `mod
+    // tests`, outside this chunk — so the content scan below cannot see it. The
+    // tag is the authoritative signal; rely on it first.
+    if entry.chunk.chunk_type == cqs::parser::ChunkType::Test {
+        return true;
+    }
     let origin = entry.chunk.file.to_string_lossy();
     // Origin-prefix: a `tests/` path segment (also `/tests/`, `\tests\`).
     if origin.starts_with("tests/") || origin.contains("/tests/") || origin.contains("\\tests\\") {
@@ -162,13 +171,13 @@ fn classify_verdict(
     overlay_candidate: &std::collections::HashMap<String, cqs::store::LowConfidenceLiveInfo>,
 ) -> (DeadVerdict, String) {
     if is_test_only(entry) {
-        // Softened to claim only what the substring scan actually knows: a
-        // `tests/` path segment or the literal `#[cfg(test)]` appearing in the
-        // chunk content (which the comment scan cannot distinguish from a real
-        // attribute — documented limitation).
+        // Claim only what the test-only check actually knows: a `ChunkType::Test`
+        // tag (a `#[test]` function), a `tests/` path segment, or the literal
+        // `#[cfg(test)]` appearing in the chunk content (which the substring scan
+        // cannot distinguish from a real attribute — documented limitation).
         return (
             DeadVerdict::TestOnly,
-            "origin under tests/ path or content contains '#[cfg(test)]'".to_string(),
+            "test chunk, origin under tests/ path, or content contains '#[cfg(test)]'".to_string(),
         );
     }
     // Pick the liveness-evidence map for this entry. A Direction-B overlay
@@ -811,6 +820,56 @@ mod tests {
         );
         let (v, _) = classify_parent(&f, &no_low_conf());
         assert_eq!(v, DeadVerdict::TestOnly);
+    }
+
+    /// A `#[test]` function classifies `test-only` even when its content lacks
+    /// `#[cfg(test)]` and its origin is NOT under a `tests/` path. The parser
+    /// tags it `ChunkType::Test`; a bare `#[test]` fn's byte range carries only
+    /// `#[test]` (the enclosing `#[cfg(test)]` is on the `mod tests`, outside the
+    /// chunk), so the content substring scan alone misses it — the chunk-type tag
+    /// is what catches it. RED before the fix: with neither the `tests/` prefix
+    /// nor `#[cfg(test)]` in content, the old `is_test_only` returned false and
+    /// the entry mis-classified `dead`. Calibration: the SAME chunk built as
+    /// `ChunkType::Function` (via `dead_fn`) classifies `dead`, so the tag is what
+    /// flips the verdict.
+    #[test]
+    fn verdict_test_only_by_chunk_type_tag() {
+        let mut f = dead_fn(
+            "it_works",
+            "src/lib.rs",
+            cqs::parser::Language::Rust,
+            // Only `#[test]` is inside the chunk — no `#[cfg(test)]`, no tests/
+            // path. The content scan and origin-prefix check both miss it.
+            "#[test]\nfn it_works() { assert!(true); }",
+        );
+        f.chunk.chunk_type = cqs::parser::ChunkType::Test;
+        let (v, reason) = classify_parent(&f, &no_low_conf());
+        assert_eq!(
+            v,
+            DeadVerdict::TestOnly,
+            "a #[test] fn (ChunkType::Test) must classify test-only even without \
+             #[cfg(test)] in content or a tests/ origin"
+        );
+        assert!(
+            reason.contains("test chunk"),
+            "reason should name the test-chunk tag: {reason}"
+        );
+
+        // Calibration: the identical chunk tagged Function (the `dead_fn`
+        // default) has no other test-only signal, so it is `dead`. The tag is
+        // exactly what flips the verdict.
+        let f_fn = dead_fn(
+            "it_works",
+            "src/lib.rs",
+            cqs::parser::Language::Rust,
+            "#[test]\nfn it_works() { assert!(true); }",
+        );
+        let (v_fn, _) = classify_parent(&f_fn, &no_low_conf());
+        assert_eq!(
+            v_fn,
+            DeadVerdict::Dead,
+            "without the ChunkType::Test tag, the same chunk would be dead"
+        );
     }
 
     #[test]

--- a/src/store/calls/dead_code.rs
+++ b/src/store/calls/dead_code.rs
@@ -1076,6 +1076,18 @@ pub fn apply_dead_overlay<M>(
         // `low_conf` HEURISTIC breakdown for it and instead consults the
         // overlay-merged CANDIDATE map (`build_overlay_candidate_map`) — a
         // candidate-only addition still relabels `low-confidence-live`.
+        //
+        // Precondition for that candidate consult: the entry has zero trusted
+        // merged callers. `build_overlay_candidate_map` omits the trusted-edge
+        // exclusion, so its output is only safe to read for a zero-trusted-caller
+        // name — consulting it for a possibly-live function would mislabel it.
+        // `has_real` is false here (zero real callers), and trusted is a subset of
+        // real, so zero-trusted holds; pin it.
+        debug_assert!(
+            !merged.iter().any(|c| c.edge_kind.is_trusted()),
+            "overlay_dead candidate {name} has a trusted merged caller — the \
+             overlay candidate map must only be consulted for zero-trusted-caller entries"
+        );
         let dead_fn = DeadFunction {
             chunk: def,
             confidence: DeadConfidence::Medium,
@@ -1129,6 +1141,19 @@ pub fn apply_dead_overlay<M>(
 /// candidate-only overlay-dead entry — a function dead over the merged real
 /// caller graph but still referenced by a worktree candidate edge — relabels
 /// `low-confidence-live` instead of `dead`.
+///
+/// CALLER CONTRACT: this output must only be consulted for names with zero
+/// trusted merged callers — the `overlay_dead` entries, computed dead over the
+/// authoritative merged real-caller graph (zero real callers ⇒ zero trusted
+/// callers, since trusted is a subset of real). Unlike
+/// [`Store::find_low_confidence_live_names`], this map OMITS the trusted-edge
+/// exclusion: it counts every candidate row, including rows for a function the
+/// trusted call graph already proves live. Consulting it for a possibly-live
+/// function (one with ≥1 trusted merged caller) would therefore relabel that
+/// genuinely-live function `low-confidence-live`, mislabeling it. The consult
+/// site in `apply_dead_overlay` (where `overlay_dead = true` is set, after
+/// `merge_callers` confirms zero real merged callers) is the only admissible
+/// reader; a `debug_assert!` there pins the zero-real-caller precondition.
 pub fn build_overlay_candidate_map<M>(
     store: &Store<M>,
     overlay: &crate::worktree_overlay::WorktreeOverlay,


### PR DESCRIPTION
## fix(dead): #[test] fns classify test-only, not dead (#1573 Tier 4) + close #1944

Closes #1944. Addresses #1573 (Tier 4).

**#1573 Tier 4 — the biggest remaining `cqs dead` false-positive source.** On main, `cqs dead --verdict dead` reports 9 entries; **6 are `#[test]` functions wrongly classified `dead`**. `is_test_only` substring-scanned the chunk's own content for `#[cfg(test)]`, but a bare `#[test]`-fn chunk's byte range carries only `#[test]` — the `#[cfg(test)]` lives on the enclosing `mod tests`, outside the chunk. Fix: `is_test_only` now treats `chunk_type == ChunkType::Test` as test-only (the parser already tags these). Analysis-only — **no PARSER_VERSION bump, no reindex**. Expected effect: `--verdict dead` drops 9 → 3.

Test `verdict_test_only_by_chunk_type_tag` (verified RED-before / GREEN-after) with a `ChunkType::Function` calibration leg isolating the tag as the flipping signal.

**Closes #1944 (ride-along).** `build_overlay_candidate_map` omits the trusted-edge exclusion that `find_low_confidence_live_names` carries — safe only because its sole consumer reads it for `overlay_dead` entries (zero real ⇒ zero trusted callers). Added the caller-contract doc paragraph + a `debug_assert!` at the `overlay_dead = true` site pinning the zero-trusted-caller precondition (structurally guaranteed by the preceding `if has_real { continue }`).

**Remaining #1573 residual (NOT closed):** 2 genuine FPs — `visit_seq` (serde `Visitor` trait method) and `hnsw_filter` (HNSW filter callback) — framework-trait-impl methods invoked via dynamic dispatch the static call graph doesn't resolve (the Tier-3a class). Best addressed as a future candidate-edge kind (`external_trait_impl` → demote to `low-confidence-live`), so #1573 stays open for it.

Gates: fmt / `clippy --all-targets` / targeted verdict (17) + dead_code (22) + overlay (14) tests / provenance lint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
