### PR TITLE
chore: Release v1.46.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.46.0] - 2026-06-15
+
+Post-v1.45.0 idle loop + a 3-round audit. **PARSER_VERSION 10 → 13 — a reindex is required** (drift-driven on the next `cqs index`, or `cqs index --force`); cqs's own (Rust) corpus is unaffected by the Dart/L5X parser changes.
+
+### Added
+
+- **L5X/L5K PLC Structured-Text extraction now runs in production (#1955, PR #1958; PARSER_VERSION → 12).** The custom ST extractor was dead on the production index path — `.l5x`/`.l5k` were parsed with the generic XML grammar because they lived under `LANG_XML`'s extensions; the custom dispatch only ran on a code path indexing never called. Wired via a dedicated grammar-less `LanguageDef` + `custom_all_parser`. The #1888 file-relative `byte_start` injectivity fix is now live.
+- **Dart call graph (#1967, PR #1970; PARSER_VERSION → 13).** `dart.calls.scm` (present since PR #816) was never wired into `LANG_DART.call_query` — Dart `callers`/`callees`/`impact`/`dead` were all silently empty. Wired it; fixed the chunk span to include function bodies (tree-sitter-dart inlines the top-level-definition rule, so signature and body are adjacent siblings); added a completeness guard asserting every `*.calls.scm` is wired into its language def.
+- **Full v10→v32 schema-migration-chain frozen-artifact guard (#1950)** and embedder property tests — `normalize_l2` bounds/idempotence, pooling batch==single (#1971).
+
+### Changed
+
+- **`cqs dead` verdicts hardened against adversarial indexed content (#1954).** `build_test_chunk_filter` keys on the `ChunkType::Test` parser tag (was a `#[cfg(test)]` content-substring a comment could spoof to hide a function from the whole sweep); the external-trait-method known-gap excuse is gated on `ChunkType::Method` (was name-only — a free function named `visit_seq` was wrongly excused). SECURITY.md documents `--verdict dead` as a confident subset under adversarial content.
+- **Cross-project `callers`/`impact` restore trust-ordering at the cap/first-discovery boundary (#1966)** — a remote `doc_reference` no longer evicts (in the capped window) or mislabels (in the impact BFS) a real `call`.
+- **`--rerank` overlay/reference merge now reranks the *merged* set (#1952)** so both legs share the cross-encoder's score frame (was: sigmoid project scores sorted against raw cosine overlay/reference scores in one comparator). The default no-rerank path is byte-for-byte unchanged.
+- CAGRA/tiered cosine score clamped to ≤ 1.0 (f32 self-dot overshoot) (#1971).
+
+### Fixed
+
+- **HNSW DotProduct metric no longer panics on f32 unit-norm vectors (#1951).** `normalize_l2` yields `a·a ≈ 1.0000005 > 1.0`, tripping anndists' `DistDot` assert — on both build (in a rayon worker → killed the whole index build) and search. A custom `DistDotClamped` (`1 - min(a·b, 1)`) replaces it. Cosine arm immune/unchanged.
+- candidate_edges persisted on the watch zero-chunk finalize path (#1942); overlay candidate recompute → `low-confidence-live` for candidate-only Direction-B additions (#1943); `#[test]` fns + framework-trait methods classify correctly in `cqs dead` (#1945/#1946, closing #1573); L5X chunk-id injectivity (#1947).
+
+### Security
+
+- **Daemon overlay-root validation hardened (#1956, closes #1953).** A forged or symlinked `.git`, and a post-validation symlink/rename swap, can no longer steer the daemon into indexing+relaying an arbitrary out-of-tree directory as trusted `user-code`: validation now requires `git worktree list` registry membership and pins the validated directory's inode via a held fd (`openat2 RESOLVE_NO_SYMLINKS`; git ops via `/proc/self/fd/N`). Found via red-team audit; four bypasses caught across review rounds. A residual same-uid check-then-recreate race + the non-CLOEXEC O_PATH fd are tracked low-severity (#1969).
+
+### Recall
+
+- v3.v2 dual-judge (218q, 2026-06-15 snapshot at ~16.8k chunks): **72.0% R@5 / 48.7% R@1 / 87.6% R@20**. vs v1.45.0 (72.0 / 47.7 / 88.5): R@5 flat, R@1 +1.0, R@20 −0.9 — corpus churn from the new code (scoring unchanged on the default path), 0 dead golds.
+
+### Dependencies
+
+- Bumped tower-http 0.6→0.7, ignore, insta, regex, tree-sitter-erlang, chrono (dependabot).
+
 ## [1.45.0] - 2026-06-14
 
 ### Added
@@ -3763,7 +3797,8 @@ Second 14-category audit completed (117 findings). 107 of 109 actionable finding
 - CLI commands: init, doctor, index, stats, serve
 - Filter by language (`-l`) and path pattern (`-p`)
 
-[Unreleased]: https://github.com/jamie8johnson/cqs/compare/v1.45.0...HEAD
+[Unreleased]: https://github.com/jamie8johnson/cqs/compare/v1.46.0...HEAD
+[1.46.0]: https://github.com/jamie8johnson/cqs/compare/v1.45.0...v1.46.0
 [1.45.0]: https://github.com/jamie8johnson/cqs/compare/v1.44.0...v1.45.0
 [1.44.0]: https://github.com/jamie8johnson/cqs/compare/v1.43.0...v1.44.0
 [1.25.0]: https://github.com/jamie8johnson/cqs/compare/v1.24.0...v1.25.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "1.45.0"
+version = "1.46.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,10 @@ members = ["cqs-macros"]
 
 [package]
 name = "cqs"
-version = "1.45.0"
+version = "1.46.0"
 edition = "2021"
 rust-version = "1.96"
-description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 54 languages + L5X/L5K PLC exports. 72.0% R@5 / 47.7% R@1 / 88.5% R@20 on v3.v2 dual-judge code-search (218 queries, EmbeddingGemma-300m default with per-category SPLADE α; 2026-06-14 v1.45.0 snapshot). Daemon mode (3-19ms queries). Local-first, GPU-accelerated."
+description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 54 languages + L5X/L5K PLC exports. 72.0% R@5 / 48.7% R@1 / 87.6% R@20 on v3.v2 dual-judge code-search (218 queries, EmbeddingGemma-300m default with per-category SPLADE α; 2026-06-15 v1.46.0 snapshot). Daemon mode (3-19ms queries). Local-first, GPU-accelerated."
 license = "MIT"
 repository = "https://github.com/jamie8johnson/cqs"
 homepage = "https://github.com/jamie8johnson/cqs"

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -2,7 +2,7 @@
 
 ## Data Stays Local
 
-cqs processes your code locally by default. With `--llm-summaries`, function code is sent to Anthropic's API for one-sentence summary generation. With `--improve-docs`, LLM-generated doc comments are written back to your source files. With `--hyde-queries`, function descriptions are sent to Anthropic's API for synthetic search query generation. See [Anthropic's privacy policy](https://www.anthropic.com/privacy). Without these flags, nothing is transmitted externally and no source files are modified.
+cqs processes your code locally by default. With `--llm-summaries`, function code is sent to Anthropic's API for one-sentence summary generation. With `--improve-docs`, function code is sent to Anthropic's API and LLM-generated doc comments are staged as review patches under `.cqs/proposed-docs/` (passing `--apply` writes them directly to your source files). With `--hyde-queries`, function descriptions are sent to Anthropic's API for synthetic search query generation. See [Anthropic's privacy policy](https://www.anthropic.com/privacy). Without these flags, nothing is transmitted externally and no source files are modified.
 
 - **No telemetry by default**: Optional local-only command logging when `CQS_TELEMETRY=1` is set OR when `.cqs/telemetry.jsonl` already exists (persists opt-in across shells/subprocesses). Stored in `.cqs/telemetry.jsonl`, never transmitted. Delete the file and unset the env var to opt out
 - **No analytics**: No tracking of any kind

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Code intelligence and RAG for AI agents. Semantic search, call graph analysis, impact tracing, type dependencies, and smart context assembly — all in single tool calls. Local ML embeddings, GPU-accelerated.
 
-**TL;DR:** Code intelligence toolkit for Claude Code. Instead of grep + sequential file reads, cqs understands what code *does* — semantic search finds functions by concept, call graph commands trace dependencies, and `gather`/`impact`/`context` assemble the right context in one call. 17-41x token reduction vs full file reads. **72.0% R@5 / 47.7% R@1 / 88.5% R@20 on a 218-query dual-judge eval (109 test + 109 dev, v3.v2 fixture) against the cqs codebase itself** with EmbeddingGemma-300m default (2026-06-14 v1.45.0 release-gate snapshot at 16.7k chunks; gemma dense + SPLADE sparse with per-category α fusion + centroid query routing). 54 languages + L5X/L5K PLC exports, GPU-accelerated.
+**TL;DR:** Code intelligence toolkit for Claude Code. Instead of grep + sequential file reads, cqs understands what code *does* — semantic search finds functions by concept, call graph commands trace dependencies, and `gather`/`impact`/`context` assemble the right context in one call. 17-41x token reduction vs full file reads. **72.0% R@5 / 48.7% R@1 / 87.6% R@20 on a 218-query dual-judge eval (109 test + 109 dev, v3.v2 fixture) against the cqs codebase itself** with EmbeddingGemma-300m default (2026-06-15 v1.46.0 release-gate snapshot at 16.8k chunks; gemma dense + SPLADE sparse with per-category α fusion + centroid query routing). 54 languages + L5X/L5K PLC exports, GPU-accelerated.
 
 [![Crates.io](https://img.shields.io/crates/v/cqs.svg)](https://crates.io/crates/cqs)
 [![CI](https://github.com/jamie8johnson/cqs/actions/workflows/ci.yml/badge.svg)](https://github.com/jamie8johnson/cqs/actions/workflows/ci.yml)
@@ -723,14 +723,12 @@ The tiered defaults work well for most codebases; reach for the env overrides on
 
 | Preset | Params | Test R@1 | Test R@5 | Test R@20 | Dev R@1 | Dev R@5 | Dev R@20 | Agg R@1 | Agg R@5 | Agg R@20 |
 |--------|--------|---------:|---------:|----------:|--------:|--------:|---------:|--------:|--------:|---------:|
-| **embeddinggemma-300m** (default, v1.39.x α + v3.v2 re-anchor) | 308M | 49.5% | 72.5% | 84.4% | 56.0% | 82.6% | 94.5% | **52.7%** | **77.5%** | **89.4%** |
+| **embeddinggemma-300m** (default, per-category α; v3.v2 fixture) | 308M | 46.8% | 68.8% | 86.2% | 50.5% | 75.2% | 89.0% | **48.7%** | **72.0%** | **87.6%** |
 
-2026-05-08 snapshot on the gemma slot at 14,203 chunks (post-v1.39.1 cliff fix + LLM summaries refresh, 68.7% per-chunk summary coverage; **post-v1.40.0 v3.v2 fixture re-anchor #1607**). Per-category SPLADE alphas, including the v1.39.x identifier_lookup retune that closed dev `identifier_lookup` R@5 to 100%:
+2026-06-15 v1.46.0 release-gate snapshot on the gemma slot at ~16.8k chunks (schema 32, PARSER_VERSION 13, EmbeddingGemma-300m at level_scale 0.5; daemon mode). Per-category SPLADE alphas (set in the v1.36/v1.39.x retunes, unchanged since):
 
 - `IdentifierLookup` 1.00 → 0.85 (v1.39.x retune; +11.1pp dev R@5 within category)
 - `Structural` 0.60, `Behavioral` 1.00, `Conceptual` 0.80, `TypeFiltered` 0.00, `CrossLanguage` 0.70, `MultiStep` 0.10, `Negation` 0.80, `Unknown` 0.80 (catch-all hedge for misroutes).
-
-Above the 2026-05-03 v1.36-snapshot capture (50.9% / 76.2% / 88.6% agg). The pre-refresh 2026-05-08 capture was 46.3 / 74.8 / 86.2 — the fixture re-anchor (#1607) lifted agg R@K **+6.4 / +2.7 / +3.2 pp** by re-anchoring 69 test + 71 dev fixture line numbers to current corpus state (see "Eval Line-Start Drift" — the fixture matches by `(file, name, line_start)` strict; audit-driven line shifts since the original v3 generation silently turned hits into misses). Pure fixture re-anchoring — no retrieval-side change.
 
 <details>
 <summary><b>Other presets</b> (pre-retune — kept for reference, will shift up under v1.36+ alphas)</summary>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,8 @@
 # Roadmap
 
-## Unreleased (on main since v1.45.0)
+## Current: v1.46.0 (cut 2026-06-15)
+
+Minor release. Schema v32, PARSER_VERSION 10→13 (L5X byte_start + production wire-up, Dart call_query — reindex required). Recall: **72.0% R@5 / 48.7% R@1 / 87.6% R@20** (v3.v2 dual-judge, 218q; R@5 headline flat vs v1.45.0, R@1 +1.0 / R@20 −0.9 = PV13-reindex corpus churn, default scoring path byte-for-byte unchanged).
 
 **Idle loop + 3 audit rounds — 10 fixes merged, PARSER_VERSION 10→13.**
 - **Idle loop (5 issues):** #1942 (candidate_edges watch write gap), #1943 (overlay candidate recompute → low-confidence-live), #1945 (test-fn `ChunkType::Test`) + #1946 (framework-trait `KNOWN_GAP`) closing #1573, #1947 (L5X file-relative byte_start, PV→11). `cqs dead --verdict dead` → 1 genuine entry (was 9).
@@ -8,9 +10,10 @@
 - **Security #1953 (#1956):** daemon overlay-root validation hardened against forged/symlinked worktrees + a TOCTOU swap — git-registry membership (`git worktree list`) + a dirfd inode-pin (`openat2 RESOLVE_NO_SYMLINKS`, git via `/proc/self/fd/N`). 4 attempts, each bypass caught by review. Residual same-uid check-then-recreate race + non-CLOEXEC fd tracked low-severity in #1969.
 - 6 dependabot dependency bumps.
 
-**Deferred:** #1952 (overlay/reference merge sorts incomparable score-frames — recall-adjacent, needs an eval-gated fix; bounded since `--rerank` is opt-in/net-negative). #1969 (overlay same-uid TOCTOU residual; airtight = kernel peer-cwd redesign). #1573-Tier-3a (dyn-dispatch dead false-positives, deferred-by-design).
+**Landed since:** #1952 (overlay/reference merge sorted incomparable score-frames → merged-set rerank, PR #1974; default no-rerank path byte-for-byte unchanged).
+**Deferred:** #1969 (overlay same-uid TOCTOU residual; airtight = kernel peer-cwd redesign). #1973 (nightly model-cache hardening, CI-infra). #1975 (pool-truncation, low-sev). #1573-Tier-3a (dyn-dispatch dead false-positives, deferred-by-design).
 
-## Current: v1.45.0 (cut 2026-06-14, crates.io published)
+## Previous: v1.45.0 (cut 2026-06-14, crates.io published)
 
 Minor release. Schema v32, PARSER_VERSION 10. Recall: **72.0% R@5 / 47.7% R@1 / 88.5% R@20** (v3.v2 dual-judge, 218q; R@5 headline; R@1+R@20 flat vs v1.44.0, R@5 −0.5 agg = corpus-determinacy churn, scoring code unchanged — the reduced-indeterminacy call). Three threads:
 


### PR DESCRIPTION
## Release v1.46.0

Minor release. **PARSER_VERSION 10 → 13 — a reindex is required** (drift-driven on the next `cqs index`, or `cqs index --force`). cqs's own (Rust) corpus is unaffected by the Dart/L5X parser changes. Schema unchanged at 32.

This bundles the post-v1.45.0 idle loop (5 issues) + a 3-round audit (7 auditors, 6+ real bugs) + security hardening + 6 dependabot bumps.

### Headlines
- **L5X/L5K PLC Structured-Text extraction now runs in production** (#1955, PR #1958; PV→12) — was dead on the index path, parsed as generic XML.
- **Dart call graph** (#1967, PR #1970; PV→13) — `dart.calls.scm` was never wired; callers/impact/dead were silently empty.
- **`cqs dead` verdicts hardened against adversarial indexed content** (#1954) — `ChunkType` tags instead of spoofable content substrings.
- **Daemon overlay-root validation hardened** (#1956, closes #1953) — git-registry membership + dirfd inode-pin; 4 bypasses caught across review. Residual same-uid race tracked low-sev (#1969).
- **HNSW DotProduct no longer panics on f32 unit-norm vectors** (#1951) — `DistDotClamped`.
- **Cross-project trust-ordering restored at the cap/first-discovery boundary** (#1966).
- **`--rerank` overlay/reference merge reranks the merged set** (#1952, PR #1974) — default no-rerank path byte-for-byte unchanged.

### Recall gate — PASS
v3.v2 dual-judge (218q, 2026-06-15 snapshot, ~16.8k chunks): **72.0% R@5 / 48.7% R@1 / 87.6% R@20**.
vs v1.45.0 (72.0 / 47.7 / 88.5): R@5 flat, R@1 +1.0, R@20 −0.9 — PV13-reindex corpus churn, **0 dead golds**. No retrieval-scoring regression: the default (no-rerank) scoring path is byte-for-byte unchanged; the #1952 fix touches only the opt-in `--rerank` branch.

### Docs synced
README TL;DR + Retrieval Quality table, Cargo.toml description, GitHub repo description → v1.46.0 gate numbers. PRIVACY.md corrected: `--improve-docs` stages review patches under `.cqs/proposed-docs/` by default (`--apply` writes to source) — it had overstated the data-handling effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
