### PR TITLE
ci(release): deny warnings on cross-target dry-run; narrow platform_cfg_sweep claim

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,16 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+          components: clippy
+
+      # Deny-warnings lint on the actual sibling target, with real type info.
+      # PR CI runs clippy on ubuntu only, so a dead_code/E0277 break specific to
+      # a sibling target (aarch64-apple-darwin / x86_64-pc-windows-msvc) is
+      # invisible until here. `cargo build` alone would let a dead_code WARNING
+      # through (non-fatal); this gate makes it fatal pre-tag. Fire this workflow
+      # via workflow_dispatch on the release branch before tagging to validate.
+      - name: Cross-target lint (deny warnings)
+        run: cargo clippy --release --target ${{ matrix.target }} -- -D warnings
 
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }}

--- a/tests/platform_cfg_sweep_test.rs
+++ b/tests/platform_cfg_sweep_test.rs
@@ -1,22 +1,39 @@
-//! Completeness guard for the *platform-cfg divergence* family — the
-//! incomplete-sweep class that PR CI is structurally blind to.
+//! PR-time tripwire for ONE shape in the platform-cfg divergence family: the
+//! E0277 "unsized back-inferred binding" straggler. This is NOT a completeness
+//! guard for the whole family — see "Coverage boundary" below for what closes
+//! the rest.
 //!
 //! ## The structural null this defends
 //!
 //! `.github/workflows/ci.yml` builds, tests, and runs `clippy -D warnings`
 //! **only on `ubuntu-latest`**. The cross-target build (Linux + macOS +
-//! Windows) lives in `release.yml` and fires only on a `v*` tag. So an entire
-//! class of bug — code that compiles clean on Linux but breaks on a *sibling*
-//! target in the release matrix {`x86_64-unknown-linux-gnu`,
-//! `aarch64-apple-darwin`, `x86_64-pc-windows-msvc`} — is invisible until the
-//! release cross-build. v1.46.0's release build is exactly where it last bit.
+//! Windows) lives in `release.yml`. So a bug that compiles clean on Linux but
+//! breaks on a *sibling* target in the release matrix {`x86_64-unknown-linux-gnu`,
+//! `aarch64-apple-darwin`, `x86_64-pc-windows-msvc`} is invisible to PR CI.
+//! v1.46.0's release build is exactly where this shape last bit.
 //!
 //! Each Linux build is correct **in isolation** (its own green suite passes);
 //! the defect lives in the *relation* across the platform peer-set: a sweep
 //! that updated the Linux arm but left a sibling arm diverging or unannotated.
 //! No single-target test can express "all three targets type-check", so this
-//! guard asserts the *source-level invariants* that keep the sibling arms
-//! sound, on the one platform CI actually runs.
+//! guard asserts one *source-level invariant* that keeps the sibling arms
+//! sound, on the one platform CI actually runs — catching this shape at PR time
+//! instead of waiting for the cross-build.
+//!
+//! ## Coverage boundary (what this does NOT catch, and what does)
+//!
+//! This scan recognizes exactly one shape: a `#[cfg(unix)] let X = { … }`
+//! block-let with a `#[cfg(target_os = "linux")]` value arm and no type
+//! annotation. It does NOT catch the other sibling-break shapes — most notably
+//! an ungated `fn`/`const`/`static` reachable only from a single-target cfg arm,
+//! which becomes `dead_code` on the sibling and fails `-D warnings` there.
+//!
+//! The whole family — every shape, with real type info — is closed by the
+//! `release.yml` cross-target lint: `cargo clippy --release --target <T>
+//! -- -D warnings` runs on all three native runners. Fire it via
+//! `workflow_dispatch` on the release branch **before tagging** to validate.
+//! This source scan is the cheap PR-time early warning for the one shape it
+//! knows; the dry-run is the authoritative family-level gate.
 //!
 //! ## The exemplar (the bug this family is named for)
 //!


### PR DESCRIPTION
## ci(release): deny warnings on the cross-target dry-run + narrow the source-scan test's claim

Closes #1992.

The #1983 `workflow_dispatch` dry-run built all three targets but ran **no lint**, so a `dead_code` warning specific to a sibling target (`aarch64-apple-darwin` / `x86_64-pc-windows-msvc`) was emitted-yet-non-fatal — the dead-code-on-sibling shape stayed open even after the dry-run landed. (It did close the E0277 *hard-error* shape, since that fails the build outright.)

### Changes
- **`release.yml`**: add `cargo clippy --release --target <T> -- -D warnings` before the build, on each native runner. Real type info per sibling target, warnings fatal — closes the *whole* platform-cfg family pre-tag (both the E0277 binding shape and dead-code-on-sibling), not just the hard-error subset. `--release` shares the build's compilation cache; `components: clippy` added to the toolchain step (dtolnay's default profile is minimal).
- **`platform_cfg_sweep_test.rs`**: the scan only ever recognized the one E0277 unsized-binding shape while the module doc claimed family-level completeness — false confidence. Narrowed the doc to "PR-time tripwire for one shape" and documented the cross-target lint as the authoritative family-level gate. Test logic unchanged; both tests still pass.

After merge I'll fire the dry-run via `workflow_dispatch` on a release branch to confirm main is currently clean on all three targets under the new gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
