### PR TITLE
fix(cross-project): restore trust-ordering at callers cap + impact first-discovery (closes #1966)

### DIFF
--- a/src/cli/commands/graph/callers.rs
+++ b/src/cli/commands/graph/callers.rs
@@ -763,6 +763,24 @@ pub(crate) fn callers_cross_core(
     if let Some(want) = args.edge_kind {
         callers.retain(|c| c.caller.edge_kind == want);
     }
+    // Trust-ordering at the cross-project boundary. `get_callers_cross`
+    // concatenates each project's callers in store iteration order, so without
+    // this sort a capped window could be filled by an earlier project's
+    // low-trust `doc_reference` edges while a real `call` edge in a later
+    // project is truncated away. Sort lowest-trust-rank first (call < serde <
+    // macro < fn-pointer < doc-reference), then by project/file/line for a
+    // stable order — mirroring single-project `get_callers_full`'s
+    // `ORDER BY trust_rank, file, caller_line`. Applied AFTER the edge-kind
+    // filter and BEFORE the cap so `--limit` keeps the most-trusted page.
+    callers.sort_by(|a, b| {
+        a.caller
+            .edge_kind
+            .trust_rank()
+            .cmp(&b.caller.edge_kind.trust_rank())
+            .then_with(|| a.project.cmp(&b.project))
+            .then_with(|| a.caller.file.cmp(&b.caller.file))
+            .then_with(|| a.caller.line.cmp(&b.caller.line))
+    });
     let total = callers.len();
     callers.truncate(limit);
     let entries: Vec<CallerEntry> = callers
@@ -808,6 +826,20 @@ pub(crate) fn callees_cross_core(
     if let Some(want) = args.edge_kind {
         callees.retain(|c| c.edge_kind == want);
     }
+    // Trust-ordering at the cross-project boundary — mirror of
+    // `callers_cross_core`. Callees carry no `file` (the in-memory graph records
+    // callees by name + call_line), so the stable key is
+    // (trust_rank, project, name, line). BEFORE the cap so a later project's
+    // real `call` edge can't be evicted by an earlier project's
+    // `doc_reference`.
+    callees.sort_by(|a, b| {
+        a.edge_kind
+            .trust_rank()
+            .cmp(&b.edge_kind.trust_rank())
+            .then_with(|| a.project.cmp(&b.project))
+            .then_with(|| a.name.cmp(&b.name))
+            .then_with(|| a.line.cmp(&b.line))
+    });
     let total = callees.len();
     callees.truncate(limit);
     let calls: Vec<CalleeEntry> = callees
@@ -1522,5 +1554,136 @@ mod tests {
             "past the cap, the hint must mention --edge-kind: {over:?}"
         );
         assert!(over.contains("doc_reference"));
+    }
+
+    // ----- Cross-project cap trust-ordering -----
+
+    /// Build a `NamedStore` carrying one `(caller -> callee)` edge of a given
+    /// provenance kind, written through the lib-public `upsert_function_calls`
+    /// path so the edge surfaces with the right `edge_kind` cross-project. The
+    /// tempdir is leaked (`keep`) so the backing `index.db` survives the test.
+    fn cross_named_store(
+        project: &str,
+        caller: &str,
+        callee: &str,
+        kind: cqs::parser::CallEdgeKind,
+    ) -> cqs::cross_project::NamedStore {
+        use cqs::parser::{CallSite, FunctionCalls};
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join(cqs::INDEX_DB_FILENAME);
+        {
+            let store = cqs::Store::open(&db_path).unwrap();
+            store.init(&cqs::store::ModelInfo::default()).unwrap();
+            store
+                .upsert_function_calls(
+                    std::path::Path::new("src/lib.rs"),
+                    &[FunctionCalls {
+                        name: caller.to_string(),
+                        line_start: 1,
+                        calls: vec![CallSite {
+                            callee_name: callee.to_string(),
+                            line_number: 2,
+                            kind,
+                        }],
+                    }],
+                )
+                .unwrap();
+        }
+        let ro = cqs::Store::open_readonly(&db_path).unwrap();
+        let _keep = dir.keep();
+        cqs::cross_project::NamedStore::new(project.to_string(), ro, db_path)
+    }
+
+    /// Cross-project cap keeps the most-trusted caller (callers).
+    ///
+    /// Two projects each contribute a caller of `target`: the EARLIER-listed
+    /// project via a low-trust `doc_reference`, the LATER-listed project via a
+    /// real `call`. With `--limit 1` the single surfaced caller must be the
+    /// `call`, never the `doc_reference`. Before the trust-sort,
+    /// `get_callers_cross` concatenated in store order and `truncate(1)` kept the
+    /// earlier project's `doc_reference`, evicting the real `call`.
+    #[test]
+    fn callers_cross_cap_surfaces_call_over_doc_reference() {
+        use cqs::parser::CallEdgeKind;
+        // Order matters: the doc_reference project is listed FIRST so the
+        // pre-fix concatenation would surface it first.
+        let earlier = cross_named_store(
+            "doc_proj",
+            "doc_caller",
+            "target",
+            CallEdgeKind::DocReference,
+        );
+        let later = cross_named_store("call_proj", "real_caller", "target", CallEdgeKind::Call);
+        let mut ctx = cqs::cross_project::CrossProjectContext::new(vec![earlier, later]);
+
+        let output = callers_cross_core(
+            &mut ctx,
+            &CallersArgs {
+                name: "target".to_string(),
+                limit: 1,
+                edge_kind: None,
+            },
+        )
+        .unwrap();
+
+        // Both callers exist pre-cap; the cap keeps the most-trusted one.
+        assert_eq!(output.total, 2, "both projects contribute a caller");
+        assert_eq!(output.count, 1, "--limit 1 keeps one");
+        assert_eq!(
+            output.callers[0].name, "real_caller",
+            "the capped window must keep the real `call`, not the `doc_reference`"
+        );
+        // A `call` edge renders edge_kind omitted (empty string).
+        assert!(
+            output.callers[0].edge_kind.is_empty(),
+            "surfaced caller is a `call` edge (edge_kind omitted), got {:?}",
+            output.callers[0].edge_kind
+        );
+    }
+
+    /// Cross-project cap keeps the most-trusted callee (callees), mirror of the
+    /// callers case. The SAME caller name reaches an earlier-listed
+    /// `doc_reference` callee and a later-listed real `call` callee; the cap
+    /// must keep the `call`.
+    #[test]
+    fn callees_cross_cap_surfaces_call_over_doc_reference() {
+        use cqs::parser::CallEdgeKind;
+        // Same caller name in both projects, reaching DIFFERENT callees: an
+        // earlier-listed doc_reference and a later-listed real call.
+        let earlier = cross_named_store(
+            "doc_proj",
+            "shared_caller",
+            "doc_callee",
+            CallEdgeKind::DocReference,
+        );
+        let later = cross_named_store(
+            "call_proj",
+            "shared_caller",
+            "call_callee",
+            CallEdgeKind::Call,
+        );
+        let mut ctx = cqs::cross_project::CrossProjectContext::new(vec![earlier, later]);
+
+        let output = callees_cross_core(
+            &mut ctx,
+            &CalleesArgs {
+                name: "shared_caller".to_string(),
+                limit: 1,
+                edge_kind: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(output.total, 2, "both projects contribute a callee");
+        assert_eq!(output.count, 1, "--limit 1 keeps one");
+        assert_eq!(
+            output.calls[0].name, "call_callee",
+            "the capped window must keep the real `call`, not the `doc_reference`"
+        );
+        assert!(
+            output.calls[0].edge_kind.is_empty(),
+            "surfaced callee is a `call` edge (edge_kind omitted), got {:?}",
+            output.calls[0].edge_kind
+        );
     }
 }

--- a/src/impact/cross_project.rs
+++ b/src/impact/cross_project.rs
@@ -59,11 +59,15 @@ pub fn analyze_impact_cross(
     // BFS: reverse traversal across all projects.
     //
     // `visited` records depth + project per name. `edge_provenance` captures the
-    // metadata of the edge that FIRST discovered each caller — its file, caller
-    // line, and `edge_kind` — threaded through the in-memory `CallGraph`.
-    // The discovering edge is a stable choice: BFS visits each name once, and the
-    // file/line/kind describe that caller's own definition, independent of which
-    // callee surfaced it.
+    // metadata of the edge that FIRST discovers each caller — its file, caller
+    // line, and `edge_kind` — threaded through the in-memory `CallGraph`. BFS
+    // visits each name once and records only the first edge. file/line describe
+    // the caller's own DEFINITION, so they are the same whichever edge surfaces
+    // it; `edge_kind`, however, is a property of the EDGE, not the caller, and
+    // differs per edge. To make first-discovered = most-trusted, each frontier's
+    // caller stream is sorted by `edge_kind.trust_rank()` before this step (see
+    // below), so a real `call` is never shadowed by a `doc_reference` that merely
+    // came from an earlier-listed project.
     let mut visited: HashMap<String, (usize, String)> = HashMap::new(); // name -> (depth, project)
     let mut edge_provenance: HashMap<String, crate::store::CallerInfo> = HashMap::new();
     let mut queue: VecDeque<(String, usize)> = VecDeque::new();
@@ -76,7 +80,27 @@ pub fn analyze_impact_cross(
             continue;
         }
 
-        let callers = ctx.get_callers_cross(&current)?;
+        let mut callers = ctx.get_callers_cross(&current)?;
+        // Trust-order the frontier before the first-discovery step.
+        // `get_callers_cross` concatenates each project's callers in store
+        // iteration order, so the same caller name can arrive via BOTH a real
+        // `call` edge (in a later-listed project) and a low-trust
+        // `doc_reference` (in an earlier-listed project). BFS records the FIRST
+        // edge that discovers a name and ignores the rest, so without this sort
+        // the recorded `edge_kind` flips with project order — a `doc_reference`
+        // wins purely by being listed first. Sorting lowest-trust-rank first
+        // (call < serde < macro < fn-pointer < doc-reference) makes the
+        // first-discovered edge the most-trusted one, matching single-project
+        // `build_caller_info`, which draws from trust-ordered SQL.
+        callers.sort_by(|a, b| {
+            a.caller
+                .edge_kind
+                .trust_rank()
+                .cmp(&b.caller.edge_kind.trust_rank())
+                .then_with(|| a.project.cmp(&b.project))
+                .then_with(|| a.caller.file.cmp(&b.caller.file))
+                .then_with(|| a.caller.line.cmp(&b.caller.line))
+        });
         for caller in callers {
             if !visited.contains_key(&caller.caller.name) {
                 // Detect cross-boundary hop
@@ -427,6 +451,64 @@ mod tests {
         assert_eq!(c.edge_kind, CallEdgeKind::FnPointer);
         assert_eq!(c.file, std::path::PathBuf::from("src/a.rs"));
         assert_eq!(c.line, 42);
+    }
+
+    /// Cross-project impact first-discovery records the most-trusted edge kind.
+    ///
+    /// The SAME caller name reaches `target` via a real `call` in one project
+    /// and a `doc_reference` in another. BFS records only the edge that FIRST
+    /// discovers the caller, so before the per-frontier trust-sort the recorded
+    /// `edge_kind` flipped with project iteration order — a `doc_reference`
+    /// listed first mislabelled a real `call`. After the fix the discovering
+    /// edge is the most-trusted one regardless of order: the caller's
+    /// `edge_kind` is `call` in BOTH project orderings.
+    #[test]
+    fn cross_project_impact_first_discovery_keeps_most_trusted_kind() {
+        use crate::parser::CallEdgeKind;
+
+        // Helper: build the 2-project context and return the recorded edge_kind
+        // for `same_caller`, given the order the projects are listed in.
+        fn recorded_kind(doc_first: bool) -> CallEdgeKind {
+            let doc_proj = make_named_store_typed(
+                "doc_proj",
+                "same_caller",
+                "target",
+                CallEdgeKind::DocReference,
+                "src/doc.rs",
+                10,
+            );
+            let call_proj = make_named_store_typed(
+                "call_proj",
+                "same_caller",
+                "target",
+                CallEdgeKind::Call,
+                "src/call.rs",
+                20,
+            );
+            let stores = if doc_first {
+                vec![doc_proj, call_proj]
+            } else {
+                vec![call_proj, doc_proj]
+            };
+            let mut ctx = CrossProjectContext::new(stores);
+            let result = analyze_impact_cross(&mut ctx, "target", 3, false, false).unwrap();
+            assert_eq!(result.callers.len(), 1, "one distinct caller name");
+            assert_eq!(result.callers[0].name, "same_caller");
+            result.callers[0].edge_kind
+        }
+
+        // doc_reference listed FIRST — the order that pre-fix mislabelled it.
+        assert_eq!(
+            recorded_kind(true),
+            CallEdgeKind::Call,
+            "doc_reference-first ordering must still record the real `call`"
+        );
+        // call listed first — the order that happened to be correct pre-fix.
+        assert_eq!(
+            recorded_kind(false),
+            CallEdgeKind::Call,
+            "call-first ordering records the real `call`"
+        );
     }
 
     // ===== Cross-project trace tests =====


### PR DESCRIPTION
## fix(cross-project): restore trust-ordering at the callers cap + impact first-discovery

Closes #1966. From the round-3 cross-project seam-audit. The #1829 class (a remote `doc_reference` presenting as a confident `call`) re-emerged at two cross-project boundaries the single-project paths guard with trust-ordered SQL.

**Finding 1 — `callers_cross_core` / `callees_cross_core` cap.** `get_callers_cross`/`get_callees_cross` concatenate per-project edges in store order, then `truncate(limit)` with no sort — so a `doc_reference` from an earlier-listed project evicts a real `call` from a later one. Added a sort AFTER the edge-kind filter, BEFORE the cap: callers `(trust_rank, project, file, line)` (mirrors `get_callers_full`'s `ORDER BY trust_rank, file, caller_line`), callees `(trust_rank, project, name, line)` (callees carry no file). One fix serves CLI + daemon (shared cores).

**Finding 2 — `analyze_impact_cross` BFS first-discovery.** The visited-insert records the discovering edge's `edge_kind`, but the per-frontier caller stream was unsorted → the recorded kind flipped with project order. Sort each frontier by `(trust_rank, project, file, line)` before the `!visited` step, so first-discovered = most-trusted (matching single-project `build_caller_info`). Also corrected the stale rationale comment (the discovering-edge choice is stable for file/line but NOT for `edge_kind`, which is a property of the edge).

**Tests (fail-before/pass-after, verified by reverting):** `callers_cross_cap_surfaces_call_over_doc_reference`, `callees_cross_cap_surfaces_call_over_doc_reference`, `cross_project_impact_first_discovery_keeps_most_trusted_kind` (both project orderings). Gates: clippy `--all-targets` / fmt / provenance clean; callers (22) + cross_project (22) + impact (90) + daemon-parity graph (71) suites green. Intra-array ordering only — no schema/PV change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
