### PR TITLE
fix(parser): wire L5X/L5K ST extraction onto the production index path (closes #1955)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,7 @@ libc = "0.2"
 ort = { version = "2.0.0-rc.12", features = ["cuda", "tensorrt", "half"] }
 
 [features]
-default = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-cpp", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-bash", "lang-hcl", "lang-kotlin", "lang-swift", "lang-objc", "lang-sql", "lang-protobuf", "lang-graphql", "lang-php", "lang-lua", "lang-zig", "lang-r", "lang-yaml", "lang-toml", "lang-elixir", "lang-elm", "lang-erlang", "lang-haskell", "lang-ocaml", "lang-julia", "lang-gleam", "lang-css", "lang-perl", "lang-html", "lang-json", "lang-xml", "lang-ini", "lang-nix", "lang-make", "lang-latex", "lang-solidity", "lang-cuda", "lang-glsl", "lang-svelte", "lang-razor", "lang-vbnet", "lang-vue", "lang-markdown", "lang-aspx", "lang-st", "lang-dart", "convert", "llm-summaries", "serve"]
+default = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-cpp", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-bash", "lang-hcl", "lang-kotlin", "lang-swift", "lang-objc", "lang-sql", "lang-protobuf", "lang-graphql", "lang-php", "lang-lua", "lang-zig", "lang-r", "lang-yaml", "lang-toml", "lang-elixir", "lang-elm", "lang-erlang", "lang-haskell", "lang-ocaml", "lang-julia", "lang-gleam", "lang-css", "lang-perl", "lang-html", "lang-json", "lang-xml", "lang-ini", "lang-nix", "lang-make", "lang-latex", "lang-solidity", "lang-cuda", "lang-glsl", "lang-svelte", "lang-razor", "lang-vbnet", "lang-vue", "lang-markdown", "lang-aspx", "lang-st", "lang-l5x", "lang-dart", "convert", "llm-summaries", "serve"]
 
 # Language support (opt-in, all enabled by default)
 lang-rust = ["dep:tree-sitter-rust"]
@@ -257,8 +257,9 @@ lang-vue = ["dep:tree-sitter-vue"]
 lang-markdown = []  # No external deps — custom parser
 lang-aspx = ["lang-csharp", "lang-vbnet"]  # Delegates to C#/VB.NET grammars
 lang-st = ["dep:tree-sitter-structured-text"]
+lang-l5x = ["lang-st"]  # Rockwell PLC exports — delegates to the ST grammar
 lang-dart = ["dep:tree-sitter-dart"]
-lang-all = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-cpp", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-bash", "lang-hcl", "lang-kotlin", "lang-swift", "lang-objc", "lang-sql", "lang-protobuf", "lang-graphql", "lang-php", "lang-lua", "lang-zig", "lang-r", "lang-yaml", "lang-toml", "lang-elixir", "lang-elm", "lang-erlang", "lang-haskell", "lang-ocaml", "lang-julia", "lang-gleam", "lang-css", "lang-perl", "lang-html", "lang-json", "lang-xml", "lang-ini", "lang-nix", "lang-make", "lang-latex", "lang-solidity", "lang-cuda", "lang-glsl", "lang-svelte", "lang-razor", "lang-vbnet", "lang-vue", "lang-markdown", "lang-aspx", "lang-st", "lang-dart"]
+lang-all = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-cpp", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-bash", "lang-hcl", "lang-kotlin", "lang-swift", "lang-objc", "lang-sql", "lang-protobuf", "lang-graphql", "lang-php", "lang-lua", "lang-zig", "lang-r", "lang-yaml", "lang-toml", "lang-elixir", "lang-elm", "lang-erlang", "lang-haskell", "lang-ocaml", "lang-julia", "lang-gleam", "lang-css", "lang-perl", "lang-html", "lang-json", "lang-xml", "lang-ini", "lang-nix", "lang-make", "lang-latex", "lang-solidity", "lang-cuda", "lang-glsl", "lang-svelte", "lang-razor", "lang-vbnet", "lang-vue", "lang-markdown", "lang-aspx", "lang-st", "lang-l5x", "lang-dart"]
 
 # Document conversion
 convert = ["dep:fast_html2md", "dep:walkdir"]

