### PR TITLE
fix(hnsw): DotProduct metric no longer panics on f32 unit-norm vectors (closes #1949)

### DIFF
--- a/src/hnsw/build.rs
+++ b/src/hnsw/build.rs
@@ -743,4 +743,52 @@ mod tests {
         let nan_query = Embedding::new(vec![f32::NAN; crate::EMBEDDING_DIM]);
         assert!(index.search(&nan_query, 5).is_empty());
     }
+
+    /// The DotProduct arm must build AND self-query without panicking on
+    /// f32-L2-normalized vectors. A vector L2-normalized in f32 has a self-dot
+    /// fractionally above 1.0 (≈ 1.0000005); the stock dot distance asserts
+    /// `a·b <= 1` and would unwind a parallel-insert worker on the build path
+    /// (killing the whole build) and panic on the self-match search path. The
+    /// clamped dot distance maps that to distance 0 instead. Sweeping a wide
+    /// seed band exercises the many seeds that produce a >1.0 self-dot.
+    #[test]
+    fn dot_build_and_self_query_does_not_panic_over_seed_band() {
+        use crate::index::DistanceMetric;
+        // Build one DotProduct index over a band of make_test_embedding seeds,
+        // then self-query EACH indexed vector. The previous failure unwound
+        // during parallel_insert_data (build) or during search_neighbours
+        // (the self-match dot > 1.0), so reaching the end without a panic IS
+        // the assertion.
+        let embeddings: Vec<(String, Embedding)> = (0..64u32)
+            .map(|i| (format!("chunk_{i}"), make_embedding(i)))
+            .collect();
+        let index = HnswIndex::build_with_dim_and_metric(
+            embeddings,
+            crate::EMBEDDING_DIM,
+            DistanceMetric::DotProduct,
+        )
+        .expect("DotProduct build must not panic on f32-normalized vectors");
+        assert_eq!(index.len(), 64);
+
+        for i in 0..64u32 {
+            // The query is an indexed vector; its self-dot is the >1.0 input
+            // that previously tripped the assert. Search must return finite,
+            // in-range scores rather than panic.
+            let q = make_embedding(i);
+            let hits = index.search(&q, 5);
+            for h in &hits {
+                assert!(
+                    h.score.is_finite(),
+                    "non-finite dot score for seed {i}: {}",
+                    h.score
+                );
+                // score = 1 - dist = min(a·b, 1) — never exceeds 1.0.
+                assert!(
+                    h.score <= 1.0 + 1e-5,
+                    "clamped dot score must not exceed 1.0 for seed {i}: {}",
+                    h.score
+                );
+            }
+        }
+    }
 }

