### PR TITLE
search: rerank pool selects by frame-neutral rank, not raw score

### DIFF
--- a/src/cli/commands/search/query.rs
+++ b/src/cli/commands/search/query.rs
@@ -988,16 +988,18 @@ pub(crate) fn apply_overlay(
 
     // Frame-correct merge. When a reranker is active the project leg
     // arrives in sigmoid frame `[0, 1]` (rescored by `retrieve_project`) while
-    // the overlay leg is raw cosine — incomparable in `merge_results`' raw
-    // `score` sort. The cross-encoder scores `(query, passage)` pairs, so it
-    // ranks both legs in one frame: merge the full pool (`merge_results` to the
-    // pre-rerank pool size, not yet truncated to `limit`), rerank the merged
-    // set, then truncate to `limit`. With no reranker the merge truncates to
-    // `limit` directly — the default cosine-family path is unchanged (byte-
-    // identical), and that recall-sensitive path keeps today's score sort.
+    // the overlay leg is raw cosine — incomparable in a raw `score` sort. The
+    // cross-encoder scores `(query, passage)` pairs, so it ranks both legs in
+    // one frame: build the candidate pool by frame-neutral within-leg rank (so a
+    // low-cosine / high-relevance overlay hit can't be truncated out of the pool
+    // by the mismatched score frame before the cross-encoder sees it), rerank
+    // the merged set, then truncate to `limit`. With no reranker the merge
+    // truncates to `limit` directly — the default cosine-family path is
+    // unchanged (byte-identical), and that recall-sensitive path keeps today's
+    // score sort.
     let merged = if let Some(reranker) = prepared.reranker.as_deref() {
         let pool_limit = crate::cli::limits::rerank_pool_size(args.limit);
-        let pool = reference::merge_results(masked, leg, pool_limit);
+        let pool = reference::merge_results_for_rerank(masked, leg, pool_limit);
         rerank_tagged(reranker, args.query.as_str(), pool, args.limit)?
     } else {
         reference::merge_results(masked, leg, args.limit)
@@ -1124,11 +1126,13 @@ pub(crate) fn merge_references(
 
     if let Some(reranker) = prepared.reranker.as_deref() {
         // Frame-correct: rerank the merged (project + reference) pool so the
-        // cross-encoder ranks both legs on one scale. Merge to the pre-rerank
-        // pool size (not yet truncated to `limit`) so the reranker sees the full
-        // candidate set, then truncate to `limit` in the rerank step.
+        // cross-encoder ranks both legs on one scale. Build the candidate pool by
+        // frame-neutral within-leg rank (not by the mismatched raw score) so a
+        // low-cosine / high-relevance reference hit can't be truncated out of the
+        // pool before the cross-encoder sees it, then truncate to `limit` in the
+        // rerank step.
         let pool_limit = crate::cli::limits::rerank_pool_size(args.limit);
-        let pool = reference::merge_results(project_results, ref_results, pool_limit);
+        let pool = reference::merge_results_for_rerank(project_results, ref_results, pool_limit);
         rerank_tagged(reranker, args.query.as_str(), pool, args.limit)
     } else {
         // No reranker: today's score-sort path, unchanged. The default
@@ -1969,6 +1973,44 @@ mod tests {
             (dir, ctx, emb)
         }
 
+        /// Variant of [`ctx_with_seeded_query`] whose reference chunk is stored at
+        /// a *low-cosine* embedding (`ref_cos` against the query), so the
+        /// reference fan-out retrieves `ref_target` with a low raw score. Used to
+        /// reproduce the large-`--limit` rerank-pool truncation: a low-cosine but
+        /// high-relevance reference hit must survive the pool the cross-encoder
+        /// rescores.
+        fn ctx_with_low_cosine_reference(
+            query: &str,
+            ref_cos: f32,
+        ) -> (TempDir, CountingCtx, Embedding) {
+            let dir = TempDir::new().expect("tempdir");
+            let mut qv = vec![0.0_f32; cqs::EMBEDDING_DIM];
+            qv[0] = 1.0;
+            let emb = Embedding::new(qv);
+
+            // A unit vector with `cos(query, ref) == ref_cos`: first component
+            // `ref_cos`, second component `sqrt(1 - ref_cos^2)`.
+            let mut rv = vec![0.0_f32; cqs::EMBEDDING_DIM];
+            rv[0] = ref_cos;
+            rv[1] = (1.0 - ref_cos * ref_cos).max(0.0).sqrt();
+            let ref_emb = Embedding::new(rv);
+
+            let embedder =
+                Embedder::new(cqs::embedder::ModelConfig::default_model()).expect("build embedder");
+            embedder.seed_query_cache(query, emb.clone());
+
+            let reference = Arc::new(seeded_reference(dir.path(), &ref_emb));
+            let ctx = CountingCtx {
+                store: open_store(dir.path()),
+                cqs_dir: dir.path().join(".cqs"),
+                root: dir.path().to_path_buf(),
+                embedder,
+                reference,
+                project_index_touched: Cell::new(false),
+            };
+            (dir, ctx, emb)
+        }
+
         /// PIN: a `--ref`-scoped `prepare_query(ProjectSurface::Skip)` resolves
         /// the embedding + filter but never touches the project vector index or
         /// the project SPLADE index — the prepared struct's project fields are
@@ -2206,6 +2248,64 @@ mod tests {
                 top.chunk.name, "ref_target",
                 "no reranker ⇒ raw-score sort is unchanged: the cosine ~1.0 \
                  reference hit outranks the 0.55 project hit"
+            );
+        }
+
+        // merge_references at `--limit >= 10`: the rerank pool cap (20) is at or
+        // below the project leg, so a low-cosine but high-relevance reference hit
+        // gets truncated out of the pool by the mismatched raw-score sort *before*
+        // the cross-encoder runs. The frame-neutral pool keeps each leg's top, so
+        // `ref_target` (rank-0 in its own leg) survives and the reranker — which
+        // judges it most relevant — promotes it to the reranked output.
+        //
+        // Fail-before (raw-score `merge_results` pool): the 20 high-sigmoid
+        // project hits fill the pool, `ref_target` (cosine ~0.2) is dropped, and
+        // it never appears in the output. Pass-after (`merge_results_for_rerank`):
+        // `ref_target` is in the pool and the stub reranker ranks it first.
+        #[test]
+        fn merge_references_large_limit_keeps_low_cosine_ref_in_rerank_pool() {
+            // Reference chunk at cosine ~0.2 to the query — low raw score, so the
+            // raw-score pool truncation would drop it behind the project leg.
+            let (_dir, ctx, emb) = ctx_with_low_cosine_reference("large limit rerank pool", 0.2);
+            let args = QueryArgs {
+                query: "large limit rerank pool".to_string(),
+                limit: 10, // rerank_pool_size(10) = min(40, 20) = 20
+                threshold: 0.0,
+                fts_first: false,
+                ..QueryArgs::default()
+            };
+
+            // 25 project hits in sigmoid frame, all well above the reference's
+            // ~0.2 cosine — enough to overflow the 20-candidate pool by raw score.
+            let project_results: Vec<UnifiedResult> = (0..25)
+                .map(|i| project_hit(&format!("project_{i:02}"), 0.95 - 0.001 * i as f32))
+                .collect();
+
+            // The cross-encoder judges the reference hit most relevant; the
+            // project distractors get the sentinel-low default (-1.0).
+            let reranker = stub_reranker(&[("ref_target", 0.99)]);
+            let prepared = prepared_for_refs(emb, reranker);
+            let references = ctx.references().expect("references");
+
+            let tagged = merge_references(&args, &prepared, project_results, &references)
+                .expect("merge_references");
+            let names: Vec<&str> = tagged
+                .iter()
+                .map(|t| {
+                    let UnifiedResult::Code(sr) = &t.result;
+                    sr.chunk.name.as_str()
+                })
+                .collect();
+            assert!(
+                names.contains(&"ref_target"),
+                "the low-cosine reference hit must survive the rerank pool at \
+                 --limit 10 and reach the reranked output; got {names:?}"
+            );
+            assert_eq!(
+                names.first().copied(),
+                Some("ref_target"),
+                "the cross-encoder's top hit must lead the reranked output; \
+                 got {names:?}"
             );
         }
     }
@@ -2500,6 +2600,66 @@ mod tests {
                 };
                 store
                     .upsert_chunks_batch(&[(chunk, one_hot(*slot))], Some(0))
+                    .expect("seed overlay chunk");
+            }
+
+            let masked_origins: HashSet<PathBuf> = masked.iter().map(PathBuf::from).collect();
+            WorktreeOverlay {
+                store,
+                masked_origins,
+                fingerprint: [0u8; 32],
+                worktree_root: PathBuf::from("/wt"),
+                stats: OverlayStats {
+                    files_in_delta: masked.len(),
+                    chunks_indexed: seeds.len(),
+                    build_ms: 0,
+                },
+            }
+        }
+
+        /// A unit embedding whose cosine with `one_hot(0)` is exactly `cos`
+        /// (first component `cos`, second `sqrt(1 - cos^2)`). Lets an overlay
+        /// chunk be seeded at a *low* cosine to the query so the fan-out
+        /// retrieves it with a low raw score.
+        fn low_cosine_emb(cos: f32) -> Embedding {
+            let mut v = vec![0.0_f32; cqs::EMBEDDING_DIM];
+            v[0] = cos;
+            v[1] = (1.0 - cos * cos).max(0.0).sqrt();
+            Embedding::new(v)
+        }
+
+        /// Like [`overlay_with`] but seeds each chunk with an explicit embedding
+        /// rather than `one_hot(slot)`, so a chunk can sit at an arbitrary cosine
+        /// to the query.
+        fn overlay_with_emb(seeds: &[(&str, &str, Embedding)], masked: &[&str]) -> WorktreeOverlay {
+            let mut store = Store::open_memory().expect("open_memory");
+            store
+                .init(&ModelInfo::default())
+                .expect("init overlay store");
+            store.set_dim(cqs::EMBEDDING_DIM);
+
+            for (file, name, emb) in seeds {
+                let chunk = Chunk {
+                    id: format!("{file}:{name}"),
+                    file: PathBuf::from(file),
+                    language: Language::Rust,
+                    chunk_type: ChunkType::Function,
+                    name: name.to_string(),
+                    signature: format!("fn {name}()"),
+                    content: format!("fn {name}() {{}}"),
+                    doc: None,
+                    line_start: 1,
+                    line_end: 2,
+                    byte_start: 0,
+                    content_hash: blake3::hash(name.as_bytes()).to_hex().to_string(),
+                    canonical_hash: String::new(),
+                    parent_id: None,
+                    window_idx: None,
+                    parent_type_name: None,
+                    parser_version: 0,
+                };
+                store
+                    .upsert_chunks_batch(&[(chunk, emb.clone())], Some(0))
                     .expect("seed overlay chunk");
             }
 
@@ -3095,6 +3255,64 @@ mod tests {
                 Some("shiny_distractor"),
                 "no reranker ⇒ raw-score sort is unchanged: the cosine ~1.0 \
                  overlay hit outranks the 0.55 project hit; got {got:?}"
+            );
+        }
+
+        // ── apply_overlay at `--limit >= 10`: the rerank pool cap (20) is at or
+        //    below the project leg, so a low-cosine but high-rerank-relevance
+        //    overlay hit gets truncated out of the pool by the mismatched
+        //    raw-score sort *before* the cross-encoder runs. The frame-neutral
+        //    pool keeps each leg's top, so `overlay_target` (rank-0 in its own
+        //    leg) survives and the reranker — which judges it most relevant —
+        //    promotes it to the reranked output. Mirrors the reference-leg
+        //    `merge_references_large_limit_keeps_low_cosine_ref_in_rerank_pool`
+        //    so BOTH legs of the dual-surface bug are pinned at the large-limit
+        //    shape.
+        //
+        //    Fail-before (raw-score `merge_results` pool): the 20 high-sigmoid
+        //    project hits fill the pool, `overlay_target` (cosine ~0.2) is
+        //    dropped, and it never appears in the output. Pass-after
+        //    (`merge_results_for_rerank`): it is in the pool and the stub
+        //    reranker ranks it first.
+        #[test]
+        fn overlay_large_limit_keeps_low_cosine_overlay_hit_in_rerank_pool() {
+            cqs::worktree_overlay::clear_overlay_meta();
+            // Overlay chunk at cosine ~0.2 to the query — low raw score, so the
+            // raw-score pool truncation would drop it behind the project leg.
+            let overlay = overlay_with_emb(
+                &[("src/edited.rs", "overlay_target", low_cosine_emb(0.2))],
+                &["src/edited.rs"],
+            );
+            // 25 project hits in sigmoid frame, all well above the overlay's
+            // ~0.2 cosine — enough to overflow the 20-candidate pool by raw score.
+            // Each on a distinct unmasked origin so the mask keeps them all.
+            let project: Vec<UnifiedResult> = (0..25)
+                .map(|i| {
+                    UnifiedResult::Code(project_result(
+                        &format!("src/p{i:02}.rs"),
+                        &format!("project_{i:02}"),
+                        0.95 - 0.001 * i as f32,
+                    ))
+                })
+                .collect();
+            // The cross-encoder judges the overlay hit most relevant; the project
+            // distractors get the sentinel-low default (-1.0).
+            let reranker = stub_reranker(&[("overlay_target", 0.99)]);
+            // Query at slot 0 so `low_cosine_emb(0.2)` retrieves `overlay_target`.
+            let prepared = prepared_with_reranker(one_hot(0), reranker);
+
+            let out = apply_overlay(&args_limit(10), &prepared, project, &overlay).unwrap();
+            let got = names(&out);
+            assert!(
+                got.contains(&"overlay_target".to_string()),
+                "the low-cosine overlay hit must survive the rerank pool at \
+                 --limit 10 and reach the reranked output; got {got:?}"
+            );
+            assert_eq!(
+                got.first().map(String::as_str),
+                Some("overlay_target"),
+                "the cross-encoder's top hit must lead the reranked output; \
+                 got {got:?}"
             );
         }
     }

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -452,6 +452,100 @@ pub fn merge_results(
     tagged
 }
 