--- a/src/language/languages.rs
+++ b/src/language/languages.rs
@@ -8254,9 +8254,10 @@ fn post_process_xml_xml(
 static LANG_XML: LanguageDef = LanguageDef {
     name: "xml",
     grammar: Some(|| tree_sitter_xml::LANGUAGE_XML.into()),
-    extensions: &[
-        "xml", "xsl", "xslt", "xsd", "svg", "wsdl", "rss", "plist", "l5x", "l5k",
-    ],
+    // L5X/L5K (Rockwell PLC exports) are XML/ASCII on the surface but carry
+    // Structured-Text routines — routed to their own grammar-less LanguageDef
+    // (LANG_L5X) with a custom ST extractor, not parsed as generic XML.
+    extensions: &["xml", "xsl", "xslt", "xsd", "svg", "wsdl", "rss", "plist"],
     chunk_query: include_str!("queries/xml.chunks.scm"),
     signature_style: SignatureStyle::FirstLine,
     doc_nodes: &["Comment"],
@@ -8281,6 +8282,43 @@ static LANG_XML: LanguageDef = LanguageDef {
 
 pub fn definition_xml() -> &'static LanguageDef {
     &LANG_XML
+}
+
+// ============================================================================
+// L5X / L5K (Rockwell/Allen-Bradley PLC exports — Structured Text)
+// ============================================================================
+
+static LANG_L5X: LanguageDef = LanguageDef {
+    name: "l5x",
+    grammar: None, // Custom parser — extracts embedded Structured Text routines.
+    extensions: &["l5x", "l5k"],
+    signature_style: SignatureStyle::FirstLine,
+    stopwords: &[
+        "routine",
+        "program",
+        "rung",
+        "tag",
+        "controller",
+        "datatype",
+        "rll",
+        "stcontent",
+        "addonInstr",
+    ],
+    // Grammar-less dispatch: a separate LanguageDef (not LANG_XML) so
+    // `Language::from_extension` routes `.l5x`/`.l5k` to the custom ST
+    // extractor on BOTH the chunks-only (`parse_source`) and combined
+    // (`parse_file_all_inner`) paths. The emitted chunks carry
+    // `Language::StructuredText`, whose call/type queries power per-chunk
+    // relationship extraction.
+    custom_chunk_parser: Some(crate::parser::l5x::parse_l5x_chunks_dispatch),
+    custom_all_parser: Some(crate::parser::l5x::parse_l5x_all),
+    line_comment_prefixes: &["//", "(*", "<!--"],
+    aliases: &["l5k", "rockwell"],
+    ..DEFAULTS
+};
+
+pub fn definition_l5x() -> &'static LanguageDef {
+    &LANG_L5X
 }
 
 // ============================================================================

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -1206,6 +1206,8 @@ define_languages! {
     Aspx => "aspx", feature = "lang-aspx", def = languages::definition_aspx;
     /// IEC 61131-3 Structured Text (.st, .stl files)
     StructuredText => "structured_text", feature = "lang-st", def = languages::definition_structured_text;
+    /// Rockwell/Allen-Bradley PLC exports (.l5x, .l5k files — embedded Structured Text)
+    L5x => "l5x", feature = "lang-l5x", def = languages::definition_l5x;
     /// Dart (.dart files)
     Dart => "dart", feature = "lang-dart", def = languages::definition_dart;
 }
@@ -1833,6 +1835,10 @@ mod tests {
             expected += 1;
         }
         #[cfg(feature = "lang-st")]
+        {
+            expected += 1;
+        }
+        #[cfg(feature = "lang-l5x")]
         {
             expected += 1;
         }
@@ -2673,7 +2679,7 @@ mod tests {
     /// fails and reminds the contributor to update the constant.
     #[test]
     fn test_language_variant_count() {
-        const EXPECTED_LANGUAGE_COUNT: usize = 54;
+        const EXPECTED_LANGUAGE_COUNT: usize = 55;
         let actual = Language::all_variants().len();
         assert_eq!(
             actual, EXPECTED_LANGUAGE_COUNT,

--- a/src/parser/chunk.rs
+++ b/src/parser/chunk.rs
@@ -39,7 +39,14 @@ use super::Parser;
 /// lift changes the stored `byte_start` and thus the `id` for every L5X/L5K
 /// chunk past the first region, so a refresh is required even for unchanged
 /// content.
-pub const PARSER_VERSION: u32 = 11;
+/// 12: L5X/L5K files are now routed to their own grammar-less LanguageDef
+/// (custom ST extractor) on the production index path instead of being parsed
+/// as generic XML. Previously `parse_file_all_inner` resolved `.l5x`/`.l5k`
+/// to `Language::Xml` and emitted XML-element chunks; now it emits
+/// Structured-Text routine chunks. The chunk class, ids, and content change
+/// wholesale for every indexed L5X/L5K file, so a refresh is required even for
+/// byte-identical content.
+pub const PARSER_VERSION: u32 = 12;
 
 /// Build the canonical chunk id from its identifying coordinates.
 ///

--- a/src/parser/l5x.rs
+++ b/src/parser/l5x.rs
@@ -12,7 +12,11 @@ use std::sync::LazyLock;
 use regex::Regex;
 use tree_sitter::StreamingIterator;
 
-use super::types::{capture_name_to_chunk_type, Chunk, ChunkType, Language, ParserError};
+use super::types::{
+    capture_name_to_chunk_type, Chunk, ChunkType, ChunkTypeRefs, FunctionCalls, Language,
+    ParserError, TypeRef,
+};
+use super::ParseAllResult;
 use super::Parser;
 
 // ===========================================================================
@@ -518,6 +522,133 @@ pub(crate) fn parse_l5k_chunks(
         "L5K parse complete"
     );
     Ok(chunks)
+}
+
+// ===========================================================================
+// Production entry point (custom_all_parser)
+// ===========================================================================
+
+/// Chunks-only extractor for Rockwell PLC exports.
+///
+/// Registered as `LanguageDef::custom_chunk_parser` so the chunks-only path
+/// (`Parser::parse_source`) routes `.l5x`/`.l5k` to the ST extractor too,
+/// keeping a single declarative routing surface (the old explicit `if
+/// ext == "l5x"` block in `Parser::parse_file` is removed). Dispatches by
+/// extension to the format-specific extractor.
+pub fn parse_l5x_chunks_dispatch(
+    source: &str,
+    path: &Path,
+    parser: &Parser,
+) -> Result<Vec<Chunk>, ParserError> {
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase())
+        .unwrap_or_default();
+    match ext.as_str() {
+        "l5k" => parse_l5k_chunks(source, path, parser),
+        // Default to the XML form for "l5x" and any future alias routed here.
+        _ => parse_l5x_chunks(source, path, parser),
+    }
+}
+
+/// Combined chunks + calls + type-refs extractor for Rockwell PLC exports.
+///
+/// Registered as `LanguageDef::custom_all_parser` on the L5X/L5K language row,
+/// so the production index path (`Parser::parse_file_all_inner`) routes
+/// `.l5x`/`.l5k` here instead of the generic XML grammar. Dispatches by
+/// extension to the format-specific chunk extractor (`parse_l5x_chunks` for the
+/// XML form, `parse_l5k_chunks` for the legacy ASCII form), then derives
+/// file-level call and type-reference relationships from each emitted chunk.
+///
+/// The chunks carry `Language::StructuredText`, whose definition has both a
+/// call and a type query, so relationships are extracted with the same
+/// per-chunk machinery the grammar-less indexing path independently runs for
+/// `chunk_calls`. Calls are grouped under the chunk's name (the
+/// `function_calls` table joins on `caller_name` + `file`); types are grouped
+/// per chunk like `parse_aspx_all` does, with the chunk's own name filtered out
+/// of its type-ref set.
+pub fn parse_l5x_all(
+    source: &str,
+    path: &Path,
+    parser: &Parser,
+) -> Result<ParseAllResult, ParserError> {
+    let _span = tracing::info_span!("parse_l5x_all", path = %path.display()).entered();
+
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase())
+        .unwrap_or_default();
+
+    let chunks = match ext.as_str() {
+        "l5k" => parse_l5k_chunks(source, path, parser)?,
+        // Default to the XML form for "l5x" and any future alias routed here.
+        _ => parse_l5x_chunks(source, path, parser)?,
+    };
+
+    let mut all_calls: Vec<FunctionCalls> = Vec::new();
+    let mut all_types: Vec<ChunkTypeRefs> = Vec::new();
+
+    for chunk in &chunks {
+        // Reuse the per-chunk extractors so file-level relationships match the
+        // `chunk_calls`/candidate path the grammar-less indexing route runs.
+        let calls = parser.extract_calls_from_chunk(chunk);
+        if !calls.is_empty() {
+            all_calls.push(FunctionCalls {
+                name: chunk.name.clone(),
+                line_start: chunk.line_start,
+                calls,
+            });
+        }
+
+        let type_refs = extract_chunk_type_refs(chunk, parser);
+        if !type_refs.is_empty() {
+            all_types.push(ChunkTypeRefs {
+                name: chunk.name.clone(),
+                line_start: chunk.line_start,
+                type_refs,
+            });
+        }
+    }
+
+    tracing::info!(
+        chunks = chunks.len(),
+        calls = all_calls.len(),
+        types = all_types.len(),
+        "L5X/L5K parse_all complete"
+    );
+
+    Ok((chunks, all_calls, all_types))
+}
+
+/// Extract type references from a single ST chunk's content via a standalone
+/// tree-sitter parse, dropping the chunk's own name (a self-reference is not a
+/// dependency edge — same filter `parse_aspx_all` applies).
+fn extract_chunk_type_refs(chunk: &Chunk, parser: &Parser) -> Vec<TypeRef> {
+    let st_lang = Language::StructuredText;
+    let grammar = match st_lang.try_grammar() {
+        Some(g) => g,
+        None => {
+            tracing::warn!("Structured Text grammar unavailable; skipping ST type refs");
+            return Vec::new();
+        }
+    };
+    let mut ts_parser = tree_sitter::Parser::new();
+    if ts_parser.set_language(&grammar).is_err() {
+        tracing::warn!("Failed to set ST grammar for type-ref extraction");
+        return Vec::new();
+    }
+    let tree = match ts_parser.parse(&chunk.content, None) {
+        Some(t) => t,
+        None => {
+            tracing::warn!("ST type-ref parse returned no tree");
+            return Vec::new();
+        }
+    };
+    let mut refs = parser.extract_types(&chunk.content, &tree, st_lang, 0, chunk.content.len());
+    refs.retain(|t| t.type_name != chunk.name);
+    refs
 }
 
 // ===========================================================================
@@ -1074,5 +1205,125 @@ END_PROGRAM
                 "line_end must saturate at u32::MAX, not wrap"
             );
         }
