### PR TITLE
perf: cut per-call allocations on three hot paths (audit PERF-1/2/3)

### DIFF
--- a/src/embedder/core.rs
+++ b/src/embedder/core.rs
@@ -1003,12 +1003,14 @@ impl Embedder {
         }
 
         // Tokenize (lazy init tokenizer).
-        // `encode_batch` requires `Vec<EncodeInput>` (owned), so `texts.to_vec()` is
-        // unavoidable — the tokenizer API does not accept `&[impl AsRef<str>]`.
+        // `encode_batch` takes `Vec<E>` where `E: Into<EncodeInput<'s>>`, and
+        // `&str` satisfies that bound (`InputSequence: From<&'s str>`), so we
+        // borrow each string rather than deep-cloning the whole batch.
         let encodings = {
             let _tokenize = tracing::debug_span!("tokenize").entered();
+            let inputs: Vec<&str> = texts.iter().map(String::as_str).collect();
             self.tokenizer()?
-                .encode_batch(texts.to_vec(), true)
+                .encode_batch(inputs, true)
                 .map_err(|e| EmbedderError::Tokenizer(e.to_string()))?
         };
 

--- a/src/splade/mod.rs
+++ b/src/splade/mod.rs
@@ -453,8 +453,17 @@ impl SpladeEncoder {
         let session = create_session(&onnx_path, provider)
             .map_err(|e| SpladeError::InferenceFailed(format!("ORT session: {e}")))?;
 
-        let tokenizer = tokenizers::Tokenizer::from_file(&tokenizer_path)
+        let mut tokenizer = tokenizers::Tokenizer::from_file(&tokenizer_path)
             .map_err(|e| SpladeError::TokenizationFailed(e.to_string()))?;
+        // Disable tokenizer-level padding. `encode_batch` would otherwise apply
+        // this model's `BatchLongest` strategy and pad every input up to the
+        // batch's longest sequence, changing the input_ids/mask layout fed to
+        // ORT versus the single-input `encode` path (which, batching one item,
+        // never pads). The encode loops here do their own constant `max_seq_len`
+        // padding downstream, so tokenizer padding is both redundant and
+        // behavior-altering — without this, batched and serial encodes of the
+        // same text produce different sparse vectors.
+        tokenizer.with_padding(None);
 
         let tokenizer_vocab = tokenizer.get_vocab_size(true);
 
@@ -564,10 +573,13 @@ impl SpladeEncoder {
         }
         // Rare path — only after `clear_session` has dropped the tokenizer.
         let _span = tracing::info_span!("splade_tokenizer_reload").entered();
-        let loaded = std::sync::Arc::new(
-            tokenizers::Tokenizer::from_file(&self.tokenizer_path)
-                .map_err(|e| SpladeError::TokenizationFailed(e.to_string()))?,
-        );
+        let mut reloaded = tokenizers::Tokenizer::from_file(&self.tokenizer_path)
+            .map_err(|e| SpladeError::TokenizationFailed(e.to_string()))?;
+        // Match `new`: disable tokenizer-level padding so `encode_batch` returns
+        // natural-length encodings (the downstream loops pad to a constant
+        // `max_seq_len` themselves). Keeps batched and serial encodes identical.
+        reloaded.with_padding(None);
+        let loaded = std::sync::Arc::new(reloaded);
         let mut guard = self.tokenizer.lock().unwrap_or_else(|p| p.into_inner());
         if let Some(existing) = guard.as_ref() {
             return Ok(std::sync::Arc::clone(existing));
@@ -796,16 +808,17 @@ impl SpladeEncoder {
         }
         let non_empty_texts: Vec<&str> = non_empty_indices.iter().map(|&i| truncated[i]).collect();
 
-        // Step 2: tokenize each non-empty input.
+        // Step 2: tokenize all non-empty inputs in one batch — the tokenizer
+        // parallelizes the batch internally (rayon), so this beats a serial
+        // per-input encode loop. The tokenizer has padding disabled at load
+        // (see `new`/the reload path), so each encoding keeps its natural
+        // length — identical to what the single-input `encode` path produces,
+        // and the constant `max_seq_len` padding below stays the only padding.
+        // Map the single batch-level Result to SpladeError once.
         let tokenizer = self.tokenizer()?;
-        let encodings: Vec<_> = non_empty_texts
-            .iter()
-            .map(|t| {
-                tokenizer
-                    .encode(*t, true)
-                    .map_err(|e| SpladeError::TokenizationFailed(e.to_string()))
-            })
-            .collect::<Result<_, _>>()?;
+        let encodings = tokenizer
+            .encode_batch(non_empty_texts, true)
+            .map_err(|e| SpladeError::TokenizationFailed(e.to_string()))?;
 
         let batch_size = encodings.len();
 

--- a/src/store/calls/cross_project.rs
+++ b/src/store/calls/cross_project.rs
@@ -333,6 +333,9 @@ impl CrossProjectContext {
         self.ensure_all_graphs()?;
 
         let mut all_callers = Vec::new();
+        // Intern the loop-invariant callee once (not once per edge) so the
+        // per-edge lookup below pays only Arc refcount bumps, no string alloc.
+        let callee_key: std::sync::Arc<str> = std::sync::Arc::from(callee_name);
         for (idx, ns) in self.stores.iter().enumerate() {
             let graph = &self.graphs[&idx];
             if let Some(callers) = graph.reverse.get(callee_name) {
@@ -342,7 +345,7 @@ impl CrossProjectContext {
                     // recorded at graph load — threaded through the in-memory
                     // CallGraph so cross-project callers carry the same
                     // edge_kind/file/line the single-project SQL path does.
-                    let meta = graph.edge_meta(caller_name, callee_name);
+                    let meta = graph.edge_meta_arc(caller_arc, &callee_key);
                     tracing::debug!(
                         project = %ns.name,
                         caller = caller_name,
@@ -383,6 +386,9 @@ impl CrossProjectContext {
         self.ensure_all_graphs()?;
 
         let mut all_callees = Vec::new();
+        // Intern the loop-invariant caller once (not once per edge) so the
+        // per-edge lookup below pays only Arc refcount bumps, no string alloc.
+        let caller_key: std::sync::Arc<str> = std::sync::Arc::from(caller_name);
         for (idx, ns) in self.stores.iter().enumerate() {
             let graph = &self.graphs[&idx];
             if let Some(callees) = graph.forward.get(caller_name) {
@@ -391,7 +397,7 @@ impl CrossProjectContext {
                     // Edge provenance + call-site line from the in-memory graph;
                     // `line` is the call_line (where the call occurs), matching
                     // the single-project `get_callees_full` semantics.
-                    let meta = graph.edge_meta(caller_name, callee_name);
+                    let meta = graph.edge_meta_arc(&caller_key, callee_arc);
                     tracing::debug!(
                         project = %ns.name,
                         caller = caller_name,

--- a/src/store/helpers/types.rs
+++ b/src/store/helpers/types.rs
@@ -571,6 +571,20 @@ impl CallGraph {
             .cloned()
             .unwrap_or_else(CallEdgeMeta::default_call)
     }
+
+    /// `edge_meta` for callers that already hold the interned [`Arc<str>`]
+    /// adjacency-list entries (the cross-project caller/callee render loops).
+    ///
+    /// Builds the lookup key with two [`Arc::clone`]s (refcount bumps) instead
+    /// of the `&str` path's two `Arc::from` calls (each a fresh heap allocation
+    /// of the string + control block), so the per-edge render loop pays no
+    /// string allocation per lookup.
+    pub fn edge_meta_arc(&self, caller: &Arc<str>, callee: &Arc<str>) -> CallEdgeMeta {
+        self.edges
+            .get(&(Arc::clone(caller), Arc::clone(callee)))
+            .cloned()
+            .unwrap_or_else(CallEdgeMeta::default_call)
+    }
 }
 
 /// Chunk identity for diff comparison


### PR DESCRIPTION
## perf: cut per-call allocations on three hot paths (audit PERF-V1.46.1-1/2/3)

- **PERF-1 `embedder/core.rs`** — `embed_batch` borrows each chunk (`Vec<&str>`) into `encode_batch` instead of a per-batch deep `texts.to_vec()` clone. EmbeddingGemma's tokenizer has `padding: None`, so output is bit-identical — pure allocation win. (Removed the false "unavoidable" comment.)
- **PERF-2 `splade/mod.rs`** — replace the serial per-input `encode` loop with the tokenizer's internally-parallel `encode_batch` (rayon). **⚠️ Behavior-relevant detail:** SPLADE's `tokenizer.json` ships `padding: BatchLongest`, so a naive `encode_batch` would pad to the batch's longest sequence and shift the input layout vs the single-`encode` path (a ranking regression). Fixed by disabling the redundant tokenizer-level padding (`with_padding(None)`) at both load points — the encode loops already pad to a constant `max_seq_len` downstream, so the model input is unchanged. **Behavior-preserving by construction** (downstream padding dominates) and the `encode_batch`-vs-serial parity test passes.
- **PERF-3 `store/helpers/types.rs` + `cross_project.rs`** — add an `Arc`-keyed `edge_meta_arc` (refcount bumps, no string alloc) and hoist the loop-invariant key out of the cross-project render loops.

Gates: clippy `--all-targets -D warnings` clean, fmt clean; targeted suites green (splade 44, embedder 118 + 8 integration, store::calls 48, cross_project 22, search_test 21).

PERF-2 touches the SPLADE encode path (part of hybrid ranking) — behavior-preserving per the above + parity-tested, but flagging for visibility; a recall gate is available if you want belt-and-suspenders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
