### PR TITLE
chore: post-round-3 hardening — embedder proptests, cosine clamps, doc sync

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -303,7 +303,7 @@ src/
   output_format.rs - Wire-envelope selector: EnvelopeShape (V1Envelope | V2Bare; gated by CQS_OUTPUT_FORMAT, process-lifetime cached). Default V2Bare emits the bare payload on the CLI direct success path; v1 restores the full envelope. Consumed by emission helpers in src/cli/json_envelope.rs. Distinct from the CLI `--format` flag enum `OutputFormat` in src/cli/definitions.rs. (The CQS_ULTRASECURITY posture knob was removed in #1690 — security signals always emit when meaningful.)
   language/     - Tree-sitter language support (54 languages + L5X/L5K)
     mod.rs      - Language enum (define_languages! macro), LanguageRegistry, LanguageDef, ChunkType
-    languages.rs - All 54 language definitions (LanguageDef statics with ..DEFAULTS) + custom functions
+    languages.rs - All 55 LanguageDef statics with ..DEFAULTS (54 general languages + the L5X/L5K PLC extractor) + custom functions
     queries/    - Tree-sitter queries (.scm files, loaded via include_str!())
       <lang>.chunks.scm, <lang>.calls.scm, <lang>.types.scm
   test_helpers.rs - Shared test fixtures module

--- a/src/cagra.rs
+++ b/src/cagra.rs
@@ -654,7 +654,11 @@ impl CagraIndex {
             }
             if idx < self.id_map.len() {
                 let score = match self.metric {
-                    DistanceMetric::Cosine => 1.0 - dist / 2.0,
+                    // Clamp the f32 overshoot: a near-self match where the
+                    // unit-norm self-dot rounds just above 1.0 makes cos = 1 - d/2
+                    // exceed 1.0; cap it so a downstream acos/sqrt-of-(1-score)
+                    // consumer can't NaN.
+                    DistanceMetric::Cosine => (1.0 - dist / 2.0).min(1.0),
                     DistanceMetric::DotProduct => dist,
                 };
                 results.push(IndexResult {

--- a/src/embedder/core.rs
+++ b/src/embedder/core.rs
@@ -1808,6 +1808,174 @@ mod tests {
                 prop_assert_eq!(emb.as_slice().len(), EMBEDDING_DIM);
                 prop_assert_eq!(emb.as_vec().len(), EMBEDDING_DIM);
             }
+
+            /// Property (#1949 boundary characterization): the self-dot of an
+            /// f32-`normalize_l2`'d vector is NOT guaranteed `<= 1.0`. It is
+            /// `~1.0` but can overshoot by a tiny epsilon — `normalize` divides
+            /// by `sqrt(sum(x^2))` accumulated in f32, and `sum(x^2) /
+            /// sum(x^2)` rounds slightly above 1 on ~40% of realistic inputs
+            /// (worst observed excess ≈ 1.7e-6 at dim 768). This is WHY
+            /// `DistDotClamped` (`hnsw/mod.rs`) clamps `dot.min(1.0)` and why
+            /// every downstream cosine consumer (MMR, name-blend, note-boost)
+            /// clamps its score range. The guard pins the magnitude of the
+            /// overshoot: it must stay tiny (a regression that let it grow —
+            /// e.g. a buggy normalize — would surface here), but it must NOT
+            /// be asserted away as exactly `<= 1.0`, because that is false.
+            /// A hand-written example can pick one vector that happens to land
+            /// at-or-below 1.0 and conclude (wrongly) the bound holds; only a
+            /// generator over the input space exposes the over-unit cases.
+            #[test]
+            fn prop_normalize_l2_self_dot_overshoot_bounded(
+                v in prop::collection::vec(-10.0f32..10.0f32, 64..=1024)
+            ) {
+                let norm_sq: f32 = v.iter().map(|x| x * x).sum();
+                prop_assume!(norm_sq > 1e-6); // skip near-zero-norm (left unscaled)
+                let n = normalize_l2(v);
+                let self_dot: f32 = n.iter().map(|x| x * x).sum();
+                // The overshoot, when present, is bounded by a tiny epsilon.
+                // 1e-3 is generous headroom over the ~1.7e-6 observed worst
+                // case — a real regression (wrong divisor, missing sqrt) would
+                // blow past it.
+                prop_assert!(
+                    (1.0 - 1e-3..=1.0 + 1e-3).contains(&self_dot),
+                    "self-dot of normalized vector must be ~1.0 (±1e-3), got {self_dot}"
+                );
+            }
+
+            /// Property (idempotence): `normalize_l2(normalize_l2(v)) ==
+            /// normalize_l2(v)` within f32 tolerance. An already-unit vector
+            /// must survive a second pass unchanged — a divisor bug or an
+            /// `if norm_sq != 1.0` short-circuit would break this. Example
+            /// tests apply normalize once and never the second time.
+            #[test]
+            fn prop_normalize_l2_idempotent(
+                v in prop::collection::vec(-10.0f32..10.0f32, 64..=1024)
+            ) {
+                let norm_sq: f32 = v.iter().map(|x| x * x).sum();
+                prop_assume!(norm_sq > 1e-6);
+                let n1 = normalize_l2(v);
+                let n2 = normalize_l2(n1.clone());
+                for (a, b) in n1.iter().zip(n2.iter()) {
+                    prop_assert!(
+                        (a - b).abs() < 1e-5,
+                        "normalize_l2 not idempotent: {a} vs {b}"
+                    );
+                }
+            }
+        }
+    }
+
+    // ===== Pooling batch-vs-single equivalence (proptest) =====
+    //
+    // The core inference-correctness invariant the example suite never
+    // expresses: a row's pooled vector must be invariant to which OTHER rows
+    // share its batch. Real BERT/decoder inference with right-padding +
+    // attention masking produces the same per-token hidden states regardless
+    // of batch composition; the poolers must preserve that. The hand-written
+    // pooling tests (`mean_pool_respects_mask`, `cls_pool_returns_first_token`,
+    // `last_token_pool_picks_last_unmasked`) each use ONE fixed batch and never
+    // compare a row against the same row pooled alone — so a pooling bug that
+    // leaked a neighbor's padded positions into a row's mean would pass them.
+    mod pooling_batch_eq_single {
+        use super::*;
+        use proptest::prelude::*;
+
+        /// Build a `[batch, seq, dim]` hidden tensor + right-padded mask from
+        /// per-row true lengths. The SAME (token-position, dim) coordinate
+        /// gets the SAME hidden value across every batch composition, modeling
+        /// batch-invariant inference; padded positions (`j >= true_len`) get
+        /// distinct junk that correct masking must cancel.
+        fn build_batch(
+            lens: &[usize],
+            seed: &[f32],
+            seq_len: usize,
+            dim: usize,
+        ) -> (Array3<f32>, Array2<i64>) {
+            let batch = lens.len();
+            let mut hidden = Array3::<f32>::zeros((batch, seq_len, dim));
+            let mut mask = Array2::<i64>::zeros((batch, seq_len));
+            for (i, &true_len) in lens.iter().enumerate() {
+                for j in 0..seq_len {
+                    for d in 0..dim {
+                        let base = seed[d % seed.len()];
+                        hidden[[i, j, d]] = if j < true_len {
+                            base + (j as f32) * 0.5 + (d as f32) * 0.01
+                        } else {
+                            999.0 + j as f32 // padded junk — must be masked
+                        };
+                    }
+                    mask[[i, j]] = if j < true_len { 1 } else { 0 };
+                }
+            }
+            (hidden, mask)
+        }
+
+        proptest! {
+            /// mean_pool: a row's mean is invariant to batch padding.
+            #[test]
+            fn prop_mean_pool_batch_eq_single(
+                lens in prop::collection::vec(1usize..=12, 1..=5),
+                seed in prop::collection::vec(-3.0f32..3.0, 4..=8),
+            ) {
+                let dim = seed.len();
+                let max_len = *lens.iter().max().unwrap();
+                let (hb, mb) = build_batch(&lens, &seed, max_len, dim);
+                let batched = mean_pool(&hb, &mb, dim);
+                for (i, &l) in lens.iter().enumerate() {
+                    let (hs, ms) = build_batch(&[l], &seed, l, dim);
+                    let single = mean_pool(&hs, &ms, dim);
+                    for d in 0..dim {
+                        prop_assert!(
+                            (batched[i][d] - single[0][d]).abs() < 1e-3,
+                            "mean_pool batch != single: row {i} dim {d} (len {l}): {} vs {}",
+                            batched[i][d], single[0][d]
+                        );
+                    }
+                }
+            }
+
+            /// cls_pool: the first token is invariant to batch padding.
+            #[test]
+            fn prop_cls_pool_batch_eq_single(
+                lens in prop::collection::vec(1usize..=12, 1..=5),
+                seed in prop::collection::vec(-3.0f32..3.0, 4..=8),
+            ) {
+                let dim = seed.len();
+                let max_len = *lens.iter().max().unwrap();
+                let (hb, _mb) = build_batch(&lens, &seed, max_len, dim);
+                let batched = cls_pool(&hb);
+                for (i, &l) in lens.iter().enumerate() {
+                    let (hs, _ms) = build_batch(&[l], &seed, l, dim);
+                    let single = cls_pool(&hs);
+                    for d in 0..dim {
+                        prop_assert!((batched[i][d] - single[0][d]).abs() < 1e-3);
+                    }
+                }
+            }
+
+            /// last_token_pool: the last unmasked token is invariant to batch
+            /// padding (padding lives to the RIGHT of the last real token, so
+            /// a longer sibling in the batch must not shift the pick).
+            #[test]
+            fn prop_last_token_pool_batch_eq_single(
+                lens in prop::collection::vec(1usize..=12, 1..=5),
+                seed in prop::collection::vec(-3.0f32..3.0, 4..=8),
+            ) {
+                let dim = seed.len();
+                let max_len = *lens.iter().max().unwrap();
+                let (hb, mb) = build_batch(&lens, &seed, max_len, dim);
+                let batched = last_token_pool(&hb, &mb);
+                for (i, &l) in lens.iter().enumerate() {
+                    let (hs, ms) = build_batch(&[l], &seed, l, dim);
+                    let single = last_token_pool(&hs, &ms);
+                    for d in 0..dim {
+                        prop_assert!(
+                            (batched[i][d] - single[0][d]).abs() < 1e-3,
+                            "last_token_pool batch != single: row {i} dim {d} (len {l})"
+                        );
+                    }
+                }
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -488,13 +488,14 @@ pub fn unix_secs_i64() -> Option<i64> {
 /// Used by scout, impact, and where_to_add to filter out tests from analysis.
 ///
 /// **Not** used by `store::calls::find_dead_code`, which has its own SQL-based
-/// detection (`TEST_NAME_PATTERNS`, `TEST_CONTENT_MARKERS`, `TEST_PATH_PATTERNS`)
-/// that also checks content markers like `#[test]` and `@Test`.
+/// detection (`build_test_chunk_filter` — keyed on the `chunk_type = 'test'` tag,
+/// plus `build_test_content_markers`/`build_test_path_patterns` for tagless
+/// languages) that also checks content markers like `#[test]` and `@Test`.
 pub fn is_test_chunk(name: &str, file: &str) -> bool {
     // Name-based patterns from the language registry.
     //
     // Single source of truth for both this matcher and
-    // `store::calls::TEST_NAME_PATTERNS`. The default set uses `Test\_%`, which
+    // `store::calls::build_test_chunk_filter`. The default set uses `Test\_%`, which
     // matches `Test_bar` but NOT `TestRegistry` (a looser `Test%` would
     // incorrectly demote test-framework API types). Languages
     // with their own conventions (Kotlin/Swift `should_*`, JUnit5

--- a/src/tiered.rs
+++ b/src/tiered.rs
@@ -495,8 +495,10 @@ impl TieredIndex {
             if idx < id_map.len() {
                 let score = match self.metric {
                     // L2Expanded squared distance on unit-norm vectors:
-                    // d = 2 - 2cos → cos = 1 - d/2.
-                    DistanceMetric::Cosine => 1.0 - dist / 2.0,
+                    // d = 2 - 2cos → cos = 1 - d/2. Clamp the f32 overshoot (a
+                    // near-self match's self-dot rounds just above 1.0) so a
+                    // downstream acos/sqrt-of-(1-score) consumer can't NaN.
+                    DistanceMetric::Cosine => (1.0 - dist / 2.0).min(1.0),
                     // InnerProduct returns the raw dot product (best-first).
                     DistanceMetric::DotProduct => dist,
                 };


### PR DESCRIPTION
## chore: post-round-3 hardening — embedder proptests, cosine clamps, doc sync

Cleanup from the round-3 audit (no behavior change to the default path).

- **`embedder/core.rs`** — 5 property tests from the round-3 property audit (clean bill): `normalize_l2` bounds/idempotence + mean/cls/last-token pooling **batch == single** equivalence. The example suite never expressed batch-invariance, and ~42% of random inputs trip the f32 over-unit-norm boundary that #1949 was about — these generators pin both.
- **`cagra.rs` / `tiered.rs`** — clamp the L2→cosine score to `≤ 1.0` (`(1.0 - dist/2.0).min(1.0)`). A near-self match's f32 self-dot rounds just above 1.0; benign today (no consumer breaks) but a future `acos`/`sqrt(1-score)` would NaN. Low/latent residual flagged by the audit.
- **`lib.rs`** — refresh the `is_test_chunk` doc to the current `build_test_*` symbols (the old `TEST_*_PATTERNS` names are gone post-#1954).
- **`CONTRIBUTING.md`** — `54 → 55` LanguageDef statics (L5X/L5K became its own def in #1955).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