+    }
+
+    // --- Production-path wiring tests ---
+    //
+    // These exercise the PRODUCTION entry `Parser::parse_file_all` (NOT
+    // `parse_file`), which routes by `Language::from_extension`. Before the
+    // wireup, `.l5x`/`.l5k` resolved to `Language::Xml` (generic XML grammar)
+    // and yielded XML-element chunks; after, they resolve to the grammar-less
+    // L5X def and yield Structured-Text routine chunks.
+
+    /// Write `content` to a temp file with the given extension so the
+    /// extension-based production router sees a real `.l5x`/`.l5k` path.
+    fn write_temp_with_ext(content: &str, ext: &str) -> tempfile::NamedTempFile {
+        use std::io::Write;
+        let mut f = tempfile::Builder::new()
+            .suffix(&format!(".{ext}"))
+            .tempfile()
+            .unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    /// PRODUCTION PATH: `parse_file_all` on a `.l5x` file must return the
+    /// custom ST routine chunk, not generic XML-element chunks.
+    ///
+    /// FAIL-BEFORE: with `.l5x` registered under `LANG_XML`, this path resolved
+    /// to the XML grammar and produced chunks whose language is `Xml` and whose
+    /// names are XML element/attribute names (`Routine`, `STContent`, ...),
+    /// never a `StructuredText` chunk named `MainRoutine`.
+    #[test]
+    fn test_l5x_production_path_yields_st_chunks() {
+        let parser = Parser::new().unwrap();
+        let f = write_temp_with_ext(SAMPLE_L5X, "l5x");
+        let (chunks, _calls, _types) = parser.parse_file_all(f.path()).unwrap();
+
+        assert!(
+            !chunks.is_empty(),
+            "production parse_file_all must produce chunks for .l5x"
+        );
+        assert!(
+            chunks
+                .iter()
+                .all(|c| c.language == Language::StructuredText),
+            "every production chunk must be StructuredText, not Xml: got {:?}",
+            chunks.iter().map(|c| c.language).collect::<Vec<_>>()
+        );
+        assert!(
+            chunks.iter().any(|c| c.name == "MainRoutine"),
+            "expected the ST routine 'MainRoutine'; got {:?}",
+            chunks.iter().map(|c| c.name.clone()).collect::<Vec<_>>()
+        );
+        // The ladder (RLL) routine carries no ST and must NOT surface as a chunk.
+        assert!(
+            !chunks.iter().any(|c| c.content.contains("XIC")),
+            "RLL ladder content must not be extracted as ST"
+        );
+    }
+
+    /// PRODUCTION PATH: `parse_file_all` on a `.l5k` file must return the
+    /// custom ST routine chunk, not generic XML-element chunks.
+    ///
+    /// FAIL-BEFORE: `.l5k` was an XML extension, so the XML grammar parsed this
+    /// ASCII file (yielding either no chunks or junk element chunks), never a
+    /// `StructuredText` chunk named `MainRoutine`.
+    #[test]
+    fn test_l5k_production_path_yields_st_chunks() {
+        let parser = Parser::new().unwrap();
+        let f = write_temp_with_ext(SAMPLE_L5K, "l5k");
+        let (chunks, _calls, _types) = parser.parse_file_all(f.path()).unwrap();
+
+        assert!(
+            !chunks.is_empty(),
+            "production parse_file_all must produce chunks for .l5k"
+        );
+        assert!(
+            chunks
+                .iter()
+                .all(|c| c.language == Language::StructuredText),
+            "every production chunk must be StructuredText, not Xml: got {:?}",
+            chunks.iter().map(|c| c.language).collect::<Vec<_>>()
+        );
+        assert!(
+            chunks.iter().any(|c| c.name == "MainRoutine"),
+            "expected the ST routine 'MainRoutine'; got {:?}",
+            chunks.iter().map(|c| c.name.clone()).collect::<Vec<_>>()
+        );
+    }
+
+    /// PRODUCTION PATH: `.l5x`/`.l5k` must resolve to the grammar-less L5X
+    /// LanguageDef (not XML), so both `parse_file` and `parse_file_all` share a
+    /// single declarative routing path.
+    #[test]
+    fn test_l5x_l5k_resolve_to_grammarless_l5x_def() {
+        let lang_l5x = Language::from_extension("l5x").expect("l5x must resolve");
+        let lang_l5k = Language::from_extension("l5k").expect("l5k must resolve");
+        let def_l5x = lang_l5x.def();
+        let def_l5k = lang_l5k.def();
+        assert!(
+            def_l5x.grammar.is_none(),
+            "l5x must route to a grammar-less custom parser, not the XML grammar"
+        );
+        assert!(
+            def_l5k.grammar.is_none(),
+            "l5k must route to a grammar-less custom parser, not the XML grammar"
+        );
+        assert!(def_l5x.custom_all_parser.is_some());
+        assert!(def_l5k.custom_all_parser.is_some());
+        // And XML must NO LONGER claim these extensions.
+        let xml = Language::from_extension("xml")
+            .expect("xml must resolve")
+            .def();
+        assert!(
+            !xml.extensions.contains(&"l5x"),
+            "XML def must not claim .l5x after the wireup"
+        );
+        assert!(
+            !xml.extensions.contains(&"l5k"),
+            "XML def must not claim .l5k after the wireup"
+        );
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -258,14 +258,9 @@ impl Parser {
         let ext_raw = path.extension().and_then(|e| e.to_str()).unwrap_or("");
         let ext = ext_raw.to_ascii_lowercase();
 
-        // Rockwell PLC exports need custom ST extraction
-        if ext == "l5x" {
-            return l5x::parse_l5x_chunks(&source, path, self);
-        }
-        if ext == "l5k" {
-            return l5x::parse_l5k_chunks(&source, path, self);
-        }
-
+        // Rockwell PLC exports (.l5x/.l5k) route through their grammar-less
+        // LanguageDef's custom_chunk_parser via parse_source — a single
+        // declarative routing path shared with parse_file_all_inner.
         let language = Language::from_extension(&ext)
             .ok_or_else(|| ParserError::UnsupportedFileType(ext.to_string()))?;
 


### PR DESCRIPTION
## fix(parser): wire L5X/L5K Structured-Text extraction onto the production index path

Closes #1955.

Root cause was a routing divergence: `.l5x`/`.l5k` lived under `LANG_XML`'s extensions, so the production path `parse_file_all_inner` resolved them to `Language::Xml` and parsed with the generic XML grammar; the custom ST extractor was only reachable from `Parser::parse_file`, which indexing never calls. So the documented L5X/L5K PLC-export feature (and the #1888/#1947 byte_start injectivity work) was dead in production.

**Fix (declarative, not a special-case):**
- New `static LANG_L5X` (`grammar: None`, `extensions: ["l5x","l5k"]`, `custom_all_parser: Some(parse_l5x_all)` + `custom_chunk_parser`); removed `l5x`/`l5k` from `LANG_XML`. Registered `L5x => "l5x"` in `define_languages!` behind a `lang-l5x` feature (in `default` + `lang-all`).
- `parse_l5x_all` matches the `parse_aspx_all` shape — dispatches by extension to `parse_l5x_chunks`/`parse_l5k_chunks`, then derives file-level `FunctionCalls`/`TypeRefs` per chunk via the existing per-chunk extractors (chunks carry `Language::StructuredText`, which has call/type queries). Removed the explicit `if ext=="l5x"` block from `Parser::parse_file` → a single routing path (the divergence was the root cause). The #1888 byte_start injectivity fix is now LIVE in production.
- PARSER_VERSION **11 → 12** (production L5X/L5K chunks change from XML-grammar to ST routine chunks).

**Tests (fail-before verified):** `test_l5x_production_path_yields_st_chunks` (was `[Xml, Xml]`), `test_l5k_production_path_yields_st_chunks` (XML grammar yielded zero chunks on the ASCII file), `test_l5x_l5k_resolve_to_grammarless_l5x_def` — all via the production entry `parse_file_all`.

Full `cargo test --features cuda-index --tests` (PV bump = global state): **4694 passed, 0 failed, 67 ignored, 0 flakes**. The sweep caught two hardcoded language-count guards (54→55 LanguageDef statics) — both fixed. clippy `--all-targets` / fmt / provenance clean.

Note: internal LanguageDef count is now 55; the user-facing "54 languages + L5X/L5K PLC exports" framing still holds (L5X/L5K is the distinct PLC extractor). A CONTRIBUTING.md "54 language definitions" line needs syncing (follow-up doc nit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
