### PR TITLE
fix(parser): wire Dart call_query + capture function bodies (closes #1967)

### DIFF
--- a/src/language/languages.rs
+++ b/src/language/languages.rs
@@ -1116,6 +1116,7 @@ static LANG_DART: LanguageDef = LanguageDef {
     grammar: Some(|| tree_sitter_dart::LANGUAGE.into()),
     extensions: &["dart"],
     chunk_query: include_str!("queries/dart.chunks.scm"),
+    call_query: Some(include_str!("queries/dart.calls.scm")),
     signature_style: SignatureStyle::UntilBrace,
     doc_nodes: &["comment", "documentation_comment"],
     method_node_kinds: &[],

--- a/src/language/queries/dart.calls.scm
+++ b/src/language/queries/dart.calls.scm
@@ -17,3 +17,13 @@
 (conditional_assignable_selector
   "?."
   (identifier) @callee)
+
+;; Plain function/constructor calls: an identifier whose immediately-following
+;; sibling is an argument selector — `helper()`, `add(1, 2)`, `Greeter("x")`.
+;; The grammar represents `f(args)` as a `_primary` (identifier) followed by a
+;; `selector` containing an `argument_part`, with no enclosing call node, so the
+;; callee is matched by the anchored sibling sequence.
+(
+  (identifier) @callee
+  .
+  (selector (argument_part)))

--- a/src/parser/chunk.rs
+++ b/src/parser/chunk.rs
@@ -46,7 +46,15 @@ use super::Parser;
 /// Structured-Text routine chunks. The chunk class, ids, and content change
 /// wholesale for every indexed L5X/L5K file, so a refresh is required even for
 /// byte-identical content.
-pub const PARSER_VERSION: u32 = 12;
+/// 13: Dart call-graph wiring + body-inclusive chunk ranges. `LANG_DART` now
+/// has a `call_query` (was unwired — Dart yielded zero call edges), and the
+/// chunk span of a Dart function/method/getter/setter is extended to include
+/// its adjacent `function_body` (the grammar inlines the top-level-definition
+/// rule, so the signature node alone excluded the body). A byte-identical Dart
+/// file re-parsed under v13 produces call edges and body-inclusive chunk
+/// content + line_end + content_hash + id that it did not under v12, so a
+/// refresh is required even when the file's bytes are unchanged.
+pub const PARSER_VERSION: u32 = 13;
 
 /// Build the canonical chunk id from its identifying coordinates.
 ///
@@ -159,6 +167,19 @@ pub fn canonical_hash_fallback(content: &str) -> String {
 ///   affected comment range is skipped with a `warn!`, degrading to a
 ///   slightly-less-canonical (but still valid) hash rather than panicking.
 pub(crate) fn canonical_hash(node: tree_sitter::Node, content: &str) -> String {
+    canonical_hash_spanning(node, None, content)
+}
+
+/// Like [`canonical_hash`], but additionally strips comment descendants of an
+/// optional `extra` node whose subtree extends `content` past `node`'s own
+/// `byte_range()` (the Dart body-span case — see `extract_chunk`). The `extra`
+/// node's absolute byte ranges are rebased by the SAME `node.start_byte()` base
+/// because both nodes occupy one contiguous content slice that begins at `node`.
+pub(crate) fn canonical_hash_spanning(
+    node: tree_sitter::Node,
+    extra: Option<tree_sitter::Node>,
+    content: &str,
+) -> String {
     let _span = tracing::debug_span!("canonical_hash", kind = node.kind()).entered();
     let base = node.start_byte();
     let content_len = content.len();
@@ -166,6 +187,9 @@ pub(crate) fn canonical_hash(node: tree_sitter::Node, content: &str) -> String {
     // Collect chunk-local byte ranges of all comment descendants.
     let mut ranges: Vec<(usize, usize)> = Vec::new();
     collect_comment_ranges(node, base, content_len, &mut ranges);
+    if let Some(extra) = extra {
+        collect_comment_ranges(extra, base, content_len, &mut ranges);
+    }
 
     if ranges.is_empty() {
         return canonical_hash_fallback(content);
@@ -287,6 +311,18 @@ impl Parser {
                 ParserError::ParseFailed("No definition capture found in match".into())
             })?;
 
+        // Dart body-range span: the tree-sitter-dart grammar inlines its
+        // top-level-definition rule, so a `function_signature` and its
+        // `function_body` are ADJACENT SIBLINGS with no node spanning both. The
+        // chunk query captures the signature, whose `byte_range()` covers only
+        // the signature — excluding the body, which starves per-chunk call
+        // extraction (it is scoped to the captured node's byte range). When a
+        // captured signature has an associated `function_body`, extend the chunk
+        // span to include it. Other languages have a real spanning node, so this
+        // returns `None` for them and the chunk range is unchanged.
+        let body_node = dart_function_body(node, language);
+        let span_end_byte = body_node.map_or_else(|| node.end_byte(), |b| b.end_byte());
+
         // Get name capture
         let name_idx = query.capture_index_for_name("name");
         let name_capture = name_idx.and_then(|idx| m.captures.iter().find(|c| c.index == idx));
@@ -299,8 +335,10 @@ impl Parser {
             })
             .unwrap_or_else(|| "<anonymous>".to_string());
 
-        // Extract content
-        let content = source[node.byte_range()].to_string();
+        // Extract content over the (possibly body-extended) span. For all
+        // non-Dart languages `span_end_byte == node.end_byte()`, so this is the
+        // captured node's range unchanged.
+        let content = source[node.start_byte()..span_end_byte].to_string();
 
         // Validate name position: if the @name capture is far from the definition
         // start, tree-sitter error recovery likely matched the wrong node.
@@ -315,9 +353,13 @@ impl Parser {
             }
         }
 
-        // Line numbers (1-indexed for display)
+        // Line numbers (1-indexed for display). `line_end` tracks the extended
+        // span so a body-inclusive Dart chunk reports the body's last line.
         let line_start = node.start_position().row as u32 + 1;
-        let line_end = node.end_position().row as u32 + 1;
+        let line_end = body_node
+            .map_or_else(|| node.end_position(), |b| b.end_position())
+            .row as u32
+            + 1;
 
         // Extract signature
         let signature = extract_signature(&content, language);
@@ -362,8 +404,12 @@ impl Parser {
         );
 
         // Comment- and whitespace-normalized hash for embedding cache reuse.
-        // Tree-precise: strips all comment descendants of `node`.
-        let canonical = canonical_hash(node, &content);
+        // Tree-precise: strips all comment descendants of `node`. For a
+        // body-extended Dart chunk the body's comment descendants live under
+        // `body_node`, not `node`, so they are collected from both — otherwise a
+        // comment-only edit inside the body would change the canonical hash and
+        // force a needless re-embed.
+        let canonical = canonical_hash_spanning(node, body_node, &content);
 
         Ok(Chunk {
             id,
@@ -818,6 +864,45 @@ fn extract_name_fallback(content: &str) -> Option<String> {
             let name = rest[..name_end].trim();
             if !name.is_empty() {
                 return Some(name.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Locate the `function_body` node associated with a captured Dart
+/// signature/member node, so [`Parser::extract_chunk`] can extend the chunk
+/// span to include the body.
+///
+/// The tree-sitter-dart grammar inlines `_top_level_definition`, so a top-level
+/// `function_signature` / `getter_signature` / `setter_signature` and its
+/// `function_body` are adjacent siblings of `source_file` with no spanning
+/// node; in-class members nest as `class_member > method_signature >
+/// {function,getter,setter}_signature`, with `function_body` a sibling of
+/// `method_signature`. Two cases cover both shapes:
+///   1. the captured node's immediate next sibling is `function_body`
+///      (top-level signature, or an in-class method captured at
+///      `method_signature`), and
+///   2. the captured node's parent is `method_signature` whose next sibling is
+///      `function_body` (an in-class getter/setter captured at the inner
+///      `getter_signature`/`setter_signature`).
+/// Abstract members and signature-only declarations have no `function_body` and
+/// yield `None` (the chunk keeps its signature-only range). Returns `None` for
+/// every non-Dart language.
+fn dart_function_body(node: tree_sitter::Node, language: Language) -> Option<tree_sitter::Node> {
+    if language != Language::Dart {
+        return None;
+    }
+    if let Some(sib) = node.next_sibling() {
+        if sib.kind() == "function_body" {
+            return Some(sib);
+        }
+    }
+    let parent = node.parent()?;
+    if parent.kind() == "method_signature" {
+        if let Some(sib) = parent.next_sibling() {
+            if sib.kind() == "function_body" {
+                return Some(sib);
             }
         }
     }

--- a/tests/language_test.rs
+++ b/tests/language_test.rs
@@ -7590,6 +7590,162 @@ Map<String, dynamic> parseConfig(String path) {
     );
 }
 
+/// Dart call-graph extraction: a top-level function calling another function,
+/// AND a method calling a top-level function, must both surface call edges.
+/// Two preconditions hold for this: `LANG_DART` has a wired `call_query`, and
+/// the chunk span includes the body (per-chunk call extraction is scoped to the
+/// chunk's byte range, so a signature-only span finds nothing in the body).
+#[test]
+fn test_dart_call_graph() {
+    let content = r#"
+int helper(int x) {
+  return x + 1;
+}
+
+int caller() {
+  return helper(41);
+}
+
+class Widget {
+  int build() {
+    return helper(7);
+  }
+}
+"#;
+    let file = write_temp_file(content, "dart");
+    let parser = Parser::new().unwrap();
+    let chunks = parser.parse_file(file.path()).unwrap();
+
+    let caller = chunks
+        .iter()
+        .find(|c| c.name == "caller")
+        .unwrap_or_else(|| panic!("no caller chunk in {:?}", chunk_names(&chunks)));
+    let caller_callees: Vec<_> = parser
+        .extract_calls_from_chunk(caller)
+        .into_iter()
+        .map(|c| c.callee_name)
+        .collect();
+    assert!(
+        caller_callees.iter().any(|n| n == "helper"),
+        "function->function: expected `helper` edge from `caller`, got {:?}",
+        caller_callees
+    );
+
+    let build = chunks
+        .iter()
+        .find(|c| c.name == "build")
+        .unwrap_or_else(|| panic!("no build method chunk in {:?}", chunk_names(&chunks)));
+    let build_callees: Vec<_> = parser
+        .extract_calls_from_chunk(build)
+        .into_iter()
+        .map(|c| c.callee_name)
+        .collect();
+    assert!(
+        build_callees.iter().any(|n| n == "helper"),
+        "method->function: expected `helper` edge from `build`, got {:?}",
+        build_callees
+    );
+}
+
+/// A Dart function (and method) chunk's `content` must include its body, not
+/// just the signature. The tree-sitter-dart grammar inlines its
+/// top-level-definition rule, so the captured `function_signature` covers only
+/// the signature; `extract_chunk` extends the span to the adjacent
+/// `function_body`.
+#[test]
+fn test_dart_chunk_includes_body() {
+    let content = r#"
+int compute(int x) {
+  final doubled = x * 2;
+  return doubled + 1;
+}
+
+class Widget {
+  String render() {
+    final label = "ok";
+    return label;
+  }
+}
+"#;
+    let file = write_temp_file(content, "dart");
+    let parser = Parser::new().unwrap();
+    let chunks = parser.parse_file(file.path()).unwrap();
+
+    let func = chunks
+        .iter()
+        .find(|c| c.name == "compute")
+        .unwrap_or_else(|| panic!("no compute chunk in {:?}", chunk_names(&chunks)));
+    assert!(
+        func.content.contains("final doubled") && func.content.contains("return doubled + 1"),
+        "function chunk should include its body, got content:\n{}",
+        func.content
+    );
+
+    let method = chunks
+        .iter()
+        .find(|c| c.name == "render")
+        .unwrap_or_else(|| panic!("no render chunk in {:?}", chunk_names(&chunks)));
+    assert!(
+        method.content.contains("final label") && method.content.contains("return label"),
+        "method chunk should include its body, got content:\n{}",
+        method.content
+    );
+}
+
+fn chunk_names(chunks: &[cqs::parser::Chunk]) -> Vec<(&str, &ChunkType)> {
+    chunks
+        .iter()
+        .map(|c| (c.name.as_str(), &c.chunk_type))
+        .collect()
+}
+
+/// Completeness guard: every authored `*.calls.scm` query must be WIRED into
+/// its language's `LanguageDef::call_query`. Enumerates the query files, maps
+/// each basename to its `Language`, and asserts `def().call_query ==
+/// Some(<file contents>)`. An authored-but-unwired calls.scm silently yields an
+/// empty call graph for that language; this fails instead. The `>= 39` floor
+/// guards against the glob silently finding nothing (e.g. the query dir moved).
+#[test]
+fn every_calls_scm_is_wired() {
+    use std::str::FromStr;
+
+    let dir = concat!(env!("CARGO_MANIFEST_DIR"), "/src/language/queries");
+    let mut authored: Vec<(String, String)> = Vec::new();
+    for entry in std::fs::read_dir(dir).expect("read queries dir") {
+        let path = entry.expect("dir entry").path();
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) if n.ends_with(".calls.scm") => n.to_string(),
+            _ => continue,
+        };
+        let basename = name.trim_end_matches(".calls.scm").to_string();
+        let contents = std::fs::read_to_string(&path).expect("read calls.scm");
+        authored.push((basename, contents));
+    }
+
+    assert!(
+        authored.len() >= 39,
+        "expected >= 39 authored *.calls.scm files, found {} (did the query dir move?)",
+        authored.len()
+    );
+
+    let mut unwired: Vec<String> = Vec::new();
+    for (basename, contents) in &authored {
+        let lang = Language::from_str(basename)
+            .unwrap_or_else(|_| panic!("no Language for calls.scm basename `{basename}`"));
+        if !lang.is_enabled() {
+            continue; // feature-gated off in this build; nothing to assert
+        }
+        match lang.def().call_query {
+            Some(wired) if wired == contents => {}
+            _ => unwired.push(basename.clone()),
+        }
+    }
+    assert!(
+        unwired.is_empty(),
+        "authored calls.scm not wired into LanguageDef::call_query: {unwired:?}"
+    );
+}
+
 // -- Phase 2 chunk type tests ────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## fix(parser): wire Dart call_query + capture function bodies (call graph was silently empty)

Closes #1967. From the round-3 per-language sweep-audit.

`dart.calls.scm` (on disk since PR #816) was never wired into `LANG_DART.call_query` → Dart's call graph was empty (every callers/callees/impact/dead for Dart wrong). Three layers:

1. **Wiring:** `call_query: Some(include_str!("queries/dart.calls.scm"))` in `LANG_DART`.
2. **calls.scm gap (judgment call):** the existing 5 patterns only matched `.method` selectors + constructors, not plain function calls (`helper()`, `add(1,2)` parse as a bare `identifier` + `selector > argument_part`, no enclosing call node). Added an anchored sibling pattern `((identifier) @callee . (selector (argument_part)))`. Without this, wiring alone left function→function edges empty.
3. **Body-range:** tree-sitter-dart inlines `_top_level_definition`, so for top-level functions NO node spans `function_signature` + `function_body` (adjacent siblings) — the `@function` chunk covered the signature only, and per-chunk call extraction (scoped to the chunk range) found nothing in bodies. Extended the chunk span in `extract_chunk` via a Dart-gated `dart_function_body` helper (top-level: captured node's next sibling is `function_body`; in-class: parent `method_signature`'s sibling). `canonical_hash_spanning` strips body comments so the cache key stays correct.
4. **Completeness guard** `every_calls_scm_is_wired`: enumerates `*.calls.scm`, asserts each is wired into its `LanguageDef.call_query` (floor ≥39) — the next unwired-calls.scm straggler fails automatically.

PARSER_VERSION **12 → 13** (Dart parse-output changes: call edges + body-inclusive chunks).

**Tests (fail-before/pass-after):** `every_calls_scm_is_wired` (was `not wired: ["dart"]`), `test_dart_call_graph` (function→function + method→function; was `[]`), `test_dart_chunk_includes_body` (was signature-only). Full `cargo test --features cuda-index --tests`: **4702 passed, 0 failed, 67 ignored, 0 flakes** (all 9 Dart + 310 chunk lib tests green). clippy `--all-targets` / fmt / provenance clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
