### PR TITLE
chore(serve): drop dead AuthChannel::name()

### DIFF
--- a/src/serve/auth.rs
+++ b/src/serve/auth.rs
@@ -325,14 +325,6 @@ enum ChannelOutcome {
 /// Priority is (header > cookie > query), documented at the channel array's
 /// construction site, not implicit in the trait.
 trait AuthChannel {
-    /// Stable short name. Used only for tracing; an observability follow-up
-    /// could log the matched channel here.
-    #[allow(
-        dead_code,
-        reason = "reserved for the audit-logging follow-up flagged in #1218"
-    )]
-    fn name(&self) -> &'static str;
-
     /// Inspect the request for this channel's credential and compare
     /// constant-time against `expected`. Returns
     /// [`ChannelOutcome::Authenticated`] / `Mismatch` / `NotPresent`.
@@ -362,10 +354,6 @@ trait AuthChannel {
 struct BearerHeaderChannel;
 
 impl AuthChannel for BearerHeaderChannel {
-    fn name(&self) -> &'static str {
-        "bearer"
-    }
-
     fn check(&self, req: &Request, expected: &AuthToken) -> ChannelOutcome {
         let bearer = req
             .headers()
@@ -401,10 +389,6 @@ struct CookieChannel<'a> {
 }
 
 impl AuthChannel for CookieChannel<'_> {
-    fn name(&self) -> &'static str {
-        "cookie"
-    }
-
     fn check(&self, req: &Request, expected: &AuthToken) -> ChannelOutcome {
         let cookie_header = req
             .headers()
@@ -441,10 +425,6 @@ impl AuthChannel for CookieChannel<'_> {
 struct QueryParamChannel;
 
 impl AuthChannel for QueryParamChannel {
-    fn name(&self) -> &'static str {
-        "query"
-    }
-
     fn check(&self, req: &Request, expected: &AuthToken) -> ChannelOutcome {
         let Some(query) = req.uri().query() else {
             return ChannelOutcome::NotPresent;


### PR DESCRIPTION
## chore(serve): drop dead `AuthChannel::name()`

`AuthChannel::name()` had **zero call sites** — kept alive only by an `#[allow(dead_code)]` whose `reason` cited a **closed** issue (which was the auth-channel trait refactor itself, not the claimed "audit-logging follow-up"). Per the no-deferred-debt / delete-dead-code-immediately policy, removed the trait declaration + its three impls (`bearer` / `cookie` / `query`) rather than carry a dead method propped up by a stale reference.

- 401 telemetry is unchanged — it uses `unauthorized_reason()`, not `name()`.
- If channel-name logging is ever wanted, re-adding a const-returning method is trivial.

Surfaced by an `/archeo` comment-archaeology sweep (whose only actionable yield this pass — the rest of ~317 deferral-language hits were legitimately explanatory). clippy `--all-targets -D warnings` clean, fmt clean, provenance clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
