### PR TITLE
fix(serve): gate unwrap_dispatch_payload to any(unix, test) — dead on Windows release

### DIFF
--- a/src/daemon_translate.rs
+++ b/src/daemon_translate.rs
@@ -996,6 +996,13 @@ fn daemon_request_with_timeout<T: serde::de::DeserializeOwned>(
 /// (typically null) `data` payload. If neither an `error` nor a `data` field
 /// is present — i.e. the value is already the bare handler payload — return
 /// it as-is so the legacy mock-test path keeps working.
+//
+// Compiled on unix (its only production caller, `daemon_request_with_timeout`,
+// is `#[cfg(unix)]`) and under any test build (the unit tests below are
+// cross-platform `#[test]`). On a non-unix release build it has no caller, so
+// gating it here keeps `clippy -D warnings` (run per-target in release.yml)
+// from tripping dead_code on the Windows cross-build.
+#[cfg(any(unix, test))]
 fn unwrap_dispatch_payload(
     output: &serde_json::Value,
     type_name: &str,


### PR DESCRIPTION
## fix(serve): gate `unwrap_dispatch_payload` to `any(unix, test)` — dead on Windows release

The new release.yml cross-target clippy gate (deny-warnings, landed in #2004) **caught a latent Windows-only break on its first run** — exactly what #1992 added it for:

```
error: function `unwrap_dispatch_payload` is never used
   --> src\daemon_translate.rs:999:4
   = note: `-D dead-code` implied by `-D warnings`
```

`unwrap_dispatch_payload`'s only production caller, `daemon_request_with_timeout`, is `#[cfg(unix)]`. On a non-unix **release** build (lib only, no tests) the function has no reference → `dead_code` → fails `-D warnings` on the `x86_64-pc-windows-msvc` cross-build. Its unit tests are cross-platform `#[test]`, so it must still compile under any test build.

`#[cfg(any(unix, test))]` makes it exist exactly where it's used — unix production + any test build, absent on non-unix release. This is the established project pattern (cf. `SLOW_MMAP_FSTYPES`/`fstype_for_path` in `store/mod.rs`, from the v1.46.1 sweep).

**Impact:** this would have skipped the GitHub Release on the next `v*` tag (the v1.46.0-darwin scenario, Windows edition: the release job needs all three targets green). The gate found it pre-tag. Linux/darwin dry-run builds passed clean — this was the only straggler.

Validated locally on Linux (`clippy --lib -D warnings` clean, unix compilation unchanged). I'll re-fire the release dry-run after merge to confirm all three targets are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
