### PR TITLE
feat(mcp): Phase 0 — JsonSchema on command-core input structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,6 +850,7 @@ dependencies = [
  "regex",
  "reqwest 0.13.4",
  "rustyline",
+ "schemars",
  "self_cell",
  "serde",
  "serde_json",
@@ -1268,6 +1269,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -3427,6 +3434,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3723,6 +3750,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3812,6 +3864,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,9 @@ aho-corasick = "1"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 toml = "1.1"
+# JSON Schema generation for command-core input structs (the MCP inputSchema
+# source). Additive only — no schema-gen logic or server yet.
+schemars = "1"
 
 # Path canonicalization (strips Windows UNC \\?\ prefixes)
 dunce = "1"

--- a/docs/plans/2026-06-16-mcp-server-design.md
+++ b/docs/plans/2026-06-16-mcp-server-design.md
@@ -2,7 +2,19 @@
 
 Companion to `2026-06-16-mcp-wrap-assessment.md` (the *what/why/gap*). This is the *how*: module layout, the bridge protocol, schema generation, request flow, and the decisions still open. Target spec revision: **MCP 2025-11-25**.
 
-Status: **DESIGN / pre-decision.** Several choices in §10 are unresolved and gate implementation. Nothing here is built.
+Status: **BUILD GREENLIT (2026-06-17).** Phase 0 is committed (this branch). The two foundational choices §10 left open are now decided — see §0.
+
+---
+
+## 0. Status & corrections (2026-06-17)
+
+**Build greenlit (OQ-14 resolved).** The user confirmed re-introducing MCP. This is a *re-intro*, not greenfield — see §0b.
+
+**inputSchema source = the `commands::*` core-input structs, NOT the `args.rs` clap structs** (this supersedes §6 below and assessment-doc G2). Discovered while building Phase 0: the command cores under `src/cli/commands/**` are ALREADY `#[derive(serde::Deserialize)] #[serde(default)]` with `///` doc comments → their schemas are correctly **optional** (a wire caller supplies just the fields it wants) and **described** (schemars harvests `///`). The `args.rs` clap structs mark every field *required* and their clap `#[arg(help)]` is invisible to schemars. The cores are also the canonical surface-agnostic input (`*_core` consumes them), so MCP becomes a true third surface — wire JSON → core struct → `*_core`, no clap re-parse — which is the anti-duplication discipline the command-core pattern exists for. Phase 0 (committed) derives `JsonSchema` on the ~21 such cores + their enums (schemars 1, JSON Schema 2020-12). Coverage: the ~22 commands without a core-input struct are mostly no-arg (`stats`/`health`/`ping`) → empty schema; the few real ones get a core struct as command-core completion in Phase 1.
+
+## 0b. Prior art — the removed v0.10.0 MCP server
+
+cqs shipped an MCP server through v0.9.x (`src/mcp/`, `cqs serve`): **in-process** (loaded GPU + index itself), **HTTP+SSE** transport, **27 files / ~3700 lines** with a **separate handler per tool** (`search.rs` alone was 428 lines) — each tool *reimplemented* its logic parallel to the CLI. That duplication is exactly what the CLI-first migration (#320/#333) and the command-core refactor set out to kill; the server was removed in **v0.10.0 (#352, commit `291ec6b0`)** for CLI-first + slim deps. **The re-intro inverts the old design**: thin (rides the cores → no per-tool files, ~10× smaller), an `stdio`↔daemon-socket bridge to the warm daemon (not in-process; supersedes HTTP+SSE; keeps stdout clean re the #2009 leak class), optional + slim (no HTTP-server deps). Mine the old code for reference via `git show 291ec6b0^:src/mcp/<file>` — especially `validation.rs` (resurrect its security tests), `server.rs`, `types.rs`, `transports/stdio.rs`.
 
 ---
 

--- a/src/cli/commands/graph/callers.rs
+++ b/src/cli/commands/graph/callers.rs
@@ -38,7 +38,7 @@ use super::KindFallbackOutput;
 /// core: the cross-project path has its own (multi-index) semantics and no
 /// kind-fallback. The core covers the single-project path both surfaces
 /// share.
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 #[serde(default)]
 pub(crate) struct CallersArgs {
     /// Function name to analyze.

--- a/src/cli/commands/graph/deps.rs
+++ b/src/cli/commands/graph/deps.rs
@@ -18,7 +18,7 @@ use super::KindFallbackOutput;
 /// Input for [`deps_core`]. Cross-project deps is not yet supported (both
 /// surfaces warn and return the local result); the flag lives on the
 /// adapter side, so the core covers the single-project path.
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 #[serde(default)]
 pub(crate) struct DepsArgs {
     /// Type name (forward) or function name (with `reverse`).

--- a/src/cli/commands/graph/impact.rs
+++ b/src/cli/commands/graph/impact.rs
@@ -27,7 +27,7 @@ use crate::cli::OutputFormat;
 /// Input for [`impact_core`]. Cross-project impact lives in the adapters
 /// (separate cross-project analyzer); the core covers the single-project
 /// path both surfaces share.
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 #[serde(default)]
 pub(crate) struct ImpactArgs {
     /// Function name or `file:function`.

--- a/src/cli/commands/graph/test_map.rs
+++ b/src/cli/commands/graph/test_map.rs
@@ -26,7 +26,7 @@ use crate::cli::commands::resolve::resolve_target;
 /// Input for [`test_map_core`]. Cross-project test-map lives in the
 /// adapters (it has no kind-fallback and a merged-graph context); the core
 /// covers the single-project path both surfaces share.
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 #[serde(default)]
 pub(crate) struct TestMapArgs {
     /// Function name or `file:function`.

--- a/src/cli/commands/graph/trace.rs
+++ b/src/cli/commands/graph/trace.rs
@@ -27,7 +27,7 @@ use crate::cli::OutputFormat;
 /// Input for [`trace_core`]. Cross-project trace lives in the adapters
 /// (separate cross-project BFS, no kind-fallback); the core covers the
 /// single-project path.
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 #[serde(default)]
 pub(crate) struct TraceArgs {
     /// Source function name or `file:function`.

--- a/src/cli/commands/index/stats.rs
+++ b/src/cli/commands/index/stats.rs
@@ -221,7 +221,7 @@ pub(crate) fn build_stats<Mode>(store: &cqs::Store<Mode>, cqs_dir: &Path) -> Res
 
 /// Input for [`stats_core`]. `cqs stats` takes no positional or flag input
 /// beyond the freshness toggle — both CLI and daemon want the same numbers.
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub(crate) struct StatsArgs {
     /// When `true`, walk the filesystem and populate `stale_files` /
     /// `missing_files`. Both surfaces set this; it is an Arg (not hardcoded)

--- a/src/cli/commands/infra/audit_mode.rs
+++ b/src/cli/commands/infra/audit_mode.rs
@@ -39,7 +39,7 @@ pub(crate) struct AuditModeOutput {
 /// Owned + `Deserialize` like every other core Args, so a wire/MCP caller can
 /// inflate it from `{"state": "on", "expires": "30m"}`. `expires` defaults to
 /// `30m` when omitted, matching the clap default.
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub(crate) struct AuditModeArgs {
     /// `None` → query current state; `Some(On)` / `Some(Off)` → set it.
     #[serde(default)]

--- a/src/cli/commands/infra/telemetry_cmd.rs
+++ b/src/cli/commands/infra/telemetry_cmd.rs
@@ -453,7 +453,7 @@ fn build_telemetry(entries: &[Entry]) -> TelemetryOutput {
 // ---------------------------------------------------------------------------
 
 /// Input for [`telemetry_core`].
-#[derive(Debug, Default, serde::Deserialize)]
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
 pub(crate) struct TelemetryArgs {
     /// Aggregate every `telemetry*.jsonl` (archived + current) rather than
     /// just the live `telemetry.jsonl`.

--- a/src/cli/commands/io/blame.rs
+++ b/src/cli/commands/io/blame.rs
@@ -25,7 +25,7 @@ use cqs::{normalize_path, rel_display, resolve_target};
 ///
 /// `#[serde(default)]` so a wire caller can supply just `name` and inherit the
 /// production defaults (commits mirrors clap's `--commits` default of 10).
-#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Deserialize, schemars::JsonSchema)]
 #[serde(default)]
 pub(crate) struct BlameArgs {
     /// Function name or `file:function` to blame.

--- a/src/cli/commands/io/context.rs
+++ b/src/cli/commands/io/context.rs
@@ -30,7 +30,7 @@ use crate::cli::staleness;
 /// `#[serde(default)]` so a wire caller can supply just `path` and inherit the
 /// production defaults. `summary`/`compact` are mutually-exclusive modes (clap
 /// enforces; the core treats `compact` as winning if both are somehow set).
-#[derive(Debug, Clone, PartialEq, Default, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Default, serde::Deserialize, schemars::JsonSchema)]
 #[serde(default)]
 pub(crate) struct ContextArgs {
     /// File path (relative to project root) to build context for.

--- a/src/cli/commands/io/diff.rs
+++ b/src/cli/commands/io/diff.rs
@@ -28,7 +28,7 @@ use crate::cli::find_project_root;
 ///
 /// `#[serde(default)]` so a wire caller can omit `target`/`lang` and inherit
 /// the production defaults; `threshold` defaults to the clap value.
-#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Deserialize, schemars::JsonSchema)]
 #[serde(default)]
 pub(crate) struct DiffArgs {
     /// Source reference name (echoed into the output label).

--- a/src/cli/commands/io/drift.rs
+++ b/src/cli/commands/io/drift.rs
@@ -24,7 +24,7 @@ use crate::cli::find_project_root;
 ///
 /// `#[serde(default)]` so a wire caller can supply just `reference` and inherit
 /// the production defaults (matching clap's `DriftArgs`).
-#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Deserialize, schemars::JsonSchema)]
 #[serde(default)]
 pub(crate) struct DriftArgs {
     /// Reference name to compare the project against (echoed into output).

--- a/src/cli/commands/review/ci.rs
+++ b/src/cli/commands/review/ci.rs
@@ -13,7 +13,7 @@ use cqs::RiskLevel;
 /// Input for [`ci_core`]. The diff text + gate threshold are supplied by the
 /// adapter (which owns I/O and the `GateThreshold` parse); `tokens` folds the
 /// request-scoped budget in.
-#[derive(Debug, Default, serde::Deserialize)]
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
 pub(crate) struct CiArgs {
     /// Token budget for the embedded review (truncates callers/tests lists).
     #[serde(default)]

--- a/src/cli/commands/review/dead.rs
+++ b/src/cli/commands/review/dead.rs
@@ -22,7 +22,11 @@ use cqs::store::{DeadConfidence, DeadFunction};
 /// Self-classification of a dead-code entry. Ordered most-excusable to
 /// least: a `test-only` fixture is almost never worth deleting, a `dead`
 /// entry is the actionable residue.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, schemars::JsonSchema)]
+// kebab-case on the schema to match the stable strings the `--verdict` filter /
+// `de_opt_verdict` deserializer accept (`test-only`, `low-confidence-live`,
+// `known-gap`). schemars reads serde attributes even without a serde derive.
+#[serde(rename_all = "kebab-case")]
 pub(crate) enum DeadVerdict {
     /// Default: no classification ran / none matched above `dead`. Rendered as
     /// the absent (skip-when-default) state on JSON entries.
@@ -383,7 +387,7 @@ pub(crate) struct DeadOutput {
 /// Input for [`dead_core`]. Derives `Deserialize` (MCP param surface) with
 /// doc-commented fields; `min_confidence` deserializes from the same
 /// `low`/`medium`/`high` strings the CLI / wire accept.
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub(crate) struct DeadArgs {
     /// Include public-API functions in the main `dead` list (otherwise they
     /// land in `possibly_dead_pub`, which agents usually skip).

--- a/src/cli/commands/review/dead.rs
+++ b/src/cli/commands/review/dead.rs
@@ -23,10 +23,11 @@ use cqs::store::{DeadConfidence, DeadFunction};
 /// least: a `test-only` fixture is almost never worth deleting, a `dead`
 /// entry is the actionable residue.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, schemars::JsonSchema)]
-// kebab-case on the schema to match the stable strings the `--verdict` filter /
-// `de_opt_verdict` deserializer accept (`test-only`, `low-confidence-live`,
-// `known-gap`). schemars reads serde attributes even without a serde derive.
-#[serde(rename_all = "kebab-case")]
+// schemars-only kebab-case so the SCHEMA matches the stable strings the
+// `--verdict` filter / `de_opt_verdict` deserializer accept (`test-only`,
+// `low-confidence-live`, `known-gap`). This type has no serde derive — its
+// (de)serialization is `as_str` / `parse` — so the rename is scoped to schemars.
+#[schemars(rename_all = "kebab-case")]
 pub(crate) enum DeadVerdict {
     /// Default: no classification ran / none matched above `dead`. Rendered as
     /// the absent (skip-when-default) state on JSON entries.

--- a/src/cli/commands/review/diff_review.rs
+++ b/src/cli/commands/review/diff_review.rs
@@ -11,7 +11,7 @@ use cqs::RiskLevel;
 
 /// Input for [`review_core`]. The diff text is acquired by the adapter
 /// (CLI: git or stdin; daemon: git) and passed in, so the core stays I/O-free.
-#[derive(Debug, Default, serde::Deserialize)]
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
 pub(crate) struct ReviewArgs {
     /// Token budget for the output. When set, callers/tests lists are
     /// truncated to fit; changed functions + notes are always included.

--- a/src/cli/commands/search/gather.rs
+++ b/src/cli/commands/search/gather.rs
@@ -25,7 +25,7 @@ use crate::cli::staleness;
 ///
 /// `#[serde(default)]` so a wire caller can supply just `query` and inherit the
 /// production defaults (depth/direction/limit mirror clap).
-#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Deserialize, schemars::JsonSchema)]
 #[serde(default)]
 pub(crate) struct GatherArgs {
     /// Search query / question.

--- a/src/cli/commands/search/onboard.rs
+++ b/src/cli/commands/search/onboard.rs
@@ -23,7 +23,7 @@ use cqs::{Embedder, GatherDirection};
 ///
 /// `#[serde(default)]` so a wire caller can supply just `query` and inherit the
 /// production defaults (depth/direction/limit mirror clap).
-#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Deserialize, schemars::JsonSchema)]
 #[serde(default)]
 pub(crate) struct OnboardArgs {
     /// Concept or query to explore.

--- a/src/cli/commands/search/query.rs
+++ b/src/cli/commands/search/query.rs
@@ -50,7 +50,7 @@ use crate::cli::{display, signal, staleness, Cli};
 ///
 /// `#[serde(default)]` on the whole struct so a wire/MCP caller can supply just
 /// `query` and inherit the production defaults for the rest.
-#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Deserialize, schemars::JsonSchema)]
 #[serde(default)]
 pub(crate) struct QueryArgs {
     /// Search query (quote multi-word queries).
@@ -3315,5 +3315,178 @@ mod tests {
                  got {got:?}"
             );
         }
+    }
+}
+
+// ─── MCP Phase 0: JsonSchema smoke test ─────────────────────────────────────
+//
+// Verifies the command-core input structs are a usable MCP `inputSchema`
+// source: the schemas are JSON Schema 2020-12, their `serde(default)` fields are
+// OPTIONAL (no `required` array — the load-bearing distinction from the clap
+// `args.rs` surface, whose fields are mandatory), the `///` doc comments survive
+// into `description`s, and a minimal wire object round-trips back to the struct.
+#[cfg(test)]
+mod jsonschema_smoke {
+    use super::QueryArgs;
+    use crate::cli::commands::gather::GatherArgs;
+    use crate::cli::commands::{CallersCoreArgs, DeadArgs, ImpactCoreArgs as ImpactArgs};
+
+    /// The 2020-12 dialect URI schemars 1.x emits in the root `$schema`.
+    const DIALECT_2020_12: &str = "https://json-schema.org/draft/2020-12/schema";
+
+    /// Assert the shape an MCP `inputSchema` source must have for `T`:
+    /// (a) the root is the 2020-12 dialect, (b) `T` has no required fields (its
+    /// `serde(default)` makes every param optional on the wire), and (c) at
+    /// least one property carries a non-empty `description` harvested from a
+    /// `///` doc comment.
+    fn assert_inputschema_shape<T: schemars::JsonSchema>(label: &str) {
+        let schema = serde_json::to_value(schemars::schema_for!(T))
+            .unwrap_or_else(|e| panic!("{label}: schema serialize failed: {e}"));
+
+        // (a) 2020-12 dialect.
+        assert_eq!(
+            schema.get("$schema").and_then(|v| v.as_str()),
+            Some(DIALECT_2020_12),
+            "{label}: root $schema must be JSON Schema 2020-12"
+        );
+
+        // (b) No required fields — serde(default) ⇒ every param optional.
+        // Either the key is absent or it is an empty array.
+        match schema.get("required") {
+            None => {}
+            Some(req) => {
+                let arr = req
+                    .as_array()
+                    .unwrap_or_else(|| panic!("{label}: `required` present but not an array"));
+                assert!(
+                    arr.is_empty(),
+                    "{label}: serde(default) struct must have no required fields, got {arr:?}"
+                );
+            }
+        }
+
+        // (c) At least one property has a non-empty description (proving `///`
+        // → schema description).
+        let props = schema
+            .get("properties")
+            .and_then(|v| v.as_object())
+            .unwrap_or_else(|| panic!("{label}: schema has no `properties` object"));
+        let has_description = props.values().any(|p| {
+            p.get("description")
+                .and_then(|d| d.as_str())
+                .is_some_and(|d| !d.is_empty())
+        });
+        assert!(
+            has_description,
+            "{label}: at least one property must carry a `///`-derived description"
+        );
+    }
+
+    #[test]
+    fn command_core_structs_are_mcp_inputschema_ready() {
+        // (a)+(b)+(c) over four representative cores.
+        assert_inputschema_shape::<QueryArgs>("QueryArgs");
+        assert_inputschema_shape::<ImpactArgs>("ImpactArgs");
+        assert_inputschema_shape::<GatherArgs>("GatherArgs");
+        assert_inputschema_shape::<DeadArgs>("DeadArgs");
+
+        // (d) A MINIMAL wire object deserializes — wire-optionality is real, not
+        // just declared in the schema. The search struct takes only `query`.
+        let q: QueryArgs = serde_json::from_value(serde_json::json!({ "query": "x" }))
+            .expect("minimal {query} object must deserialize into QueryArgs");
+        assert_eq!(q.query, "x");
+        // And an entirely empty object inflates to all-defaults (the ultimate
+        // optionality proof for a `serde(default)` struct).
+        let empty: GatherArgs =
+            serde_json::from_value(serde_json::json!({})).expect("empty object → GatherArgs");
+        assert_eq!(empty, GatherArgs::default());
+    }
+
+    /// The enum-typed fields must surface the same spelling the CLI accepts —
+    /// schemars reads `#[serde(rename_all = ...)]`, so the schema's enum values
+    /// match the wire/CLI form (not the PascalCase Rust variant names). Guards
+    /// the CLI-vs-schema casing mismatch the dual-surface contract requires.
+    #[test]
+    fn enum_fields_use_cli_casing() {
+        // GatherDirection → lowercase (`both` / `callers` / `callees`).
+        let gather = serde_json::to_value(schemars::schema_for!(GatherArgs)).unwrap();
+        let values = collect_enum_values(&gather);
+        for want in ["both", "callers", "callees"] {
+            assert!(
+                values.contains(&want.to_string()),
+                "GatherArgs schema must offer direction `{want}` (lowercase); got {values:?}"
+            );
+        }
+
+        // DeadArgs: DeadConfidence → lowercase, DeadVerdict → kebab-case.
+        let dead = serde_json::to_value(schemars::schema_for!(DeadArgs)).unwrap();
+        let dvalues = collect_enum_values(&dead);
+        for want in [
+            "low",
+            "medium",
+            "high",
+            "test-only",
+            "low-confidence-live",
+            "known-gap",
+        ] {
+            assert!(
+                dvalues.contains(&want.to_string()),
+                "DeadArgs schema must offer enum value `{want}`; got {dvalues:?}"
+            );
+        }
+
+        // CallersArgs.edge_kind → CallEdgeKind in snake_case (`serde_callback`,
+        // `macro_heuristic`, `fn_pointer`, `doc_reference`) — the stored / wire
+        // spelling `parse_edge_kind` accepts.
+        let callers = serde_json::to_value(schemars::schema_for!(CallersCoreArgs)).unwrap();
+        let cvalues = collect_enum_values(&callers);
+        for want in [
+            "serde_callback",
+            "macro_heuristic",
+            "fn_pointer",
+            "doc_reference",
+        ] {
+            assert!(
+                cvalues.contains(&want.to_string()),
+                "CallersArgs schema must offer edge_kind `{want}` (snake_case); got {cvalues:?}"
+            );
+        }
+    }
+
+    /// Collect every enumerated string value anywhere in the schema (root +
+    /// `$defs`). schemars 1.x emits two shapes depending on the enum: a plain
+    /// `"enum": [..]` array for variants with no per-variant docs, and a
+    /// `"oneOf": [{ "const": "low", "description": ".." }, ..]` form when each
+    /// variant carries a `///`. Both are gathered, and referenced enums live
+    /// under `$defs`, so a field-level scan is not enough.
+    fn collect_enum_values(schema: &serde_json::Value) -> Vec<String> {
+        let mut out = Vec::new();
+        fn walk(v: &serde_json::Value, out: &mut Vec<String>) {
+            match v {
+                serde_json::Value::Object(map) => {
+                    if let Some(serde_json::Value::Array(arr)) = map.get("enum") {
+                        for e in arr {
+                            if let Some(s) = e.as_str() {
+                                out.push(s.to_string());
+                            }
+                        }
+                    }
+                    if let Some(s) = map.get("const").and_then(|c| c.as_str()) {
+                        out.push(s.to_string());
+                    }
+                    for child in map.values() {
+                        walk(child, out);
+                    }
+                }
+                serde_json::Value::Array(arr) => {
+                    for child in arr {
+                        walk(child, out);
+                    }
+                }
+                _ => {}
+            }
+        }
+        walk(schema, &mut out);
+        out
     }
 }

--- a/src/cli/commands/search/scout.rs
+++ b/src/cli/commands/search/scout.rs
@@ -19,7 +19,7 @@ use cqs::{scout_with_options, scout_with_overlay, Embedder, ScoutOptions};
 ///
 /// `#[serde(default)]` so a wire caller can supply just `query` and inherit the
 /// production defaults (limit mirrors clap's `LimitArg`).
-#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Deserialize, schemars::JsonSchema)]
 #[serde(default)]
 pub(crate) struct ScoutArgs {
     /// Search query to investigate.

--- a/src/cli/commands/search/similar.rs
+++ b/src/cli/commands/search/similar.rs
@@ -23,7 +23,7 @@ use crate::cli::display;
 /// `#[serde(default)]` so a wire caller can supply just `name` and inherit the
 /// production defaults (limit mirrors clap's `LimitArg`, threshold mirrors the
 /// `--threshold` default).
-#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Deserialize, schemars::JsonSchema)]
 #[serde(default)]
 pub(crate) struct SimilarArgs {
     /// Function name or `file:function`.

--- a/src/cli/commands/train/plan.rs
+++ b/src/cli/commands/train/plan.rs
@@ -11,7 +11,7 @@ use cqs::Embedder;
 
 /// Input for [`plan_core`]. The embedder is a resource the adapter resolves
 /// (`ctx.embedder()`); the request-scoped fields live here.
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub(crate) struct PlanArgs {
     /// Natural-language task description to classify and plan.
     pub description: String,

--- a/src/cli/definitions.rs
+++ b/src/cli/definitions.rs
@@ -95,7 +95,7 @@ impl TextJsonArgs {
 pub use cqs::ci::GateThreshold;
 
 /// Audit mode state for the audit-mode command
-#[derive(Clone, Debug, clap::ValueEnum, serde::Deserialize)]
+#[derive(Clone, Debug, clap::ValueEnum, serde::Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum AuditModeState {
     /// Enable audit mode

--- a/src/gather.rs
+++ b/src/gather.rs
@@ -186,8 +186,20 @@ impl Default for GatherOptions {
 
 /// Direction of call graph expansion
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, clap::ValueEnum,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    clap::ValueEnum,
+    schemars::JsonSchema,
 )]
+// Lowercase on the wire/schema to match the CLI spelling (`both`/`callers`/
+// `callees` via clap `FromStr`); without it serde + schemars would expect the
+// PascalCase variant names.
+#[serde(rename_all = "lowercase")]
 pub enum GatherDirection {
     Both,
     Callers,

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -98,12 +98,13 @@ pub struct Chunk {
 /// skip-when-default value, so a present `edge_kind` always signals a
 /// non-syntactic edge worth extra scrutiny.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Default, schemars::JsonSchema)]
-// snake_case on the schema to match the stored / wire strings
+// schemars-only snake_case so the SCHEMA matches the stored / wire strings
 // (`serde_callback`, `macro_heuristic`, `fn_pointer`, `doc_reference`) that the
-// `parse_edge_kind` deserializer accepts. The derived `Serialize` is not the
-// JSON output path — every output struct routes through `serialize_edge_kind` /
-// `as_str` — so this only governs the input schema.
-#[serde(rename_all = "snake_case")]
+// `parse_edge_kind` deserializer accepts. Scoped to schemars (not serde) so the
+// derived `Serialize` stays untouched — every output struct already routes the
+// JSON through `serialize_edge_kind` / `as_str`, so this only shapes the input
+// schema and leaves the (unused) derived `Serialize` byte-identical.
+#[schemars(rename_all = "snake_case")]
 pub enum CallEdgeKind {
     /// Syntactic `call_expression` — ground truth.
     #[default]

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -97,7 +97,13 @@ pub struct Chunk {
 /// `Call` is the default and the overwhelming majority — it is the
 /// skip-when-default value, so a present `edge_kind` always signals a
 /// non-syntactic edge worth extra scrutiny.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Default, schemars::JsonSchema)]
+// snake_case on the schema to match the stored / wire strings
+// (`serde_callback`, `macro_heuristic`, `fn_pointer`, `doc_reference`) that the
+// `parse_edge_kind` deserializer accepts. The derived `Serialize` is not the
+// JSON output path — every output struct routes through `serialize_edge_kind` /
+// `as_str` — so this only governs the input schema.
+#[serde(rename_all = "snake_case")]
 pub enum CallEdgeKind {
     /// Syntactic `call_expression` — ground truth.
     #[default]

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -430,6 +430,38 @@ pub struct ChunkTypeRefs {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Pins the DERIVED `Serialize` spelling of `CallEdgeKind` (PascalCase
+    /// variant names). Output today routes through `as_str` (snake_case) and the
+    /// derived impl is unused, but the derive exists — so a future bare
+    /// `#[serde(rename_all = ...)]` (e.g. someone "fixing" the schema casing in
+    /// serde instead of schemars) would silently flip this the moment the derived
+    /// impl reaches any output. Schema casing belongs to `#[schemars(rename_all)]`;
+    /// serde output is a wire contract. This fails first if that line is crossed.
+    #[test]
+    fn call_edge_kind_derived_serialize_spelling_is_pinned() {
+        assert_eq!(
+            serde_json::to_string(&CallEdgeKind::Call).unwrap(),
+            "\"Call\""
+        );
+        assert_eq!(
+            serde_json::to_string(&CallEdgeKind::SerdeCallback).unwrap(),
+            "\"SerdeCallback\""
+        );
+        assert_eq!(
+            serde_json::to_string(&CallEdgeKind::MacroHeuristic).unwrap(),
+            "\"MacroHeuristic\""
+        );
+        assert_eq!(
+            serde_json::to_string(&CallEdgeKind::FnPointer).unwrap(),
+            "\"FnPointer\""
+        );
+        assert_eq!(
+            serde_json::to_string(&CallEdgeKind::DocReference).unwrap(),
+            "\"DocReference\""
+        );
+    }
+
     /// Tests that all TypeEdgeKind variants can be converted to strings and parsed back to equal values.
     /// # Arguments
     /// None. This is a test function that operates on hardcoded TypeEdgeKind variants.

--- a/src/store/calls/mod.rs
+++ b/src/store/calls/mod.rs
@@ -81,13 +81,17 @@ pub struct DeadFunction {
     PartialOrd,
     Ord,
     serde::Serialize,
-    serde::Deserialize,
     clap::ValueEnum,
     schemars::JsonSchema,
 )]
-// Lowercase on the wire/schema to match the `low`/`medium`/`high` strings the
-// CLI and the `de_confidence` deserializer accept.
-#[serde(rename_all = "lowercase")]
+// schemars-only lowercase so the SCHEMA matches the `low`/`medium`/`high`
+// strings the CLI and the `de_confidence` deserializer accept. A serde
+// rename_all would also flip the derived `Serialize`, which IS the ci
+// `dead_in_diff` JSON output path (PascalCase today) — so the rename is scoped
+// to schemars to keep that output byte-identical. The input field deserializes
+// via `de_confidence` (a `deserialize_with`), so no serde `Deserialize` is
+// needed here for the wire surface.
+#[schemars(rename_all = "lowercase")]
 pub enum DeadConfidence {
     /// Likely a false positive (methods, functions in active files)
     Low,

--- a/src/store/calls/mod.rs
+++ b/src/store/calls/mod.rs
@@ -72,7 +72,22 @@ pub struct DeadFunction {
 
 /// Confidence level for dead code detection.
 /// Ordered from least to most confident, enabling `>=` filtering.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, clap::ValueEnum)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    serde::Serialize,
+    serde::Deserialize,
+    clap::ValueEnum,
+    schemars::JsonSchema,
+)]
+// Lowercase on the wire/schema to match the `low`/`medium`/`high` strings the
+// CLI and the `de_confidence` deserializer accept.
+#[serde(rename_all = "lowercase")]
 pub enum DeadConfidence {
     /// Likely a false positive (methods, functions in active files)
     Low,

--- a/src/store/calls/mod.rs
+++ b/src/store/calls/mod.rs
@@ -112,6 +112,35 @@ impl DeadConfidence {
     }
 }
 
+#[cfg(test)]
+mod dead_confidence_serde_guard {
+    use super::DeadConfidence;
+
+    /// Pins the DERIVED `Serialize` spelling of `DeadConfidence`. That impl is a
+    /// live JSON output path — `DeadInDiff.confidence` (`ci`) and
+    /// `DeadFunction.confidence` serialize the enum directly, no `serialize_with`
+    /// — so it emits the variant name verbatim (PascalCase) today. The schema
+    /// casing is shaped by `#[schemars(rename_all = "lowercase")]`, which cannot
+    /// touch serde. If someone ever "fixes" the schema with a bare
+    /// `#[serde(rename_all = ...)]` instead, that flips this output too; this
+    /// test fails first. (Schema casing => schemars; output is a wire contract.)
+    #[test]
+    fn derived_serialize_spelling_is_pinned() {
+        assert_eq!(
+            serde_json::to_string(&DeadConfidence::Low).unwrap(),
+            "\"Low\""
+        );
+        assert_eq!(
+            serde_json::to_string(&DeadConfidence::Medium).unwrap(),
+            "\"Medium\""
+        );
+        assert_eq!(
+            serde_json::to_string(&DeadConfidence::High).unwrap(),
+            "\"High\""
+        );
+    }
+}
+
 /// Low-confidence-liveness evidence for a callee with NO trusted caller: the
 /// heuristic-edge breakdown (from `function_calls`) AND the candidate-edge
 /// breakdown (from the `candidate_edges` side-table, Lane 2). Either population


### PR DESCRIPTION
## feat(mcp): Phase 0 — JsonSchema on command-core input structs (inputSchema groundwork)

First step of re-introducing an MCP interface (cqs had one through v0.9.x, removed in v0.10.0 #352). Phase 0 is **additive derives only** — no MCP server, no behavior change — that unblock auto-generating MCP `inputSchema`.

### What
- Adds `schemars = "1"` (emits JSON Schema **2020-12**, MCP's default; MSRV 1.96 OK — verified by the CI `msrv` job).
- Derives `schemars::JsonSchema` on the **~21 `commands::*` core-input structs** (already `Deserialize` + `serde(default)` + `///`-documented) + their domain/transitive enums (GatherDirection, DeadConfidence, GateThreshold, RerankerMode, a `definitions` ValueEnum, the parser edge-kind enum — with `rename_all` matching the wire/CLI casing).
- `args.rs` clap structs are **untouched**.
- Smoke test asserts the core schemas are **optional + described + round-trip**, and that enum fields use CLI casing.

### Why these structs (not `args.rs`)
The `commands::*` cores are the canonical surface-agnostic input (`*_core` consumes them) and are already MCP-shaped: `serde(default)` → optional params, `///` → descriptions (clap `#[arg(help)]` is invisible to schemars; args.rs would mark everything required + description-less). MCP then deserializes wire JSON → core struct → `*_core` with no clap re-parse — the anti-duplication discipline the command-core pattern was built for (the old v0.10.0 MCP's per-tool duplication is exactly what got removed). Design doc §0 records this correction + the prior-art.

### Provenance
Salvaged from a lane that finished its edits + gates but died (session restart killed its MSRV check) before committing; re-verified here: fmt + `clippy --all-targets -D warnings` + smoke tests clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
