### PR TITLE
ci(release): pre-tag cross-build dry-run via workflow_dispatch

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -63,6 +63,13 @@ Release a new version of cqs.
      powershell.exe -Command 'cd C:\Projects\cqs; gh run list --branch release/vX.Y.Z --workflow CI --limit 1'
      powershell.exe -Command 'cd C:\Projects\cqs; gh run watch RUN_ID --exit-status'
      ```
+   - **Pre-tag cross-build dry-run (REQUIRED — catches macOS/Windows breaks the Linux-only PR CI can't see).** The `v*` tag is the only thing that builds all three release targets, so a platform-specific break (e.g. the v1.46.0 `aarch64-apple-darwin` E0277) is otherwise invisible until you've already tagged and published the crate. Trigger release.yml on the release branch as a build-only dry-run (it skips the "Create GitHub Release" job, which is gated on a tag ref) and confirm all three Build jobs pass BEFORE tagging:
+     ```
+     powershell.exe -Command 'cd C:\Projects\cqs; gh workflow run release.yml --ref release/vX.Y.Z'
+     sleep 45
+     powershell.exe -Command 'cd C:\Projects\cqs; gh run list --workflow release.yml --limit 1 --json databaseId,headBranch'
+     # poll `gh run view <id> --json status,conclusion,jobs`; every Build job must be green before you tag
+     ```
 
 7. **After PR merge**:
    - Sync main: `git checkout main && git pull`, then `cqs index` (watch misses bulk git ops on WSL)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release
 on:
   push:
     tags: ['v*']
+  # Manual cross-build dry-run: trigger on a release/* branch BEFORE tagging to
+  # validate all three targets — notably aarch64-apple-darwin, which PR CI
+  # never builds, so a platform-specific break is invisible until the tag (the
+  # v1.46.0 darwin failure). Builds + uploads artifacts but does NOT publish a
+  # release (that job is gated on a tag ref below).
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -44,7 +50,10 @@ jobs:
       - name: Package archive
         shell: bash
         run: |
-          VERSION="${GITHUB_REF_NAME}"
+          # Sanitize: on a workflow_dispatch dry-run GITHUB_REF_NAME is a branch
+          # (e.g. release/v1.2.3) whose '/' would break archive filenames; on a
+          # tag it is already slash-free, so this is a no-op for real releases.
+          VERSION="${GITHUB_REF_NAME//\//-}"
           STAGING="cqs-${VERSION}-${{ matrix.target }}"
           mkdir -p "${STAGING}"
 
@@ -77,6 +86,9 @@ jobs:
   release:
     name: Create GitHub Release
     needs: build
+    # Only a tag push publishes a release; a workflow_dispatch dry-run stops
+    # after the cross-build (validation only).
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## ci(release): pre-tag cross-build dry-run via `workflow_dispatch`

PR CI builds **Linux only**; `release.yml` cross-builds macOS + Windows **only on a `v*` tag**, and the "Create GitHub Release" job needs all three green. So a platform-specific break is invisible until *after* the tag is pushed and the crate published — exactly how **v1.46.0 shipped a mac-uncompilable crate with no release binaries** (the `aarch64-apple-darwin` E0277), forcing the v1.46.1 patch.

### Change
Add a `workflow_dispatch` trigger so the full three-target cross-build can run on a `release/*` branch **before** tagging:
- The **build** job runs on both tag-push and dispatch. `VERSION` is sanitized (`${GITHUB_REF_NAME//\//-}`) so a branch ref like `release/v1.2.3` doesn't break archive filenames — a no-op for tags.
- The **Create GitHub Release** job is now gated `if: startsWith(github.ref, 'refs/tags/')` — a dispatch dry-run validates + uploads artifacts but does **not** publish a release.

The tag-push auto-release path is unchanged (releases still happen only on `v*` tags). The `/release` skill now documents the required pre-tag dry-run:
```
gh workflow run release.yml --ref release/vX.Y.Z   # confirm all 3 Build jobs green before tagging
```

YAML validated. This closes the process gap that the sweep-auditor's source-level guard only partially covered — the dry-run is the real cross-compile, catching *any* platform break, not just the E0277 shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