+/// Build a rerank candidate pool from primary + reference legs, selecting
+/// survivors by a **frame-neutral** key (each candidate's rank within its own
+/// leg) rather than by the raw `score`.
+///
+/// This is the pool feeder for the merged-set cross-encoder rerank only — the
+/// reranker rescores every survivor onto one comparable scale afterward, so the
+/// order this function emits is irrelevant; only *which* candidates survive the
+/// `pool_limit` truncation matters. The plain (no-rerank) merge stays on
+/// [`merge_results`]' raw-`score` sort, untouched.
+///
+/// Why frame-neutral selection: the primary leg arrives in the project's score
+/// frame (sigmoid `[0, 1]` once the project pool was reranked) while the
+/// reference legs carry weighted cosine. A raw-`score` truncation across those
+/// incomparable frames can drop a low-cosine / high-relevance reference or
+/// overlay hit — exactly the candidate the reranker exists to surface — before
+/// the cross-encoder ever scores it, and the bite worsens as `limit` grows past
+/// the pool cap. Selecting by within-leg rank keeps the top of *each* leg in the
+/// pool regardless of frame, so the reranker sees the full candidate set.
+///
+/// Legs are interleaved by rank (every leg's rank-0, then every leg's rank-1, …)
+/// so a leg with few hits never crowds out the others. Dedup by content hash
+/// happens during the interleave, matching [`merge_results`]' content-hash
+/// dedup, so identical content across stores occupies a single pool slot: the
+/// first candidate reached in the round-robin survives, which — because the
+/// interleave visits lower ranks first and each leg is sorted within itself — is
+/// the higher-ranked copy.
+pub fn merge_results_for_rerank(
+    primary: Vec<UnifiedResult>,
+    refs: Vec<(String, Vec<SearchResult>)>,
+    pool_limit: usize,
+) -> Vec<TaggedResult> {
+    // Build per-leg candidate queues, preserving each leg's own (already-sorted)
+    // order — that order *is* the frame-neutral rank. `VecDeque` lets the
+    // round-robin pop from the front without shifting the tail.
+    let mut legs: Vec<std::collections::VecDeque<TaggedResult>> =
+        Vec::with_capacity(1 + refs.len());
+
+    legs.push(
+        primary
+            .into_iter()
+            .map(|result| TaggedResult {
+                result,
+                source: None,
+            })
+            .collect(),
+    );
+
+    for (name, results) in refs {
+        legs.push(
+            results
+                .into_iter()
+                .map(|r| TaggedResult {
+                    result: UnifiedResult::Code(r),
+                    source: Some(name.clone()),
+                })
+                .collect(),
+        );
+    }
+
+    // Round-robin interleave by within-leg rank: take rank-0 from every leg,
+    // then rank-1 from every leg, and so on. Dedup by content hash as we go so
+    // an identical chunk from a lower-ranked leg can't displace a distinct
+    // candidate later. Truncation by `pool_limit` then keeps the top of each leg
+    // rather than letting one frame's scores dominate the cut.
+    let mut pool: Vec<TaggedResult> = Vec::new();
+    let mut seen_hashes = std::collections::HashSet::new();
+
+    'outer: while legs.iter().any(|leg| !leg.is_empty()) {
+        for leg in legs.iter_mut() {
+            let Some(candidate) = leg.pop_front() else {
+                continue;
+            };
+            let fresh = match &candidate.result {
+                UnifiedResult::Code(r) => {
+                    if r.chunk.content_hash.is_empty() {
+                        let hash = blake3::hash(r.chunk.content.as_bytes()).to_string();
+                        seen_hashes.insert(hash)
+                    } else {
+                        seen_hashes.insert(r.chunk.content_hash.clone())
+                    }
+                }
+            };
+            if fresh {
+                pool.push(candidate);
+                if pool.len() >= pool_limit {
+                    break 'outer;
+                }
+            }
+        }
+    }
+
+    pool
+}
+
 /// Default storage directory for reference indexes
 pub fn refs_dir() -> Option<std::path::PathBuf> {
     let dir = dirs::data_local_dir();
@@ -706,6 +800,81 @@ mod tests {
         // Kept the highest-scoring one (primary, 0.9)
         assert!(merged[0].source.is_none());
         assert!((merged[0].result.score() - 0.9).abs() < 0.01);
+    }
+
+    // A high-relevance reference hit whose raw cosine is low (the frame-mismatch
+    // case the merged-set rerank exists to recover) must survive into the rerank
+    // pool at `--limit >= 10`, where the pool cap (20) is at or below the project
+    // leg's over-fetch, so the cross-encoder can rescore it. The raw-
+    // score merge (`merge_results`) sorts the project leg's high cosines to the
+    // top and truncates the low-cosine target out before the reranker can see
+    // it; the frame-neutral pool (`merge_results_for_rerank`) keeps the top of
+    // each leg, so the target survives. Calibrated RED against `merge_results`,
+    // GREEN against `merge_results_for_rerank`.
+    #[test]
+    fn test_rerank_pool_keeps_low_cosine_ref_at_large_limit() {
+        // limit 10 -> rerank_pool_size = min(40, 20) = 20.
+        let pool_limit = 20;
+
+        // Project leg: 25 high-cosine hits (over-fetched well past the pool cap).
+        // All score above the reference target's raw cosine.
+        let primary: Vec<UnifiedResult> = (0..25)
+            .map(|i| {
+                UnifiedResult::Code(make_code_result(
+                    &format!("project_{i:02}"),
+                    0.95 - 0.001 * i as f32,
+                ))
+            })
+            .collect();
+
+        // Reference leg: one low-raw-cosine but high-relevance target (rank-0 in
+        // its own frame).
+        let refs = vec![(
+            "refstore".to_string(),
+            vec![make_code_result("ref_target", 0.10)],
+        )];
+
+        // Old raw-score path: the 20 highest cosines are all project hits, so the
+        // 0.10 reference target is truncated out of the pool.
+        let old_pool = merge_results(primary.clone(), refs.clone(), pool_limit);
+        assert_eq!(old_pool.len(), pool_limit);
+        assert!(
+            !old_pool.iter().any(|t| t.result.id() == "id-ref_target"),
+            "raw-score truncation drops the low-cosine reference target before rerank"
+        );
+
+        // New frame-neutral path: the reference leg's rank-0 candidate is
+        // interleaved into the pool and survives the truncation.
+        let new_pool = merge_results_for_rerank(primary, refs, pool_limit);
+        assert_eq!(new_pool.len(), pool_limit);
+        let target = new_pool
+            .iter()
+            .find(|t| t.result.id() == "id-ref_target")
+            .expect("frame-neutral pool must keep the low-cosine reference target");
+        assert_eq!(target.source.as_deref(), Some("refstore"));
+    }
+
+    // `merge_results_for_rerank` must still dedup identical content across legs:
+    // a chunk present in both the project and a reference occupies one pool slot,
+    // keeping the project (first-seen, higher within-leg rank) copy.
+    #[test]
+    fn test_rerank_pool_dedups_across_legs() {
+        let primary = vec![UnifiedResult::Code(make_code_result("shared", 0.9))];
+        let refs = vec![(
+            "refstore".to_string(),
+            vec![make_code_result("shared", 0.8)], // identical content
+        )];
+
+        let pool = merge_results_for_rerank(primary, refs, 20);
+        assert_eq!(
+            pool.len(),
+            1,
+            "identical content occupies a single pool slot"
+        );
+        assert!(
+            pool[0].source.is_none(),
+            "the project (first-seen) copy survives dedup"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## search: rerank pool selects by frame-neutral rank, not raw score

Closes #1975.

Low-severity follow-up to #1952/#1974. The merged-set rerank reranks the candidate pool, but the **pool itself was truncated by the raw, frame-mismatched score before the cross-encoder saw it**. With `rerank_pool_size(limit) = min(4·limit, 20)` and the project leg arriving at `2·limit`, at **`--limit ≥ 10`** the pool cap (20) ≤ `2·limit`, so a low-cosine / high-relevance overlay or reference hit — exactly the #1952 case — could be dropped *before* rerank. Bounded: only bites `--limit ≥ 10` **with** opt-in `--rerank`; the default path never reranked the merged set.

### Fix (option B — root cause, not a band-aid)
New `merge_results_for_rerank` (`src/reference.rs`) selects pool survivors by **within-leg rank, round-robin across legs** (keep rank-0 of every leg, then rank-1, …) instead of by raw score — so the top of every leg survives the `pool_limit` cut regardless of its score frame. Same cross-leg content-hash dedup as `merge_results`. Both rerank legs route through it: `apply_overlay` (overlay) and `merge_references` (reference) in `src/cli/commands/search/query.rs`.

### Invariants held
- **Default no-rerank path byte-for-byte unchanged** — the `else` branches still call `merge_results` with its raw-score sort; the new function is invoked only inside the `Some(reranker)` branches. The two no-reranker guard tests pass unchanged.
- **Dual-surface complete** — both overlay and reference legs fixed (the single-leg `retrieve_ref_scoped` correctly stays out: one leg, no frame to mismatch).

### Tests (RED-before / GREEN-after, verified by reverting the call sites)
- `reference::tests::test_rerank_pool_keeps_low_cosine_ref_at_large_limit` — unit, self-proving (old `merge_results` drops the target; new fn keeps it).
- `merge_references_large_limit_keeps_low_cosine_ref_in_rerank_pool` — reference leg, end-to-end.
- `overlay_large_limit_keeps_low_cosine_overlay_hit_in_rerank_pool` — overlay leg, end-to-end (added so both legs are pinned at the large-limit shape).
- Cross-leg dedup pinned by `test_rerank_pool_dedups_across_legs`.

Reviewed (opus code-reviewer): LOW risk, APPROVE. clippy `--all-targets -D warnings` clean, fmt clean, provenance clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
