### PR TITLE
fix(audit): five mechanical + test-coverage fixes (v1.46.1)

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -94,12 +94,12 @@ pub(crate) struct LimitArg {
     pub limit: usize,
 }
 
-/// The worktree-overlay tri-state flags, flattened into the commands whose SEED
-/// retrieval the overlay shadows (Part A): `scout`, `gather`, `task`. The
-/// `search` command carries the same three flags inline ([`SearchArgs`]); this
-/// is the shared subset for the seed-overlaid graph-adjacent commands. Each
-/// resolves activation through the same `resolve_overlay_active` precedence the
-/// search surface uses, so no two surfaces can diverge.
+/// The worktree-overlay tri-state flags, flattened into every command whose
+/// retrieval the overlay shadows: `search` (whole-result overlay) and the
+/// seed-overlaid graph-adjacent commands `scout`, `gather`, `task` (Part A).
+/// Each resolves activation through the same `resolve_overlay_active`
+/// precedence, so no two surfaces can diverge — `search` now flattens this
+/// shared struct rather than duplicating the three fields inline.
 #[derive(Args, Debug, Clone, Default)]
 pub(crate) struct OverlayArgs {
     /// Overlay the worktree's uncommitted/committed delta on top of the parent
@@ -254,34 +254,11 @@ pub(crate) struct SearchArgs {
     #[arg(long)]
     pub no_rank_signals: bool,
 
-    /// Overlay the worktree's uncommitted/committed delta on top of the parent
-    /// index so results reflect this checkout's edits, not main's. Default-on
-    /// when run from a worktree; off in the main checkout. Tri-state env
-    /// `CQS_WORKTREE_OVERLAY`: `1` forces on, `0` forces off, unset = default.
-    /// `--overlay` forces on; `--no-overlay` forces off (opt-out wins). Phase 1
-    /// builds overlays on the daemon path only — a CLI-direct search (no daemon)
-    /// serves the parent index with a `_meta.worktree_overlay =
-    /// "skipped-no-daemon"` marker. Requires `--json` to forward to the daemon.
-    #[arg(long, conflicts_with = "no_overlay")]
-    pub overlay: bool,
-
-    /// Opt out of the worktree search overlay even when run from a worktree
-    /// (where it is default-on). The explicit-off counterpart of
-    /// `--overlay`; equivalent to `CQS_WORKTREE_OVERLAY=0`. Opt-out wins over
-    /// every opt-in signal.
-    #[arg(long, conflicts_with = "overlay")]
-    pub no_overlay: bool,
-
-    /// Wire-only: the absolute worktree root to build the overlay for. Hidden
-    /// from `--help` — it is computed by the CLI (`cqs::worktree::overlay_root`)
-    /// and appended to the daemon-forwarded args, never set by a human. The
-    /// daemon's cwd is the parent project and the wire request carries no cwd,
-    /// so the client must say which worktree. The daemon VALIDATES it
-    /// (canonicalize + `resolve_main_project_dir == served root`) before reading
-    /// any of its files — an unvalidated value would be an arbitrary-directory
-    /// read primitive over the socket.
-    #[arg(long, hide = true)]
-    pub overlay_root: Option<std::path::PathBuf>,
+    /// Shared worktree-overlay tri-state (`--overlay` / `--no-overlay` /
+    /// hidden `--overlay-root`) via [`OverlayArgs`] flatten — the same struct
+    /// the seed-overlaid graph commands carry, so the surfaces can't diverge.
+    #[command(flatten)]
+    pub overlay: OverlayArgs,
 }
 
 impl SearchArgs {

--- a/src/cli/batch/commands.rs
+++ b/src/cli/batch/commands.rs
@@ -660,8 +660,8 @@ mod tests {
         let off = BatchInput::try_parse_from(["search", "hello", "--no-overlay"]).unwrap();
         match off.cmd {
             BatchCmd::Search { ref args, .. } => {
-                assert!(args.no_overlay, "--no-overlay sets the flag");
-                assert!(!args.overlay);
+                assert!(args.overlay.no_overlay, "--no-overlay sets the flag");
+                assert!(!args.overlay.overlay);
             }
             _ => panic!("Expected Search command"),
         }

--- a/src/cli/batch/handlers/search.rs
+++ b/src/cli/batch/handlers/search.rs
@@ -84,9 +84,9 @@ fn prepare_overlay_request(ctx: &BatchView, args: &SearchArgs) -> Result<()> {
     // `--overlay-root` validation.
     super::prepare_overlay_request_fields(
         ctx,
-        args.overlay,
-        args.no_overlay,
-        args.overlay_root.as_deref(),
+        args.overlay.overlay,
+        args.overlay.no_overlay,
+        args.overlay.overlay_root.as_deref(),
     )
 }
 
@@ -160,8 +160,8 @@ fn daemon_query_args(args: &SearchArgs) -> QueryArgs {
 /// `--overlay` / `CQS_WORKTREE_OVERLAY=1` opt-in, else off.
 fn daemon_overlay_active(args: &SearchArgs) -> bool {
     crate::cli::commands::search::query::resolve_overlay_active(
-        args.overlay,
-        args.no_overlay,
+        args.overlay.overlay,
+        args.overlay.no_overlay,
         false,
     )
 }

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -1705,8 +1705,13 @@ mod tests {
             prop_assert_eq!(sa.no_stale_check, cli.no_stale_check, "no_stale_check: argv={:?}", argv);
             prop_assert_eq!(sa.no_demote, cli.no_demote, "no_demote: argv={:?}", argv);
             prop_assert_eq!(sa.no_rank_signals, cli.no_rank_signals, "no_rank_signals: argv={:?}", argv);
-            prop_assert_eq!(sa.overlay, cli.overlay, "overlay: argv={:?}", argv);
-            prop_assert_eq!(sa.no_overlay, cli.no_overlay, "no_overlay: argv={:?}", argv);
+            prop_assert_eq!(sa.overlay.overlay, cli.overlay, "overlay: argv={:?}", argv);
+            prop_assert_eq!(
+                sa.overlay.no_overlay,
+                cli.no_overlay,
+                "no_overlay: argv={:?}",
+                argv
+            );
         }
     }
 }

--- a/src/parser/calls.rs
+++ b/src/parser/calls.rs
@@ -1282,6 +1282,7 @@ impl Parser {
         let source = match std::fs::read_to_string(path) {
             Ok(s) => s,
             Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {
+                tracing::warn!(path = %path.display(), "Skipping non-UTF8 file");
                 return Ok((vec![], vec![], vec![]));
             }
             Err(e) => return Err(e.into()),

--- a/src/parser/chunk.rs
+++ b/src/parser/chunk.rs
@@ -1274,6 +1274,103 @@ CREATE TABLE IF NOT EXISTS late (
         }
 
         #[test]
+        fn dart_body_comment_does_not_change_canonical_hash() {
+            // Exercises the Dart body-inclusive path: the tree-sitter-dart
+            // grammar inlines the top-level-definition rule, so a Dart function's
+            // `function_signature` (the captured chunk node) and its
+            // `function_body` are ADJACENT SIBLINGS. `extract_chunk` extends the
+            // chunk span over the body and passes the body as the `extra` arg to
+            // `canonical_hash_spanning`, so a comment living INSIDE the body must
+            // be stripped from the canonical hash. Parsing through `Parser`
+            // (rather than calling the helper directly) is what feeds the real
+            // body node into that `extra` argument.
+            let a = canon_of(
+                "int square(int x) {\n  return x * x;\n}\n",
+                "dart",
+                "square",
+            );
+            // `//` line comment inside the body.
+            let b = canon_of(
+                "int square(int x) {\n  // square the argument\n  return x * x;\n}\n",
+                "dart",
+                "square",
+            );
+            assert_eq!(
+                a, b,
+                "a //-comment-only edit inside a Dart fn body must not change canonical_hash"
+            );
+            // `/* */` block comment inside the body.
+            let c = canon_of(
+                "int square(int x) {\n  /* square the argument */\n  return x * x;\n}\n",
+                "dart",
+                "square",
+            );
+            assert_eq!(
+                a, c,
+                "a /* */-comment-only edit inside a Dart fn body must not change canonical_hash"
+            );
+        }
+
+        #[test]
+        fn dart_method_body_comment_does_not_change_canonical_hash() {
+            // The method case routes through `dart_function_body`'s
+            // `method_signature` branch: the body node is a sibling of the
+            // signature's parent. A comment inside a Dart class method body must
+            // still be stripped from the canonical hash.
+            let a = canon_of(
+                "class Calc {\n  int add(int a, int b) {\n    return a + b;\n  }\n}\n",
+                "dart",
+                "add",
+            );
+            let b = canon_of(
+                "class Calc {\n  int add(int a, int b) {\n    // sum the two args\n    return a + b;\n  }\n}\n",
+                "dart",
+                "add",
+            );
+            assert_eq!(
+                a, b,
+                "a //-comment-only edit inside a Dart method body must not change canonical_hash"
+            );
+        }
+
+        #[test]
+        fn dart_body_code_change_does_change_canonical_hash() {
+            // The dual of the comment tests: a REAL change inside the
+            // body-spanned region (which lives under the `extra` body node, not
+            // the captured signature node) MUST change canonical_hash. This pins
+            // that the body-inclusive path is hashing body content, not just the
+            // signature.
+            let fn_a = canon_of(
+                "int square(int x) {\n  return x * x;\n}\n",
+                "dart",
+                "square",
+            );
+            let fn_b = canon_of(
+                "int square(int x) {\n  return x + x;\n}\n",
+                "dart",
+                "square",
+            );
+            assert_ne!(
+                fn_a, fn_b,
+                "a real Dart fn body change MUST change canonical_hash"
+            );
+            let m_a = canon_of(
+                "class Calc {\n  int add(int a, int b) {\n    return a + b;\n  }\n}\n",
+                "dart",
+                "add",
+            );
+            let m_b = canon_of(
+                "class Calc {\n  int add(int a, int b) {\n    return a - b;\n  }\n}\n",
+                "dart",
+                "add",
+            );
+            assert_ne!(
+                m_a, m_b,
+                "a real Dart method body change MUST change canonical_hash"
+            );
+        }
+
+        #[test]
         fn comment_strip_does_not_fuse_adjacent_tokens() {
             // `a/* */b` must canonicalize differently from `ab`: the removed
             // comment is replaced with a space so the two identifiers stay

--- a/src/worktree_overlay.rs
+++ b/src/worktree_overlay.rs
@@ -808,7 +808,43 @@ pub fn discover_delta(worktree_root: &Path, parent_root: &Path) -> Result<Delta,
     )?;
     let mut records = parse_name_status_z(&tracked_raw);
 
-    // Untracked files (lane-new code, gitignore-respecting).
+    // Size cap, enforced incrementally so an oversized delta bails BEFORE the
+    // filesystem-heavy parse-set scan (`is_parse_candidate` stats every file).
+    // The cap is measured on the authoritative quantity — the deduped mask set
+    // — so the early bail rejects exactly what the final backstop would.
+    let cap = overlay_max_files();
+    let mut delta = Delta {
+        parent_head_oid: oid,
+        ..Default::default()
+    };
+
+    // Helper: fold one record's touched origins into the mask set.
+    fn mask_record(masked: &mut HashSet<PathBuf>, rec: &DeltaRecord) {
+        // For renames/copies the `old` path is masked too (the rename case
+        // from the program doc). `R` masks old; `C` leaves old present in
+        // parent (untouched).
+        if let Some(old) = &rec.old {
+            if rec.status == DeltaStatus::Renamed {
+                masked.insert(PathBuf::from(old));
+            }
+        }
+        masked.insert(PathBuf::from(&rec.new));
+    }
+
+    // Mask the tracked records, then check the cap before spending a git
+    // invocation on the untracked list.
+    for rec in &records {
+        mask_record(&mut delta.masked_origins, rec);
+    }
+    let count = delta.masked_origins.len();
+    if count > cap {
+        tracing::warn!(count, cap, "overlay delta exceeds cap — skipping");
+        return Err(OverlayError::DeltaTooLarge { count, cap });
+    }
+
+    // Untracked files (lane-new code, gitignore-respecting). Fold each into the
+    // mask set as it arrives and bail the moment the cap is crossed, so a giant
+    // untracked tree never builds the full set or the parse set.
     let untracked_raw = git_capture(
         worktree_root,
         &["ls-files", "--others", "--exclude-standard", "-z"],
@@ -816,32 +852,24 @@ pub fn discover_delta(worktree_root: &Path, parent_root: &Path) -> Result<Delta,
     )?;
     for field in untracked_raw.split(|&b| b == 0).filter(|f| !f.is_empty()) {
         let path = normalize_str(&String::from_utf8_lossy(field));
-        records.push(DeltaRecord {
+        let rec = DeltaRecord {
             status: DeltaStatus::Untracked,
             old: None,
             new: path,
-        });
+        };
+        mask_record(&mut delta.masked_origins, &rec);
+        records.push(rec);
+        let count = delta.masked_origins.len();
+        if count > cap {
+            tracing::warn!(count, cap, "overlay delta exceeds cap — skipping");
+            return Err(OverlayError::DeltaTooLarge { count, cap });
+        }
     }
 
-    let mut delta = Delta {
-        parent_head_oid: oid,
-        ..Default::default()
-    };
-
+    // Under the cap: build the parse set (the subset of masked origins worth
+    // indexing). `D` masks only (no content). `R`/`C` index the new path.
+    // Everything else (`M`/`A`/`T`/untracked) indexes its path.
     for rec in &records {
-        // Mask set: every touched origin. For renames/copies the `old` path
-        // is masked too (the rename case from the program doc).
-        if let Some(old) = &rec.old {
-            // `R` masks old; `C` leaves old present in parent (untouched).
-            if rec.status == DeltaStatus::Renamed {
-                delta.masked_origins.insert(PathBuf::from(old));
-            }
-        }
-        delta.masked_origins.insert(PathBuf::from(&rec.new));
-
-        // Parse set: which masked origins actually get indexed. `D` masks
-        // only (no content). `R`/`C` index the new path. Everything else
-        // (`M`/`A`/`T`/untracked) indexes its path.
         let parse_candidate = match rec.status {
             DeltaStatus::Deleted => None,
             _ => Some(&rec.new),
@@ -860,7 +888,8 @@ pub fn discover_delta(worktree_root: &Path, parent_root: &Path) -> Result<Delta,
 
     delta.records = records;
 
-    let cap = overlay_max_files();
+    // Backstop: the incremental checks above already guarantee this, but keep
+    // the authoritative final check so the invariant is enforced at one point.
     let count = delta.masked_origins.len();
     if count > cap {
         tracing::warn!(count, cap, "overlay delta exceeds cap — skipping");

--- a/tests/store_calls_test.rs
+++ b/tests/store_calls_test.rs
@@ -1554,3 +1554,184 @@ fn attributed_callers_tied_doc_label_is_deterministic() {
         );
     }
 }
+
+// ===== distinct_callees_from_origins (masked-origin candidate enumeration) =====
+//
+// `distinct_callees_from_origins` enumerates the real-caller callees reachable
+// from a set of origin files — the worktree-overlay dead-merge candidate list.
+// It had no direct test for its multi-origin dedup, its empty-origins
+// short-circuit, or the normalized-path match contract it relies on (the
+// production caller, `apply_dead_overlay`, passes `crate::normalize_path`'d
+// origins against rows `upsert_function_calls` also stored normalized).
+
+/// Two origin files with overlapping + distinct real-caller callees: the result
+/// is the deduped union. A `doc_reference` edge from one of the origins is
+/// excluded (the method is restricted to real-caller kinds), pinning the
+/// real-caller contract the merged dead verdict depends on.
+#[test]
+fn distinct_callees_from_origins_dedups_union_across_files() {
+    use cqs::parser::FunctionCalls;
+    let store = TestStore::new();
+
+    // origin_a.rs: caller_a calls `shared` and `only_a`, plus a doc-reference to
+    // `doc_only` (which must NOT surface — it is not a real-caller edge).
+    store
+        .upsert_function_calls(
+            std::path::Path::new("origin_a.rs"),
+            &[FunctionCalls {
+                name: "caller_a".to_string(),
+                line_start: 1,
+                calls: vec![
+                    CallSite {
+                        callee_name: "shared".to_string(),
+                        line_number: 2,
+                        kind: CallEdgeKind::Call,
+                    },
+                    CallSite {
+                        callee_name: "only_a".to_string(),
+                        line_number: 3,
+                        kind: CallEdgeKind::Call,
+                    },
+                    CallSite {
+                        callee_name: "doc_only".to_string(),
+                        line_number: 4,
+                        kind: CallEdgeKind::DocReference,
+                    },
+                ],
+            }],
+        )
+        .unwrap();
+    // origin_b.rs: caller_b calls `shared` (overlap) and `only_b` (distinct).
+    store
+        .upsert_function_calls(
+            std::path::Path::new("origin_b.rs"),
+            &[FunctionCalls {
+                name: "caller_b".to_string(),
+                line_start: 1,
+                calls: vec![
+                    CallSite {
+                        callee_name: "shared".to_string(),
+                        line_number: 2,
+                        kind: CallEdgeKind::Call,
+                    },
+                    CallSite {
+                        callee_name: "only_b".to_string(),
+                        line_number: 3,
+                        kind: CallEdgeKind::Call,
+                    },
+                ],
+            }],
+        )
+        .unwrap();
+    // A third file NOT in `origins` must contribute nothing.
+    store
+        .upsert_function_calls(
+            std::path::Path::new("unrelated.rs"),
+            &[FunctionCalls {
+                name: "caller_c".to_string(),
+                line_start: 1,
+                calls: vec![CallSite {
+                    callee_name: "never_in_result".to_string(),
+                    line_number: 2,
+                    kind: CallEdgeKind::Call,
+                }],
+            }],
+        )
+        .unwrap();
+
+    let mut got = store
+        .distinct_callees_from_origins(&["origin_a.rs".to_string(), "origin_b.rs".to_string()])
+        .unwrap();
+    got.sort();
+    assert_eq!(
+        got,
+        vec![
+            "only_a".to_string(),
+            "only_b".to_string(),
+            "shared".to_string()
+        ],
+        "deduped union of the two origins' real-caller callees; `shared` appears \
+         once across both files, the doc_reference and the unrelated file are excluded"
+    );
+}
+
+/// Empty origins short-circuit: returns an empty vec, never touching the DB.
+#[test]
+fn distinct_callees_from_origins_empty_origins_is_empty() {
+    use cqs::parser::FunctionCalls;
+    let store = TestStore::new();
+    // A populated table proves the empty result comes from the short-circuit,
+    // not from an empty store.
+    store
+        .upsert_function_calls(
+            std::path::Path::new("origin.rs"),
+            &[FunctionCalls {
+                name: "caller".to_string(),
+                line_start: 1,
+                calls: vec![CallSite {
+                    callee_name: "present".to_string(),
+                    line_number: 2,
+                    kind: CallEdgeKind::Call,
+                }],
+            }],
+        )
+        .unwrap();
+
+    let got = store.distinct_callees_from_origins(&[]).unwrap();
+    assert!(
+        got.is_empty(),
+        "empty origins ⇒ empty result (no delta), got {got:?}"
+    );
+}
+
+/// Path-normalization contract: `upsert_function_calls` stores the `file` column
+/// normalized (backslashes → forward slashes via `crate::normalize_path`). The
+/// production caller (`apply_dead_overlay`) normalizes the masked origins the
+/// same way before querying, so a Windows-flavored origin still matches the
+/// stored row. The raw, non-normalized form does NOT match — proving the
+/// caller-side normalization is load-bearing, not incidental.
+#[test]
+fn distinct_callees_from_origins_matches_normalized_origin() {
+    use cqs::parser::FunctionCalls;
+    let store = TestStore::new();
+    // Upsert under a backslash path; the stored `file` is normalized to
+    // `src/win.rs`.
+    let win_path = std::path::Path::new("src\\win.rs");
+    store
+        .upsert_function_calls(
+            win_path,
+            &[FunctionCalls {
+                name: "win_caller".to_string(),
+                line_start: 1,
+                calls: vec![CallSite {
+                    callee_name: "win_callee".to_string(),
+                    line_number: 2,
+                    kind: CallEdgeKind::Call,
+                }],
+            }],
+        )
+        .unwrap();
+
+    // Querying with the normalized origin (what the production caller passes)
+    // matches.
+    let normalized = cqs::normalize_path(win_path);
+    assert_eq!(normalized, "src/win.rs", "normalize_path forward-slashes");
+    let got = store.distinct_callees_from_origins(&[normalized]).unwrap();
+    assert_eq!(
+        got,
+        vec!["win_callee".to_string()],
+        "a normalized origin matches the normalized stored `file` row"
+    );
+
+    // The raw backslash form does NOT match — the row was stored normalized, so
+    // the caller MUST normalize. This is exactly why apply_dead_overlay calls
+    // normalize_path on the masked origins.
+    let raw = store
+        .distinct_callees_from_origins(&["src\\win.rs".to_string()])
+        .unwrap();
+    assert!(
+        raw.is_empty(),
+        "the non-normalized origin must NOT match the normalized stored row \
+         (caller-side normalization is required), got {raw:?}"
+    );
+}


### PR DESCRIPTION
## fix(audit): five mechanical + test-coverage fixes (v1.46.1)

- **RM-V1.46.1-3** `worktree_overlay.rs` — `discover_delta` size cap is now a pre-allocation rail: fold the mask set first, check the cap after tracked records and per untracked entry, so an oversized delta bails with `DeltaTooLarge` before building the full records/parse_set. Rejection semantics preserved.
- **OB-V1.46.1-1** `parser/calls.rs` — non-UTF8 skip in `parse_file_relationships_with_candidates` now `warn!`s like its two sibling parse paths (was an invisible silent skip).
- **API-V1.46.1-2** `cli/args.rs` (+ call sites) — `SearchArgs` flattens the shared `OverlayArgs` instead of duplicating the three overlay fields inline. **Behavior-preserving** — the 512-case CLI==daemon parity proptest `daemon_bare_query_search_args_equals_cli_parse` passes; grepped `src/cli/` to confirm no other SearchArgs overlay-field reader.
- **TC-HAP-V1.46.1-2** `tests/store_calls_test.rs` — `distinct_callees_from_origins` test (multi-origin dedup union, empty short-circuit, normalized-path match).
- **TC-HAP-V1.46.1-3** `parser/chunk.rs` — Dart `canonical_hash` tests (body comments don't change the hash; real edits do).

Gates: clippy `--all-targets -D warnings` clean, fmt clean; targeted suites green (worktree_overlay 31, chunk canonical_hash 17, parser::calls 70, overlay/parity bin 72, store_calls 34). No global-state change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