--- a/src/hnsw/mod.rs
+++ b/src/hnsw/mod.rs
@@ -33,7 +33,7 @@ pub use persist::{
 
 use std::cell::UnsafeCell;
 
-use hnsw_rs::anndists::dist::distances::{DistCosine, DistDot};
+use hnsw_rs::anndists::dist::distances::{DistCosine, Distance};
 use hnsw_rs::api::AnnT;
 use hnsw_rs::hnsw::{Hnsw, Neighbour};
 use hnsw_rs::hnswio::HnswIo;
@@ -267,6 +267,36 @@ pub enum HnswError {
 // Note: Uses crate::index::IndexResult instead of a separate HnswResult type
 // since they have identical structure (id: String, score: f32)
 
+/// Dot-product distance with the dot product clamped to `<= 1.0` before the
+/// `1 - a·b` subtraction, so the result is always `>= 0`.
+///
+/// anndists' stock `DistDot` asserts `a·b <= 1.0` (scalar path) / the SIMD
+/// equivalent, and `DistCosine`-style renormalization is NOT applied for the
+/// dot metric. f32 L2-normalization is only approximately unit-norm: a
+/// vector normalized in f32 can have `a·a` slightly above `1.0` (observed
+/// ≈ 1.0000005), and a self-match or near-collinear pair then yields
+/// `a·b > 1.0`, tripping anndists' assert and unwinding the rayon insert
+/// worker (build path) or the search call. Computing the dot here and
+/// clamping it to `1.0` first makes the precondition unconditionally true:
+/// a near-identical pair correctly maps to distance `0` (most similar),
+/// and a genuinely closer-than-unit pair can never produce a negative
+/// distance. The dot is computed locally rather than delegated to
+/// anndists' `DistDot`, so BOTH its scalar and SIMD asserts are bypassed.
+#[derive(Default, Copy, Clone)]
+pub(crate) struct DistDotClamped;
+
+impl Distance<f32> for DistDotClamped {
+    fn eval(&self, va: &[f32], vb: &[f32]) -> f32 {
+        debug_assert_eq!(va.len(), vb.len());
+        let dot: f32 = va.iter().zip(vb.iter()).map(|(a, b)| a * b).sum();
+        // Clamp BEFORE subtracting so `1 - dot` is always `>= 0`. f32
+        // L2-normalization leaves `a·a` slightly above 1.0, so an unclamped
+        // self-dot would yield a negative distance and trip the downstream
+        // ordering invariants the library relies on.
+        1.0 - dot.min(1.0)
+    }
+}
+
 /// Metric-dispatching wrapper over the concrete `Hnsw<f32, D>` types.
 ///
 /// hnsw_rs bakes the distance into the type parameter (`Hnsw<'a, f32, D>`),
@@ -281,9 +311,12 @@ pub enum HnswError {
 pub(crate) enum HnswGraph<'a> {
     /// `DistCosine` — the default metric.
     Cosine(Hnsw<'a, f32, DistCosine>),
-    /// `DistDot` (`dist = 1 − a·b`). NOTE: anndists asserts `a·b <= 1`, so
-    /// this variant expects unit-norm (or sub-unit-dot) embeddings.
-    Dot(Hnsw<'a, f32, DistDot>),
+    /// `DistDotClamped` (`dist = 1 − min(a·b, 1)`). The dot is clamped to
+    /// `<= 1` before the subtraction, so the distance is always `>= 0` even
+    /// for the f32-L2-normalized vectors whose self-dot exceeds 1.0 by a
+    /// rounding margin — the precondition can never be violated, on either
+    /// the build or the search path.
+    Dot(Hnsw<'a, f32, DistDotClamped>),
 }
 
 /// Dispatch a method body across every [`HnswGraph`] variant. Local macro
@@ -333,7 +366,7 @@ impl<'a> HnswGraph<'a> {
                     nb_elem,
                     max_layer,
                     ef_construction,
-                    DistDot,
+                    DistDotClamped,
                 );
                 h.modify_level_scale(LEVEL_SCALE_FACTOR);
                 HnswGraph::Dot(h)
@@ -360,7 +393,7 @@ impl<'a> HnswGraph<'a> {
     pub(crate) fn load(io: &'a mut HnswIo, metric: DistanceMetric) -> Result<Self, HnswError> {
         match metric {
             DistanceMetric::Cosine => io.load_hnsw::<f32, DistCosine>().map(HnswGraph::Cosine),
-            DistanceMetric::DotProduct => io.load_hnsw::<f32, DistDot>().map(HnswGraph::Dot),
+            DistanceMetric::DotProduct => io.load_hnsw::<f32, DistDotClamped>().map(HnswGraph::Dot),
         }
         .map_err(|e| HnswError::Internal(format!("Failed to load HNSW: {}", e)))
     }
@@ -753,8 +786,8 @@ impl VectorIndex for HnswIndex {
     /// HNSW with the `Cosine` metric returns `1 - DistCosine`, which on full
     /// vectors is exactly the cosine similarity the brute-force path
     /// recomputes — so its scores are reusable. The `DotProduct` metric
-    /// returns `1 - DistDot = a·b`, a different scale from cosine, so it leaves
-    /// the default `false`.
+    /// returns `1 - min(a·b, 1) = min(a·b, 1)`, a different scale from
+    /// cosine, so it leaves the default `false`.
     fn index_scores_are_cosine(&self) -> bool {
         self.metric() == DistanceMetric::Cosine
     }
@@ -965,6 +998,42 @@ mod send_sync_tests {
     fn test_hnsw_index_is_send_sync() {
         assert_send::<HnswIndex>();
         assert_sync::<HnswIndex>();
+    }
+
+    /// The clamped dot distance must never return a negative value, even when
+    /// the raw dot exceeds 1.0 — that is the precondition the stock `DistDot`
+    /// asserts and the f32-normalization margin violates. A self-dot above
+    /// 1.0 must map to distance exactly 0 (most similar), not a negative.
+    #[test]
+    fn dist_dot_clamped_never_negative_on_overunit_dot() {
+        use hnsw_rs::anndists::dist::distances::Distance;
+        let d = super::DistDotClamped;
+        // Raw dot = 1.0000005 > 1.0 (the observed f32 self-norm margin).
+        let a = [1.0f32, 0.0007f32];
+        // a·a = 1 + 0.0007^2 = 1.00000049 > 1.0.
+        let dist = d.eval(&a, &a);
+        assert!(
+            dist >= 0.0,
+            "clamped dot distance must be >= 0 for an over-unit dot, got {dist}"
+        );
+        assert!(
+            dist.abs() < 1e-6,
+            "over-unit self-dot must clamp to ~0, got {dist}"
+        );
+
+        // A sub-unit dot is unaffected: dist = 1 - a·b.
+        let x = [0.6f32, 0.0f32];
+        let y = [0.5f32, 0.0f32]; // a·b = 0.30
+        let dist2 = d.eval(&x, &y);
+        assert!(
+            (dist2 - 0.70).abs() < 1e-6,
+            "sub-unit dot must pass through: {dist2}"
+        );
+
+        // Orthogonal vectors: dot = 0 => distance 1.0 (most dissimilar).
+        let p = [1.0f32, 0.0f32];
+        let q = [0.0f32, 1.0f32];
+        assert!((d.eval(&p, &q) - 1.0).abs() < 1e-6);
     }
 
     #[test]

--- a/src/hnsw/search.rs
+++ b/src/hnsw/search.rs
@@ -123,8 +123,8 @@ impl HnswIndex {
                 if idx < self.id_map.len() {
                     // Distance → similarity. Holds for both supported
                     // metrics: DistCosine returns 1 − cos (score = cos) and
-                    // DistDot returns 1 − a·b (score = a·b) — see
-                    // `DistanceMetric`.
+                    // the clamped dot returns 1 − min(a·b, 1) (score =
+                    // min(a·b, 1)) — see `DistanceMetric`.
                     let score = 1.0 - n.distance;
                     if !score.is_finite() {
                         tracing::warn!(

--- a/src/index.rs
+++ b/src/index.rs
@@ -30,11 +30,12 @@ use crate::store::{ClearHnswDirty, Store, StoreError};
 /// - [`Cosine`](Self::Cosine) (default): HNSW uses `DistCosine`; CAGRA keeps
 ///   cuVS's default `L2Expanded`, which is rank-equivalent to cosine on the
 ///   unit-norm embeddings cqs produces (`d² = 2 − 2·cos`).
-/// - [`DotProduct`](Self::DotProduct): HNSW uses `DistDot`
-///   (`dist = 1 − a·b`); CAGRA sets cuVS `InnerProduct`. Note hnsw_rs's
-///   `DistDot` asserts `a·b <= 1`, so un-normalized embedding models whose
-///   pairwise dot products exceed 1 are not usable on the HNSW backend
-///   without a scaling pass.
+/// - [`DotProduct`](Self::DotProduct): HNSW uses `DistDotClamped`
+///   (`dist = 1 − min(a·b, 1)`); CAGRA sets cuVS `InnerProduct`. anndists'
+///   stock `DistDot` asserts `a·b <= 1` and would panic on the f32-L2-norm
+///   margin (a self-dot ≈ 1.0000005) or any pairwise dot above 1; cqs clamps
+///   the dot to `<= 1` before the subtraction, so the distance is always
+///   `>= 0` and a near-identical pair maps to distance 0 (most similar).
 ///
 /// `L2` is deliberately absent: both score-conversion paths
 /// (`1 − dist` for HNSW, `1 − d²/2` for CAGRA) are cosine-similarity-shaped

--- a/tests/proptest_hnsw_persist_orphan.proptest-regressions
+++ b/tests/proptest_hnsw_persist_orphan.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc ad0987f9cbe14b12c2423ea68a1750afbe364f476a2597f072e496802a22ccbf # shrinks to seed = 0, n = 2, k = 1, dot = true, clusters = 1, query_idx = 0

--- a/tests/proptest_hnsw_persist_orphan.rs
+++ b/tests/proptest_hnsw_persist_orphan.rs
@@ -1,0 +1,370 @@
+// Property tests for the HNSW persist/load round-trip and the reduced
+// level-scale orphan-elimination guarantee.
+//
+// Four algebraic invariants over GENERATED inputs:
+//
+// 1. PERSIST->LOAD k-NN EQUIVALENCE
+//    For any (N vectors, metric, query, k):
+//      build(V).search(q,k)  ==  load(save(build(V))).search(q,k)
+//    (same ids in the same order, same scores). The example suite only
+//    asserts "self-match reachable" and len/dim survive; it never asserts
+//    the FULL ranked result set is byte-identical across the persist
+//    boundary for an arbitrary query. A second variant exercises the
+//    DotProduct arm with clustered (near-collinear) vectors and a self
+//    query — the regime where a self-dot exceeds 1.0 in f32 and the
+//    distance impl must clamp rather than panic.
+//
+// 2. ORPHAN-ELIMINATION
+//    For any (N vectors): every inserted point is self-reachable — querying
+//    with a point's OWN vector returns its id in the top-k. Tries to find an
+//    N where LEVEL_SCALE_FACTOR=0.5 still leaves a self-unreachable orphan.
+//    The example suite checks only the *scale value* and a single 2-5 vector
+//    reachability case; it never sweeps N.
+//
+// 3. METRIC ROUND-TRIP
+//    For any (N, metric in {Cosine, DotProduct}):
+//      load(save(build_m(V))).metric() == m
+//
+// GENERATOR COVERAGE CLAIM (and distrust):
+// - N in 1..=64 (covers the empty-ish and small-tier; all < 5000 so M=16
+//   tier). Hand examples use N in {2,3,5,10,20,25}. This fills the gaps and
+//   the boundaries (N=1, N=64).
+// - vectors are EMBEDDING_DIM random unit vectors with at least one nonzero
+//   component (avoids the zero-vector skip so id_map stays == N).
+// - metric covers BOTH arms.
+// - query is either an exact copy of an indexed vector (exact-match oracle)
+//   or a fresh random vector.
+// DISTRUST: 768-dim random gaussian vectors are near-orthogonal, so the
+// k-NN ordering is well-separated and the persist round-trip SHOULD be
+// exact. If it is not, that is a real codec bug. Orphan detection is
+// probabilistic per-build (~1-2% under concurrent-insert contention) so the
+// orphan property uses a small retry to separate a SYSTEMATIC orphan
+// (every build) from concurrent-build noise.
+
+use cqs::embedder::Embedding;
+use cqs::hnsw::HnswIndex;
+use cqs::index::DistanceMetric;
+use cqs::EMBEDDING_DIM;
+
+use proptest::prelude::*;
+
+/// Deterministic pseudo-random unit vector from a seed + index. Pure (no RNG
+/// crate, reproducible from the proptest seed). Guarantees >=1 nonzero comp.
+fn unit_vec(seed: u64, idx: usize) -> Embedding {
+    let mut v = vec![0.0f32; EMBEDDING_DIM];
+    // A simple splitmix-ish hash per component → spread values in [-1,1].
+    let mut state = seed
+        .wrapping_mul(0x9E3779B97F4A7C15)
+        .wrapping_add(idx as u64)
+        .wrapping_add(1);
+    for c in v.iter_mut() {
+        state ^= state >> 30;
+        state = state.wrapping_mul(0xBF58476D1CE4E5B9);
+        state ^= state >> 27;
+        state = state.wrapping_mul(0x94D049BB133111EB);
+        state ^= state >> 31;
+        // Map to [-1, 1).
+        let frac = (state as f64) / (u64::MAX as f64);
+        *c = (frac * 2.0 - 1.0) as f32;
+    }
+    // Force a guaranteed-nonzero component so the build never skips this vector.
+    v[(idx + 1) % EMBEDDING_DIM] += 1.0;
+    let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm > 0.0 {
+        for x in &mut v {
+            *x /= norm;
+        }
+    }
+    Embedding::new(v)
+}
+
+fn build_vectors(seed: u64, n: usize) -> Vec<(String, Embedding)> {
+    (0..n)
+        .map(|i| (format!("id_{i}"), unit_vec(seed, i)))
+        .collect()
+}
+
+/// CLUSTERED vectors: groups of near-duplicates around a few centroids. This
+/// is where k-NN ranking TIES live — the regime random-orthogonal vectors
+/// never reach. If save/load ever reorders tied-distance candidates, this
+/// generator is what bites. Each vector is a centroid plus a tiny per-index
+/// perturbation, then renormalized.
+fn clustered_vectors(seed: u64, n: usize, clusters: usize) -> Vec<(String, Embedding)> {
+    let clusters = clusters.max(1);
+    (0..n)
+        .map(|i| {
+            let centroid = unit_vec(seed, i % clusters);
+            let jitter = unit_vec(seed ^ 0x5151_5151, i);
+            let mut v: Vec<f32> = centroid
+                .as_slice()
+                .iter()
+                .zip(jitter.as_slice().iter())
+                // 1e-3 jitter => members of a cluster are ~0.999+ cosine,
+                // forcing near-tied distances the graph must rank stably.
+                .map(|(c, j)| c + 1e-3 * j)
+                .collect();
+            let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+            if norm > 0.0 {
+                for x in &mut v {
+                    *x /= norm;
+                }
+            }
+            (format!("id_{i}"), Embedding::new(v))
+        })
+        .collect()
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 96,
+        max_shrink_iters: 2000,
+        .. ProptestConfig::default()
+    })]
+
+    /// INVARIANT 1: persist->load k-NN equivalence.
+    /// load(save(build(V))).search(q,k) == build(V).search(q,k), exactly.
+    #[test]
+    fn persist_load_knn_equivalence(
+        seed in any::<u64>(),
+        n in 1usize..=64,
+        k in 1usize..=20,
+        // 0 => query is a copy of an indexed vector; 1 => fresh random query.
+        query_kind in 0u8..2,
+        query_idx in any::<usize>(),
+    ) {
+        let metric = DistanceMetric::Cosine;
+        let vectors = build_vectors(seed, n);
+        let built = HnswIndex::build_with_dim_and_metric(
+            vectors.clone(), EMBEDDING_DIM, metric,
+        ).expect("build");
+        prop_assert_eq!(built.len(), n, "id_map count must equal N");
+
+        let dir = tempfile::tempdir().expect("tmp");
+        let basename = "p";
+        built.save(dir.path(), basename).expect("save");
+        let loaded = HnswIndex::load_with_dim(dir.path(), basename, EMBEDDING_DIM)
+            .expect("load");
+
+        let query = if query_kind == 0 {
+            unit_vec(seed, query_idx % n)
+        } else {
+            // Fresh query: use a seed that is not in the indexed set.
+            unit_vec(seed ^ 0xDEAD_BEEF, query_idx)
+        };
+
+        let a = built.search(&query, k);
+        let b = loaded.search(&query, k);
+
+        // Same ranked id list across the persist boundary.
+        let a_ids: Vec<&str> = a.iter().map(|r| r.id.as_str()).collect();
+        let b_ids: Vec<&str> = b.iter().map(|r| r.id.as_str()).collect();
+        prop_assert_eq!(
+            &a_ids, &b_ids,
+            "k-NN id ranking diverged across save/load (n={}, k={}): in-memory={:?} loaded={:?}",
+            n, k, a_ids, b_ids
+        );
+        // Scores must match to f32 bit-equality: same graph, same data, same
+        // dist fn => same distances.
+        for (ra, rb) in a.iter().zip(b.iter()) {
+            prop_assert!(
+                (ra.score - rb.score).abs() < 1e-6,
+                "score diverged for id {}: in-memory={} loaded={}",
+                ra.id, ra.score, rb.score
+            );
+        }
+    }
+
+    /// INVARIANT 1b: persist->load k-NN equivalence on the DotProduct arm
+    /// AND with clustered (near-tied) vectors — the two regimes the random
+    /// Cosine case above does not reach. This is also the arm that, before
+    /// the dot clamp, PANICKED: an f32-L2-normalized self/near-collinear
+    /// vector has a self-dot fractionally above 1.0, and the stock dot
+    /// distance asserts `a·b <= 1`. The clamp turns that into distance 0
+    /// instead of a panic, so the search returns a (tied) result set rather
+    /// than unwinding.
+    ///
+    /// EQUIVALENCE SHAPE under the clamp. A cluster of near-collinear vectors
+    /// collapses to a band of GENUINELY tied scores. Two facts then bound
+    /// what save/load can promise:
+    ///   - HNSW is APPROXIMATE: when the tie band is wider than k, which k of
+    ///     the equally-scored candidates come back depends on graph traversal
+    ///     order, and the in-memory build (parallel insert) and the reloaded
+    ///     dump traverse independently — so the returned id SET is NOT a
+    ///     save/load invariant in this regime.
+    ///   - What IS invariant, and is the load-bearing codec check: the result
+    ///     CARDINALITY and the SCORE SEQUENCE (sorted best-first). A codec
+    ///     that corrupted a vector, dropped a graph edge en masse, or swapped
+    ///     the dist fn would perturb the score sequence; this catches that
+    ///     without over-specifying tie-break order the library never promises.
+    #[test]
+    fn persist_load_knn_equivalence_dot_and_clustered(
+        seed in any::<u64>(),
+        n in 2usize..=64,
+        k in 1usize..=20,
+        dot in any::<bool>(),
+        clusters in 1usize..=6,
+        query_idx in any::<usize>(),
+    ) {
+        let metric = if dot { DistanceMetric::DotProduct } else { DistanceMetric::Cosine };
+        let vectors = clustered_vectors(seed, n, clusters);
+        let built = HnswIndex::build_with_dim_and_metric(
+            vectors.clone(), EMBEDDING_DIM, metric,
+        ).expect("build");
+        prop_assert_eq!(built.len(), n);
+
+        let dir = tempfile::tempdir().expect("tmp");
+        built.save(dir.path(), "c").expect("save");
+        let loaded = HnswIndex::load_with_dim(dir.path(), "c", EMBEDDING_DIM).expect("load");
+
+        // Query an indexed vector exactly: in a cluster, several members are
+        // near-tied to it, so the top-k is the maximally ambiguous case — and
+        // for the dot arm the self/near-collinear dot is the >1.0 input that
+        // previously tripped the assert.
+        let (_, q) = &vectors[query_idx % n];
+
+        // Neither call may panic (the pre-clamp failure mode). Same result
+        // count, and the score sequence matches positionally — both are sorted
+        // best-first by the same dist fn over the same persisted data.
+        let a = built.search(q, k);
+        let b = loaded.search(q, k);
+
+        prop_assert_eq!(
+            a.len(), b.len(),
+            "result count diverged across save/load \
+             (metric={:?}, n={}, k={}, clusters={}): mem={} loaded={}",
+            metric, n, k, clusters, a.len(), b.len()
+        );
+        for (ra, rb) in a.iter().zip(b.iter()) {
+            prop_assert!(
+                (ra.score - rb.score).abs() < 1e-6,
+                "score sequence diverged at a position: mem={} loaded={}",
+                ra.score, rb.score
+            );
+        }
+    }
+
+    /// INVARIANT 3: metric round-trips for both arms.
+    #[test]
+    fn metric_round_trip(
+        seed in any::<u64>(),
+        n in 1usize..=32,
+        dot in any::<bool>(),
+    ) {
+        let metric = if dot { DistanceMetric::DotProduct } else { DistanceMetric::Cosine };
+        let vectors = build_vectors(seed, n);
+        let built = HnswIndex::build_with_dim_and_metric(
+            vectors, EMBEDDING_DIM, metric,
+        ).expect("build");
+        prop_assert_eq!(built.metric(), metric);
+
+        let dir = tempfile::tempdir().expect("tmp");
+        built.save(dir.path(), "m").expect("save");
+        let loaded = HnswIndex::load_with_dim(dir.path(), "m", EMBEDDING_DIM).expect("load");
+        prop_assert_eq!(loaded.metric(), metric, "metric must survive save/load");
+        prop_assert_eq!(loaded.len(), n, "len must survive save/load");
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        // Orphan detection: fewer cases, each one builds N times. Keep it cheap.
+        cases: 40,
+        max_shrink_iters: 1000,
+        .. ProptestConfig::default()
+    })]
+
+    /// INVARIANT 2: orphan-elimination.
+    /// Every inserted point is self-reachable in its own top-k. A SYSTEMATIC
+    /// orphan (unreachable on every one of `retries` builds) is a real recall
+    /// bug; a transient one is concurrent-build noise.
+    #[test]
+    fn no_self_unreachable_orphans(
+        seed in any::<u64>(),
+        n in 2usize..=64,
+    ) {
+        let metric = DistanceMetric::Cosine;
+        // k = N so self-reachability has the whole index to find itself in;
+        // an orphan is a node that even an N-wide search of its own vector
+        // cannot return.
+        let k = n;
+
+        // For each point, it is "reachable" if ANY build returns it for its
+        // own-vector query. Persistent absence across all retries = orphan.
+        let retries = 8usize;
+        let mut ever_reachable = vec![false; n];
+
+        for _ in 0..retries {
+            let vectors = build_vectors(seed, n);
+            let built = HnswIndex::build_with_dim_and_metric(
+                vectors, EMBEDDING_DIM, metric,
+            ).expect("build");
+            #[allow(clippy::needless_range_loop)] // need `i` for id + seed
+            for i in 0..n {
+                if ever_reachable[i] {
+                    continue;
+                }
+                let q = unit_vec(seed, i);
+                let hits = built.search(&q, k);
+                if hits.iter().any(|r| r.id == format!("id_{i}")) {
+                    ever_reachable[i] = true;
+                }
+            }
+            if ever_reachable.iter().all(|&b| b) {
+                break;
+            }
+        }
+
+        let orphans: Vec<usize> = (0..n).filter(|&i| !ever_reachable[i]).collect();
+        prop_assert!(
+            orphans.is_empty(),
+            "self-unreachable orphan(s) after {} builds (n={}): ids {:?} — \
+             LEVEL_SCALE_FACTOR=0.5 did not eliminate orphaning",
+            retries, n, orphans
+        );
+    }
+
+    /// INVARIANT 2b: orphan-elimination on CLUSTERED vectors. Tight clusters
+    /// (~0.999 cosine) are the documented orphan-prone regime — near-collinear
+    /// neighbours are where concurrent insert is most likely to drop a
+    /// self-match. Pushes N higher than the orthogonal case.
+    #[test]
+    fn no_orphans_clustered(
+        seed in any::<u64>(),
+        n in 4usize..=128,
+        clusters in 1usize..=4,
+    ) {
+        let metric = DistanceMetric::Cosine;
+        let k = n;
+        let retries = 8usize;
+        let mut ever_reachable = vec![false; n];
+
+        for _ in 0..retries {
+            let vectors = clustered_vectors(seed, n, clusters);
+            let built = HnswIndex::build_with_dim_and_metric(
+                vectors, EMBEDDING_DIM, metric,
+            ).expect("build");
+            #[allow(clippy::needless_range_loop)] // need `i` for id + seed
+            for i in 0..n {
+                if ever_reachable[i] {
+                    continue;
+                }
+                let q = clustered_vectors(seed, n, clusters)[i].1.clone();
+                let hits = built.search(&q, k);
+                if hits.iter().any(|r| r.id == format!("id_{i}")) {
+                    ever_reachable[i] = true;
+                }
+            }
+            if ever_reachable.iter().all(|&b| b) {
+                break;
+            }
+        }
+
+        let orphans: Vec<usize> = (0..n).filter(|&i| !ever_reachable[i]).collect();
+        prop_assert!(
+            orphans.is_empty(),
+            "clustered self-unreachable orphan(s) after {} builds \
+             (n={}, clusters={}): ids {:?}",
+            retries, n, clusters, orphans
+        );
+    }
+}


### PR DESCRIPTION
## fix(hnsw): DotProduct metric no longer panics on f32 unit-norm vectors

Closes #1949.

The DotProduct arm (`CQS_DISTANCE_METRIC=dot`) panicked because `normalize_l2` produces f32 vectors with `a·a ≈ 1.0000005 > 1.0`, and anndists' stock `DistDot` asserts `a·b ≤ 1` (SIMD) / `1 − a·b ≥ 0` (scalar). It panicked on **build** (in a rayon worker → killed the whole index build) and **search** (self-match/dedup queries). Cosine was immune (it renormalizes internally).

**Fix:** a custom `pub(crate) DistDotClamped` (`hnsw_rs::Distance<f32>`) computing `1.0 - dot.min(1.0)` — the dot is computed in-house and clamped to ≤1.0 before the subtraction, so the distance is always ≥0 and **both** anndists asserts are bypassed. A near-collinear pair correctly yields distance 0 ("most similar"). Wired at both `HnswGraph::new` and `HnswGraph::load` DotProduct arms; the `.hnsw.meta` "dot" header is unchanged and a persisted DotProduct index reloads + searches without panic. **Cosine arm untouched.** The clamp eliminates the panic *structurally* (the near-collinear vector is valid data, now indexed, not dropped), so no new build-skip was needed beyond the existing NaN/zero guards.

Also corrected a docs-lie in `src/index.rs` (`DistanceMetric::DotProduct` claimed dots >1 "aren't usable without a scaling pass" — exactly what the clamp removes) and the precondition comment in `hnsw/mod.rs`.

**Tests:** promotes the property-audit's `tests/proptest_hnsw_persist_orphan.rs` (+ pinned seed `0,n=2,k=1,dot=true`) — all 5 properties pass. One property (`persist_load_knn_equivalence_dot_and_clustered`) was relaxed from positional-id equality to the **codec invariant** (identical result cardinality + identical score sequence): under the clamp a cluster of near-collinear vectors is a genuine tie-band, and approximate HNSW does not return an identical k-*subset* across independently-traversed in-memory vs reloaded graphs when the tie-band exceeds k — inherent to approximate ANN, not a codec bug. The relaxed assertion still bites vector corruption / mass edge loss / a swapped dist fn. Plus `dist_dot_clamped_never_negative_on_overunit_dot` and `dot_build_and_self_query_does_not_panic_over_seed_band`.

Gates: lib hnsw 99 pass, proptest 5 pass (×4 runs), index/search cohorts green; clippy `--all-targets` / fmt / provenance lint clean. DotProduct is opt-in (default Cosine), so blast radius is limited; this is a distance-impl fix (no schema/PV change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
