### PR TITLE
ci(release): revert cross-build -D warnings gate; keep cross-build hard-error check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,17 +43,16 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-          components: clippy
 
-      # Deny-warnings lint on the actual sibling target, with real type info.
-      # PR CI runs clippy on ubuntu only, so a dead_code/E0277 break specific to
-      # a sibling target (aarch64-apple-darwin / x86_64-pc-windows-msvc) is
-      # invisible until here. `cargo build` alone would let a dead_code WARNING
-      # through (non-fatal); this gate makes it fatal pre-tag. Fire this workflow
-      # via workflow_dispatch on the release branch before tagging to validate.
-      - name: Cross-target lint (deny warnings)
-        run: cargo clippy --release --target ${{ matrix.target }} -- -D warnings
-
+      # Building each target on its native runner catches the hard-error class
+      # of sibling-target break — notably the E0277 unsized-binding that failed
+      # the v1.46.0 aarch64-apple-darwin build, invisible to Linux-only PR CI.
+      # Fire this workflow via workflow_dispatch on the release branch before
+      # tagging to validate. NB: this does NOT enforce `-D warnings` — Windows
+      # currently carries a large dead_code backlog of daemon-client code that is
+      # live only via the (unix-only) socket path and awaits the named-pipe
+      # transport. Enforcing warnings here is deferred until that is swept; the
+      # hard-error gate is what guards the actual "release skips a binary" risk.
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }}
 

--- a/tests/platform_cfg_sweep_test.rs
+++ b/tests/platform_cfg_sweep_test.rs
@@ -26,14 +26,20 @@
 //! block-let with a `#[cfg(target_os = "linux")]` value arm and no type
 //! annotation. It does NOT catch the other sibling-break shapes — most notably
 //! an ungated `fn`/`const`/`static` reachable only from a single-target cfg arm,
-//! which becomes `dead_code` on the sibling and fails `-D warnings` there.
+//! which becomes `dead_code` on the sibling.
 //!
-//! The whole family — every shape, with real type info — is closed by the
-//! `release.yml` cross-target lint: `cargo clippy --release --target <T>
-//! -- -D warnings` runs on all three native runners. Fire it via
-//! `workflow_dispatch` on the release branch **before tagging** to validate.
-//! This source scan is the cheap PR-time early warning for the one shape it
-//! knows; the dry-run is the authoritative family-level gate.
+//! The **hard-error** members of the family — the E0277 binding above and any
+//! other compile error specific to a sibling target — are caught by the
+//! `release.yml` cross-build: `cargo build --release --target <T>` on all three
+//! native runners. Fire it via `workflow_dispatch` on the release branch
+//! **before tagging** to validate; a hard error there is exactly the "release
+//! skips a binary" risk (v1.46.0). The **warning-only** member (dead-code on a
+//! sibling) is NOT yet enforced cross-target — a `-D warnings` gate was tried
+//! and reverted because Windows carries a large pre-existing dead_code backlog
+//! (daemon-client code, live only via the unix socket path, awaiting the
+//! named-pipe transport); enforcing it needs that swept first. Tracked
+//! separately. So this source scan stays the cheap PR-time tripwire for the one
+//! (hard-error) shape it knows, and the cross-build is the hard-error gate.
 //!
 //! ## The exemplar (the bug this family is named for)
 //!


### PR DESCRIPTION
## ci(release): revert the cross-build `-D warnings` gate; keep the cross-build hard-error check

Follow-up to the deny-warnings gate. Firing the dry-run on main revealed the gate was **stricter than the actual release requirement** and surfaced a large pre-existing backlog rather than a fresh regression.

### What happened
The dry-run's `clippy --release --target x86_64-pc-windows-msvc -- -D warnings` step failed with **27 `dead_code` errors** — daemon-client code (`dispatch_via_view`, `DaemonHint`, `daemon_control_hint`, `format_uptime`/`format_last_indexed`/`format_unix_utc`, `print_text`, … across `batch/`, `commands/infra/`, `watch/`, `eval/`, `index/`) that is live only via the **unix-only** daemon socket path and is therefore dead on the Windows release build. This code is intentionally present and awaits the named-pipe daemon transport (the Windows-daemon work is a separate open issue). It is **not** a regression, and it was never release-blocking: `cargo build` treats `dead_code` as a non-fatal warning, so prior Windows release binaries shipped fine.

### Why revert rather than sweep now
- The real "release skips a binary" risk is the **hard-error** class — the E0277 unsized-binding that failed the v1.46.0 `aarch64-apple-darwin` build. `cargo build --release --target <T>` on all three native runners (already in this workflow) catches that. That gate stays.
- Making the Windows build `-D warnings`-clean requires a deliberate cfg sweep of 27 items across ~9 modules, with a real design decision (cfg-gate the daemon-client code out vs `allow(dead_code)` it for the eventual named-pipe daemon) — gating it out now would have to be undone when the Windows daemon lands.
- That sweep can't be iterated locally (the C deps block cross-clippy), so each round costs a full ~20-min native dry-run. Not an autopilot one-shot.

### Changes
- `release.yml`: drop the `Cross-target lint (deny warnings)` step + the `components: clippy`; keep the cross-build `cargo build` on all three targets. Comment documents why warnings aren't enforced here yet.
- `platform_cfg_sweep_test.rs`: doc corrected — the cross-build catches the **hard-error** family members; the warning-only (dead-code-on-sibling) member is deferred until the backlog is swept.

The one item already fixed properly (`unwrap_dispatch_payload` → `#[cfg(any(unix, test))]`) stays. The remaining 26 + the gate re-add are tracked in the reopened issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
