### PR TITLE
feat(daemon): JSON-args dispatch path (MCP Phase 1 Lane 1)

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -631,7 +631,13 @@ pub(crate) struct TaskArgs {
 }
 
 /// Arguments shared between CLI `read` and batch `read`.
-#[derive(Args, Debug, Clone)]
+///
+/// Also the surface-agnostic core that `read_core` consumes directly, so it
+/// carries `serde::Deserialize` + `schemars::JsonSchema` for the daemon
+/// JSON-args path. `#[serde(default)]` lets a wire caller supply just `path`
+/// and inherit the production default for `focus`.
+#[derive(Args, Debug, Clone, Default, serde::Deserialize, schemars::JsonSchema)]
+#[serde(default)]
 pub(crate) struct ReadArgs {
     /// File path relative to project root
     pub path: String,

--- a/src/cli/batch/json_args.rs
+++ b/src/cli/batch/json_args.rs
@@ -1,0 +1,943 @@
+//! JSON-args daemon dispatch (MCP Phase 1, D3-b).
+//!
+//! The daemon socket request frame is parsed untyped, so alongside the
+//! historical argv form
+//!
+//! ```json
+//! {"command": "search", "args": ["error handling", "-n", "3"]}
+//! ```
+//!
+//! it now accepts a JSON `arguments` object that deserializes directly into the
+//! command's Phase-0 core input struct:
+//!
+//! ```json
+//! {"command": "search", "arguments": {"query": "error handling", "limit": 3}}
+//! ```
+//!
+//! ## The routing invariant
+//!
+//! The JSON-args path MUST reach the handler through the SAME downstream
+//! dispatch the argv path uses — [`super::commands::dispatch`] →
+//! `handlers::dispatch_*` — and NEVER call a `*_core` fn directly. The argv
+//! path's only step skipped here is the clap token parse; everything after
+//! (`commands::dispatch`, the handler's overlay/path gates, validation) runs
+//! identically. The overlay-root validation
+//! ([`super::BatchView::set_validated_overlay_request`]) and `read`'s
+//! canonicalize + `starts_with` traversal gate both live inside the handlers,
+//! so routing through `commands::dispatch` preserves them. Calling a `*_core`
+//! directly would bypass those gates and is the bug this design forecloses.
+//!
+//! ## The args.rs ↔ core impedance
+//!
+//! The `arguments` object deserializes into the Phase-0 core struct (the one
+//! that derives `serde::Deserialize` + `schemars::JsonSchema` — the shape the
+//! MCP `inputSchema` advertises). The handlers, however, consume the `args.rs`
+//! clap structs and adapt those to the cores themselves (e.g.
+//! `daemon_query_args(SearchArgs) -> QueryArgs`, applying daemon-only postures
+//! like `always_route`). So each converter here takes the deserialized core and
+//! builds the matching `args.rs` struct, defaulting the `args.rs`-only fields
+//! that the JSON schema does not expose (`cross_project`, the overlay
+//! tri-state, `ref_name`, …) to the same values clap would leave them at when
+//! they are absent from an argv invocation. Feeding that struct through
+//! `commands::dispatch` yields output value-equal to the argv path — the
+//! parity guard.
+
+use anyhow::{bail, Result};
+use serde::de::DeserializeOwned;
+
+use crate::cli::args::{
+    BlameArgs, CallersArgs, CiArgs, ContextArgs, DeadArgs, DepsArgs, DiffArgs, DriftArgs,
+    GatherArgs, ImpactArgs, LimitArg, OnboardArgs, OverlayArgs, PlanArgs, ReadArgs, ReviewArgs,
+    ScoutArgs, SearchArgs, SimilarArgs, TestMapArgs, TraceArgs,
+};
+use crate::cli::definitions::{GateThreshold, OutputArgs, OutputFormat, TextJsonArgs};
+
+use super::commands::BatchCmd;
+
+// Core (Phase-0, JsonSchema) input structs — the deserialize targets. Aliased
+// to avoid colliding with the like-named `args.rs` clap structs above.
+// `io` / `train` are private modules in `commands`; their core structs are
+// reached through the `pub(crate) use io::<m>` re-exports at the `commands`
+// level. `search` is a `pub(crate) mod`, so its submodules are addressed
+// directly.
+use crate::cli::commands::blame::BlameArgs as BlameCore;
+use crate::cli::commands::context::ContextArgs as ContextCore;
+use crate::cli::commands::diff::DiffArgs as DiffCore;
+use crate::cli::commands::drift::DriftArgs as DriftCore;
+use crate::cli::commands::search::gather::GatherArgs as GatherCore;
+use crate::cli::commands::search::onboard::OnboardArgs as OnboardCore;
+use crate::cli::commands::search::query::QueryArgs;
+use crate::cli::commands::search::scout::ScoutArgs as ScoutCore;
+use crate::cli::commands::search::similar::SimilarArgs as SimilarCore;
+use crate::cli::commands::{
+    CalleesArgs as CalleesCore, CallersCoreArgs, CiArgs as CiCore, DeadArgs as DeadCore,
+    DepsCoreArgs, ImpactCoreArgs, PlanArgs as PlanCore, ReviewArgs as ReviewCore, TestMapCoreArgs,
+    TraceCoreArgs,
+};
+
+/// Default `TextJsonArgs` for a JSON-args-built variant. The daemon always
+/// frames JSON regardless of this flag (the handler ignores it), so the value
+/// is inert — but the variant requires it.
+fn text_json() -> TextJsonArgs {
+    TextJsonArgs { json: false }
+}
+
+/// Default `OutputArgs` (text/json/mermaid) for the impact/trace variants. As
+/// with `text_json`, the daemon downgrades non-JSON to JSON, so the value is
+/// inert on the wire.
+fn output_text() -> OutputArgs {
+    OutputArgs {
+        format: OutputFormat::Text,
+        json: false,
+    }
+}
+
+/// Deserialize an `arguments` object into the typed core `T`, mapping a serde
+/// failure onto a clear error the daemon surfaces as a parse error. `T` carries
+/// `#[serde(default)]` (struct- or field-level), so a caller omitting an
+/// optional field inherits the production default.
+///
+/// The cores do not `deny_unknown_fields`, so the cross-command overlay
+/// tri-state keys (`overlay` / `no_overlay` / `overlay_root`) ride alongside the
+/// core fields in the same object and are ignored here; [`overlay_from_args`]
+/// reads them separately and stamps the argv-side `OverlayArgs`.
+fn parse_core<T: DeserializeOwned>(command: &str, arguments: &serde_json::Value) -> Result<T> {
+    serde_json::from_value::<T>(arguments.clone())
+        .map_err(|e| anyhow::anyhow!("invalid arguments for '{command}': {e}"))
+}
+
+/// Extract the worktree-overlay tri-state from the raw `arguments` object for an
+/// overlay-capable command. The cores omit `overlay_root` (it is wire-only,
+/// hidden from `--help`), so the bridge forwards it as an optional top-level key
+/// (decision D2). Stamping it onto the argv-side `OverlayArgs` is what routes a
+/// JSON-args overlay request through the daemon's overlay-root validation gate
+/// (`set_validated_overlay_request`) — the same gate the argv `--overlay-root`
+/// flows through. A non-overlay command ignores these keys.
+fn overlay_from_args(arguments: &serde_json::Value) -> OverlayArgs {
+    let obj = match arguments.as_object() {
+        Some(o) => o,
+        None => return OverlayArgs::default(),
+    };
+    let overlay = obj
+        .get("overlay")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let no_overlay = obj
+        .get("no_overlay")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let overlay_root = obj
+        .get("overlay_root")
+        .and_then(|v| v.as_str())
+        .map(std::path::PathBuf::from);
+    OverlayArgs {
+        overlay,
+        no_overlay,
+        overlay_root,
+    }
+}
+
+/// Build the `BatchCmd` for a JSON-args request: deserialize `arguments` into
+/// the command's Phase-0 core, then construct the matching argv-side
+/// `BatchCmd` variant. The caller feeds the result into the SAME
+/// `commands::dispatch` the argv path uses.
+///
+/// An unknown command, or a command that has no Phase-0 core struct (and so is
+/// argv-only in Phase 1 — `notes`, `where`, `explain`, `read`'s siblings, the
+/// zero-arg infra commands, …), returns an error rather than dispatching.
+pub(super) fn build_batch_cmd(command: &str, arguments: &serde_json::Value) -> Result<BatchCmd> {
+    let _span = tracing::info_span!("json_args_build_cmd", command).entered();
+
+    let cmd = match command {
+        "search" => {
+            let c: QueryArgs = parse_core(command, arguments)?;
+            BatchCmd::Search {
+                args: search_args_from_core(c, overlay_from_args(arguments)),
+                output: text_json(),
+            }
+        }
+        "gather" => {
+            let c: GatherCore = parse_core(command, arguments)?;
+            BatchCmd::Gather {
+                args: gather_args_from_core(c, overlay_from_args(arguments)),
+                output: text_json(),
+            }
+        }
+        "scout" => {
+            let c: ScoutCore = parse_core(command, arguments)?;
+            BatchCmd::Scout {
+                args: scout_args_from_core(c, overlay_from_args(arguments)),
+                output: text_json(),
+            }
+        }
+        "onboard" => {
+            let c: OnboardCore = parse_core(command, arguments)?;
+            BatchCmd::Onboard {
+                args: onboard_args_from_core(c),
+                output: text_json(),
+            }
+        }
+        "similar" => {
+            let c: SimilarCore = parse_core(command, arguments)?;
+            BatchCmd::Similar {
+                args: similar_args_from_core(c),
+                output: text_json(),
+            }
+        }
+        "callers" => {
+            let c: CallersCoreArgs = parse_core(command, arguments)?;
+            BatchCmd::Callers {
+                args: callers_args_from_core(
+                    c.name,
+                    c.limit,
+                    c.edge_kind,
+                    overlay_from_args(arguments),
+                ),
+                output: text_json(),
+            }
+        }
+        "callees" => {
+            let c: CalleesCore = parse_core(command, arguments)?;
+            BatchCmd::Callees {
+                args: callers_args_from_core(
+                    c.name,
+                    c.limit,
+                    c.edge_kind,
+                    overlay_from_args(arguments),
+                ),
+                output: text_json(),
+            }
+        }
+        "deps" => {
+            let c: DepsCoreArgs = parse_core(command, arguments)?;
+            BatchCmd::Deps {
+                args: deps_args_from_core(c),
+                output: text_json(),
+            }
+        }
+        "impact" => {
+            let c: ImpactCoreArgs = parse_core(command, arguments)?;
+            BatchCmd::Impact {
+                args: impact_args_from_core(c, overlay_from_args(arguments)),
+                output: output_text(),
+            }
+        }
+        "test-map" => {
+            let c: TestMapCoreArgs = parse_core(command, arguments)?;
+            BatchCmd::TestMap {
+                args: test_map_args_from_core(c)?,
+                output: text_json(),
+            }
+        }
+        "trace" => {
+            let c: TraceCoreArgs = parse_core(command, arguments)?;
+            BatchCmd::Trace {
+                args: trace_args_from_core(c)?,
+                output: output_text(),
+            }
+        }
+        "blame" => {
+            let c: BlameCore = parse_core(command, arguments)?;
+            BatchCmd::Blame {
+                args: blame_args_from_core(c),
+                output: text_json(),
+            }
+        }
+        "context" => {
+            let c: ContextCore = parse_core(command, arguments)?;
+            BatchCmd::Context {
+                args: context_args_from_core(c),
+                output: text_json(),
+            }
+        }
+        "diff" => {
+            let c: DiffCore = parse_core(command, arguments)?;
+            BatchCmd::Diff {
+                args: diff_args_from_core(c),
+                output: text_json(),
+            }
+        }
+        "drift" => {
+            let c: DriftCore = parse_core(command, arguments)?;
+            BatchCmd::Drift {
+                args: drift_args_from_core(c),
+                output: text_json(),
+            }
+        }
+        "dead" => {
+            let c: DeadCore = parse_core(command, arguments)?;
+            BatchCmd::Dead {
+                args: dead_args_from_core(c, overlay_from_args(arguments)),
+                output: text_json(),
+            }
+        }
+        "ci" => {
+            let c: CiCore = parse_core(command, arguments)?;
+            BatchCmd::Ci {
+                args: ci_args_from_core(c, overlay_from_args(arguments)),
+                output: text_json(),
+            }
+        }
+        "review" => {
+            let c: ReviewCore = parse_core(command, arguments)?;
+            BatchCmd::Review {
+                args: review_args_from_core(c, overlay_from_args(arguments)),
+                output: text_json(),
+            }
+        }
+        "plan" => {
+            let c: PlanCore = parse_core(command, arguments)?;
+            BatchCmd::Plan {
+                args: plan_args_from_core(c),
+                output: text_json(),
+            }
+        }
+        "read" => {
+            // `ReadArgs` IS the core (`read_core` consumes it directly), so the
+            // deserialize target and the variant field are the same struct.
+            let c: ReadArgs = parse_core(command, arguments)?;
+            BatchCmd::Read {
+                args: c,
+                output: text_json(),
+            }
+        }
+        other => bail!(
+            "command '{other}' does not accept a JSON `arguments` object \
+             (no Phase-0 core struct); use the argv `args` form"
+        ),
+    };
+    Ok(cmd)
+}
+
+// ─── Core → args.rs converters ─────────────────────────────────────────────
+//
+// Each builds the argv-side struct from the Phase-0 core, defaulting the
+// fields the JSON schema does not expose to the values clap leaves them at when
+// absent from an argv invocation (so the parity holds against an argv call that
+// also omits them).
+
+fn search_args_from_core(c: QueryArgs, overlay: OverlayArgs) -> SearchArgs {
+    use crate::cli::args::RerankerMode;
+    SearchArgs {
+        query: c.query,
+        limit_arg: LimitArg { limit: c.limit },
+        threshold: c.threshold,
+        name_boost: c.name_boost,
+        lang: c.lang,
+        include_type: c.include_type,
+        exclude_type: c.exclude_type,
+        path: c.path,
+        pattern: c.pattern,
+        name_only: c.name_only,
+        rrf: c.rrf,
+        include_docs: c.include_docs,
+        reranker: if c.rerank {
+            Some(RerankerMode::Onnx)
+        } else {
+            None
+        },
+        splade: c.splade,
+        splade_alpha: c.splade_alpha,
+        no_content: false,
+        context: None,
+        expand_parent: c.expand_parent,
+        ref_name: None,
+        include_refs: false,
+        tokens: c.tokens,
+        no_stale_check: false,
+        no_demote: c.no_demote,
+        // The core's `record_rank_signals` is the inverse of the CLI flag; the
+        // daemon adapter recomputes it as `!no_rank_signals`, so map it back.
+        no_rank_signals: !c.record_rank_signals,
+        overlay,
+    }
+}
+
+fn gather_args_from_core(c: GatherCore, overlay: OverlayArgs) -> GatherArgs {
+    GatherArgs {
+        query: c.query,
+        depth: c.depth,
+        direction: c.direction,
+        limit_arg: LimitArg { limit: c.limit },
+        tokens: c.tokens,
+        ref_name: None,
+        overlay,
+    }
+}
+
+fn scout_args_from_core(c: ScoutCore, overlay: OverlayArgs) -> ScoutArgs {
+    ScoutArgs {
+        query: c.query,
+        limit_arg: LimitArg { limit: c.limit },
+        tokens: c.tokens,
+        search_limit: c.search_limit,
+        search_threshold: c.search_threshold,
+        min_gap_ratio: c.min_gap_ratio,
+        overlay,
+    }
+}
+
+fn onboard_args_from_core(c: OnboardCore) -> OnboardArgs {
+    OnboardArgs {
+        query: c.query,
+        depth: c.depth,
+        direction: c.direction,
+        tokens: c.tokens,
+        limit_arg: LimitArg { limit: c.limit },
+    }
+}
+
+fn similar_args_from_core(c: SimilarCore) -> SimilarArgs {
+    SimilarArgs {
+        name: c.name,
+        limit_arg: LimitArg { limit: c.limit },
+        threshold: c.threshold,
+        lang: None,
+        path: None,
+    }
+}
+
+fn callers_args_from_core(
+    name: String,
+    limit: usize,
+    edge_kind: Option<cqs::parser::CallEdgeKind>,
+    overlay: OverlayArgs,
+) -> CallersArgs {
+    CallersArgs {
+        name,
+        cross_project: false,
+        edge_kind: edge_kind.map(|k| k.as_str().to_string()),
+        limit_arg: LimitArg { limit },
+        overlay,
+    }
+}
+
+fn deps_args_from_core(c: DepsCoreArgs) -> DepsArgs {
+    DepsArgs {
+        name: c.name,
+        reverse: c.reverse,
+        cross_project: false,
+        limit_arg: LimitArg { limit: c.limit },
+    }
+}
+
+fn impact_args_from_core(c: ImpactCoreArgs, overlay: OverlayArgs) -> ImpactArgs {
+    ImpactArgs {
+        name: c.name,
+        depth: c.depth,
+        suggest_tests: c.suggest_tests,
+        // Core `include_types` ↔ args.rs `type_impact` (same flag, two names).
+        type_impact: c.include_types,
+        cross_project: false,
+        limit_arg: LimitArg { limit: c.limit },
+        overlay,
+    }
+}
+
+fn test_map_args_from_core(c: TestMapCoreArgs) -> Result<TestMapArgs> {
+    // args.rs `depth` is a clap-bounded `u16` (1..=50). The core `max_depth` is
+    // `usize`; reject an out-of-range value with the same shape clap would,
+    // rather than silently truncating. `max_nodes` is env-resolved in the
+    // handler and has no argv flag, so it does not round-trip (consistent with
+    // the argv path, which also cannot set it).
+    let depth = u16::try_from(c.max_depth)
+        .ok()
+        .filter(|d| (1..=50).contains(d))
+        .ok_or_else(|| anyhow::anyhow!("max_depth must be in 1..=50, got {}", c.max_depth))?;
+    Ok(TestMapArgs {
+        name: c.name,
+        depth,
+        cross_project: false,
+        limit_arg: LimitArg { limit: c.limit },
+    })
+}
+
+fn trace_args_from_core(c: TraceCoreArgs) -> Result<TraceArgs> {
+    let max_depth = u16::try_from(c.max_depth)
+        .ok()
+        .filter(|d| (1..=50).contains(d))
+        .ok_or_else(|| anyhow::anyhow!("max_depth must be in 1..=50, got {}", c.max_depth))?;
+    Ok(TraceArgs {
+        source: c.source,
+        target: c.target,
+        max_depth,
+        cross_project: false,
+        limit_arg: LimitArg {
+            limit: crate::cli::args::DEFAULT_LIMIT,
+        },
+    })
+}
+
+fn blame_args_from_core(c: BlameCore) -> BlameArgs {
+    BlameArgs {
+        name: c.name,
+        commits: c.commits,
+        callers: c.callers,
+    }
+}
+
+fn context_args_from_core(c: ContextCore) -> ContextArgs {
+    ContextArgs {
+        path: c.path,
+        summary: c.summary,
+        compact: c.compact,
+        tokens: c.tokens,
+    }
+}
+
+fn diff_args_from_core(c: DiffCore) -> DiffArgs {
+    // The core's `target` is a non-optional String (defaulting to "project");
+    // the argv-side `target` is `Option<String>`. `cmd_diff`/`dispatch_diff`
+    // treat `None` as "project", so map the core default back to `None` to keep
+    // the wire shape identical to an argv call that omits the target.
+    let target = if c.target == "project" {
+        None
+    } else {
+        Some(c.target)
+    };
+    DiffArgs {
+        source: c.source,
+        target,
+        threshold: c.threshold,
+        lang: c.lang,
+    }
+}
+
+fn drift_args_from_core(c: DriftCore) -> DriftArgs {
+    DriftArgs {
+        reference: c.reference,
+        threshold: c.threshold,
+        min_drift: c.min_drift,
+        lang: c.lang,
+        limit: c.limit,
+    }
+}
+
+fn dead_args_from_core(c: DeadCore, overlay: OverlayArgs) -> DeadArgs {
+    DeadArgs {
+        include_pub: c.include_pub,
+        min_confidence: c.min_confidence,
+        // Core verdict is the typed enum; the argv-side field is the stable
+        // string the handler re-parses via `DeadVerdict::parse`.
+        verdict: c.verdict.map(|v| v.as_str().to_string()),
+        overlay,
+    }
+}
+
+fn ci_args_from_core(c: CiCore, overlay: OverlayArgs) -> CiArgs {
+    CiArgs {
+        base: None,
+        stdin: false,
+        // Mirrors the clap `--gate` default ("high") so a JSON-args `ci` gates
+        // identically to an argv `ci` that omits `--gate`.
+        gate: GateThreshold::High,
+        tokens: c.tokens,
+        overlay,
+    }
+}
+
+fn review_args_from_core(c: ReviewCore, overlay: OverlayArgs) -> ReviewArgs {
+    ReviewArgs {
+        base: None,
+        stdin: false,
+        tokens: c.tokens,
+        overlay,
+    }
+}
+
+fn plan_args_from_core(c: PlanCore) -> PlanArgs {
+    PlanArgs {
+        description: c.description,
+        limit_arg: LimitArg { limit: c.limit },
+        tokens: c.tokens,
+    }
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::batch::{create_test_context, dispatch_via_view, dispatch_via_view_json};
+    use cqs::embedder::Embedding;
+    use cqs::parser::{CallEdgeKind, CallSite, Chunk, ChunkType, FunctionCalls, Language};
+    use cqs::store::{ModelInfo, Store};
+    use serde_json::json;
+    use std::path::{Path, PathBuf};
+    use tempfile::TempDir;
+
+    fn make_chunk(id: &str, name: &str) -> Chunk {
+        let content = format!("fn {name}() {{ }}");
+        let content_hash = blake3::hash(content.as_bytes()).to_hex().to_string();
+        Chunk {
+            id: id.to_string(),
+            file: PathBuf::from("src/lib.rs"),
+            language: Language::Rust,
+            chunk_type: ChunkType::Function,
+            name: name.to_string(),
+            signature: format!("fn {name}()"),
+            content,
+            doc: None,
+            line_start: 1,
+            line_end: 5,
+            byte_start: 0,
+            content_hash,
+            canonical_hash: String::new(),
+            parent_id: None,
+            window_idx: None,
+            parent_type_name: None,
+            parser_version: 0,
+        }
+    }
+
+    /// Seed two functions with one caller→callee edge, plus a `src/lib.rs` file
+    /// on disk under the project root so `read` can resolve a real path. Returns
+    /// the tempdir (root) and a daemon `BatchContext` over the index.
+    fn seed_ctx() -> (TempDir, crate::cli::batch::BatchContext) {
+        let dir = TempDir::new().expect("tempdir");
+        let cqs_dir = dir.path().join(".cqs");
+        std::fs::create_dir_all(&cqs_dir).expect("mkdir .cqs");
+        // A real source file under the root for the `read` path tests.
+        std::fs::create_dir_all(dir.path().join("src")).expect("mkdir src");
+        std::fs::write(
+            dir.path().join("src/lib.rs"),
+            "fn caller_fn() { callee_fn(); }\nfn callee_fn() {}\n",
+        )
+        .expect("write src/lib.rs");
+        let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
+
+        let mut emb_vec = vec![0.0_f32; cqs::EMBEDDING_DIM];
+        emb_vec[0] = 1.0;
+        let embedding = Embedding::new(emb_vec);
+        {
+            let store = Store::open(&index_path).expect("open store");
+            store.init(&ModelInfo::default()).expect("init");
+            let chunks = vec![
+                (
+                    make_chunk("src/lib.rs:1:caller", "caller_fn"),
+                    embedding.clone(),
+                ),
+                (
+                    make_chunk("src/lib.rs:2:callee", "callee_fn"),
+                    embedding.clone(),
+                ),
+            ];
+            store
+                .upsert_chunks_batch(&chunks, Some(0))
+                .expect("upsert chunks");
+            let fc = FunctionCalls {
+                name: "caller_fn".to_string(),
+                line_start: 1,
+                calls: vec![CallSite {
+                    callee_name: "callee_fn".to_string(),
+                    line_number: 1,
+                    kind: CallEdgeKind::Call,
+                }],
+            };
+            store
+                .upsert_function_calls(Path::new("src/lib.rs"), &[fc])
+                .expect("upsert function call");
+        }
+        let ctx = create_test_context(&cqs_dir).expect("create_test_context");
+        (dir, ctx)
+    }
+
+    /// Run a command via the argv path and the JSON-args path against the same
+    /// view, returning the two parsed response envelopes for comparison.
+    fn run_both(
+        ctx: &crate::cli::batch::BatchContext,
+        command: &str,
+        argv: &[&str],
+        arguments: serde_json::Value,
+    ) -> (serde_json::Value, serde_json::Value) {
+        let argv: Vec<String> = argv.iter().map(|s| s.to_string()).collect();
+        let mut out_argv = Vec::new();
+        dispatch_via_view(&ctx.build_view(None), command, &argv, &mut out_argv);
+        let mut out_json = Vec::new();
+        dispatch_via_view_json(&ctx.build_view(None), command, &arguments, &mut out_json);
+        let v_argv: serde_json::Value =
+            serde_json::from_slice(&out_argv).expect("argv output is JSON");
+        let v_json: serde_json::Value =
+            serde_json::from_slice(&out_json).expect("json-args output is JSON");
+        (v_argv, v_json)
+    }
+
+    /// The core guard: the JSON-args dispatch must be value-equal to the argv
+    /// dispatch for the same logical request, across an embedder-free spread.
+    #[test]
+    fn parity_json_args_equals_argv() {
+        let (_dir, ctx) = seed_ctx();
+        // (command, argv, JSON arguments)
+        let cases: Vec<(&str, Vec<&str>, serde_json::Value)> = vec![
+            ("callers", vec!["callee_fn"], json!({"name": "callee_fn"})),
+            ("callees", vec!["caller_fn"], json!({"name": "caller_fn"})),
+            ("deps", vec!["caller_fn"], json!({"name": "caller_fn"})),
+            ("dead", vec![], json!({})),
+            ("impact", vec!["callee_fn"], json!({"name": "callee_fn"})),
+            ("test-map", vec!["callee_fn"], json!({"name": "callee_fn"})),
+            (
+                "trace",
+                vec!["caller_fn", "callee_fn"],
+                json!({"source": "caller_fn", "target": "callee_fn"}),
+            ),
+            ("context", vec!["src/lib.rs"], json!({"path": "src/lib.rs"})),
+            ("read", vec!["src/lib.rs"], json!({"path": "src/lib.rs"})),
+        ];
+        for (command, argv, arguments) in cases {
+            let (v_argv, v_json) = run_both(&ctx, command, &argv, arguments);
+            // Guard against a false-equal where BOTH paths error identically:
+            // a happy-path command must carry `data`, not an `error`.
+            assert!(
+                v_argv.get("data").is_some_and(|d| !d.is_null()),
+                "argv path for `{command}` should return data, got: {v_argv}"
+            );
+            assert_eq!(
+                v_argv, v_json,
+                "JSON-args output must equal argv output for `{command}`\nargv:  {v_argv}\njson:  {v_json}"
+            );
+        }
+    }
+
+    /// Non-default-value parity: a JSON-args request that sets explicit fields
+    /// matches the argv request carrying the equivalent flags. Guards the
+    /// converters' field mapping (limit, edge_kind, depth) against silent drops.
+    #[test]
+    fn parity_json_args_with_explicit_fields() {
+        let (_dir, ctx) = seed_ctx();
+        let cases: Vec<(&str, Vec<&str>, serde_json::Value)> = vec![
+            (
+                "callers",
+                vec!["callee_fn", "--limit", "3", "--edge-kind", "call"],
+                json!({"name": "callee_fn", "limit": 3, "edge_kind": "call"}),
+            ),
+            (
+                "impact",
+                vec!["callee_fn", "--depth", "2", "--limit", "7", "--type-impact"],
+                json!({"name": "callee_fn", "depth": 2, "limit": 7, "include_types": true}),
+            ),
+            (
+                "dead",
+                vec!["--include-pub", "--min-confidence", "high"],
+                json!({"include_pub": true, "min_confidence": "high"}),
+            ),
+        ];
+        for (command, argv, arguments) in cases {
+            let (v_argv, v_json) = run_both(&ctx, command, &argv, arguments);
+            assert_eq!(
+                v_argv, v_json,
+                "JSON-args output must equal argv output for `{command}` with explicit fields\nargv:  {v_argv}\njson:  {v_json}"
+            );
+        }
+    }
+
+    /// A missing optional field deserializes via `#[serde(default)]` — an empty
+    /// `arguments` object for a command whose only required field has a default
+    /// dispatches successfully (here `dead`, all-defaulted).
+    #[test]
+    fn missing_optional_field_uses_default() {
+        let (_dir, ctx) = seed_ctx();
+        let mut out = Vec::new();
+        dispatch_via_view_json(&ctx.build_view(None), "dead", &json!({}), &mut out);
+        let v: serde_json::Value = serde_json::from_slice(&out).expect("JSON");
+        assert!(
+            v.get("data").is_some() && v.get("error").is_none_or(|e| e.is_null()),
+            "empty arguments must dispatch successfully via serde defaults, got: {v}"
+        );
+    }
+
+    /// An out-of-tree `overlay_root` carried in a JSON-args request is rejected
+    /// by the SAME overlay-root validation gate the argv path uses — proving the
+    /// JSON relay routes through `dispatch_*`, not a `*_core` bypass. Covers a
+    /// call-graph command (`callers`) and `dead`.
+    #[test]
+    fn overlay_root_out_of_tree_rejected_on_json_path() {
+        let (_dir, ctx) = seed_ctx();
+        for (command, arguments) in [
+            (
+                "callers",
+                json!({"name": "callee_fn", "overlay": true, "overlay_root": "/etc"}),
+            ),
+            ("dead", json!({"overlay": true, "overlay_root": "/etc"})),
+        ] {
+            let mut out = Vec::new();
+            dispatch_via_view_json(&ctx.build_view(None), command, &arguments, &mut out);
+            let v: serde_json::Value = serde_json::from_slice(&out).expect("JSON");
+            let err = v.get("error");
+            assert!(
+                err.is_some_and(|e| !e.is_null()),
+                "an out-of-tree overlay_root must be rejected on the JSON-args path for `{command}`, got: {v}"
+            );
+        }
+    }
+
+    /// A `read` request with a path that escapes the project root is blocked on
+    /// the JSON-args path by `read_core`'s canonicalize + starts_with gate — the
+    /// gate is reached because the relay routes through `dispatch_read`, never
+    /// `read_core` directly.
+    #[test]
+    fn read_path_traversal_blocked_on_json_path() {
+        let (_dir, ctx) = seed_ctx();
+        let mut out = Vec::new();
+        dispatch_via_view_json(
+            &ctx.build_view(None),
+            "read",
+            &json!({"path": "../../../../etc/hostname"}),
+            &mut out,
+        );
+        let v: serde_json::Value = serde_json::from_slice(&out).expect("JSON");
+        let err = v.get("error");
+        assert!(
+            err.is_some_and(|e| !e.is_null()),
+            "a path-traversal `read` must be blocked on the JSON-args path, got: {v}"
+        );
+    }
+
+    /// An unknown command with an `arguments` object returns a clean error
+    /// envelope, never a panic.
+    #[test]
+    fn unknown_command_returns_clean_error() {
+        let (_dir, ctx) = seed_ctx();
+        let mut out = Vec::new();
+        dispatch_via_view_json(
+            &ctx.build_view(None),
+            "nonexistent_cmd",
+            &json!({"foo": 1}),
+            &mut out,
+        );
+        let v: serde_json::Value = serde_json::from_slice(&out).expect("JSON");
+        assert!(
+            v.get("error").is_some_and(|e| !e.is_null()),
+            "unknown command must return an error envelope, got: {v}"
+        );
+    }
+
+    /// A command that has no Phase-0 core (argv-only in P1) returns a clean
+    /// error on the JSON-args path rather than dispatching or panicking.
+    #[test]
+    fn argv_only_command_rejected_on_json_path() {
+        // `notes` / `where` / `explain` are argv-only in Phase 1.
+        let err = build_batch_cmd("where", &json!({"description": "x"}));
+        assert!(
+            err.is_err(),
+            "an argv-only command must be rejected on the JSON-args path"
+        );
+    }
+
+    /// Malformed `arguments` (a type the core cannot accept) produces a clean
+    /// deserialize error, not a panic.
+    #[test]
+    fn malformed_arguments_returns_clean_error() {
+        let (_dir, ctx) = seed_ctx();
+        let mut out = Vec::new();
+        // `callers.name` is a String; a number is invalid.
+        dispatch_via_view_json(
+            &ctx.build_view(None),
+            "callers",
+            &json!({"name": 42}),
+            &mut out,
+        );
+        let v: serde_json::Value = serde_json::from_slice(&out).expect("JSON");
+        assert!(
+            v.get("error").is_some_and(|e| !e.is_null()),
+            "malformed arguments must return an error envelope, got: {v}"
+        );
+    }
+
+    /// NUL bytes in a JSON-args string value are rejected (mirrors the argv
+    /// `reject_null_tokens` contract).
+    #[test]
+    fn nul_byte_in_arguments_rejected() {
+        let (_dir, ctx) = seed_ctx();
+        let mut out = Vec::new();
+        dispatch_via_view_json(
+            &ctx.build_view(None),
+            "callers",
+            &json!({"name": "calle\u{0000}e_fn"}),
+            &mut out,
+        );
+        let v: serde_json::Value = serde_json::from_slice(&out).expect("JSON");
+        assert!(
+            v.get("error").is_some_and(|e| !e.is_null()),
+            "a NUL byte in arguments must be rejected, got: {v}"
+        );
+    }
+
+    /// The embedder-dependent commands (search/gather/scout/onboard/similar) and
+    /// the reference commands (diff/drift) can't run hermetically without an
+    /// embedder/index, so pin their CONVERTERS instead: an `arguments` object
+    /// builds the expected `BatchCmd` variant with fields mapped correctly. This
+    /// catches a converter field-mapping regression without a GPU load.
+    #[test]
+    fn converter_builds_expected_variants() {
+        // `BatchCmd` is already in scope via `use super::*`.
+
+        // search: QueryArgs fields → SearchArgs, overlay stamped from top-level.
+        let cmd = build_batch_cmd(
+            "search",
+            &json!({"query": "q", "limit": 9, "name_only": true}),
+        )
+        .expect("search");
+        match cmd {
+            BatchCmd::Search { args, .. } => {
+                assert_eq!(args.query, "q");
+                assert_eq!(args.limit_arg.limit, 9);
+                assert!(args.name_only);
+            }
+            _ => panic!("expected Search"),
+        }
+
+        // gather: depth + direction round-trip.
+        let cmd = build_batch_cmd("gather", &json!({"query": "q", "depth": 3})).expect("gather");
+        match cmd {
+            BatchCmd::Gather { args, .. } => {
+                assert_eq!(args.query, "q");
+                assert_eq!(args.depth, 3);
+            }
+            _ => panic!("expected Gather"),
+        }
+
+        // diff: core `target` default "project" → argv-side None.
+        let cmd = build_batch_cmd("diff", &json!({"source": "v1"})).expect("diff");
+        match cmd {
+            BatchCmd::Diff { args, .. } => {
+                assert_eq!(args.source, "v1");
+                assert_eq!(args.target, None);
+            }
+            _ => panic!("expected Diff"),
+        }
+
+        // similar: name + threshold.
+        let cmd =
+            build_batch_cmd("similar", &json!({"name": "f", "threshold": 0.5})).expect("similar");
+        match cmd {
+            BatchCmd::Similar { args, .. } => {
+                assert_eq!(args.name, "f");
+                assert!((args.threshold - 0.5).abs() < 1e-6);
+            }
+            _ => panic!("expected Similar"),
+        }
+
+        // plan: description + limit.
+        let cmd =
+            build_batch_cmd("plan", &json!({"description": "do x", "limit": 4})).expect("plan");
+        match cmd {
+            BatchCmd::Plan { args, .. } => {
+                assert_eq!(args.description, "do x");
+                assert_eq!(args.limit_arg.limit, 4);
+            }
+            _ => panic!("expected Plan"),
+        }
+    }
+
+    /// `test-map` / `trace` clamp `max_depth` to the clap `u16` 1..=50 range; an
+    /// out-of-range value is a clean error, not a silent truncation or panic.
+    #[test]
+    fn out_of_range_depth_rejected() {
+        assert!(build_batch_cmd("test-map", &json!({"name": "f", "max_depth": 999})).is_err());
+        assert!(build_batch_cmd(
+            "trace",
+            &json!({"source": "a", "target": "b", "max_depth": 0})
+        )
+        .is_err());
+    }
+}

--- a/src/cli/batch/mod.rs
+++ b/src/cli/batch/mod.rs
@@ -26,6 +26,7 @@ mod handlers;
 /// from a normal build.
 #[cfg(all(cqs_loom, test))]
 mod interleaving_model;
+mod json_args;
 /// Loom model of the worktree-overlay LRU cross-thread protocol (the
 /// interleaving-auditor lane, #1858 Part A). Same `--cfg cqs_loom` + test-build
 /// gate as `interleaving_model`. Covers the load-outside-lock overlay rebuild
@@ -79,7 +80,9 @@ pub(super) type EpochCell<T> = (u64, Arc<T>);
 
 pub(crate) use context::BatchContext;
 pub(crate) use session::{cmd_batch, create_context, create_context_with_runtime};
-pub(crate) use view::{checkout_view_from_arc, dispatch_via_view, BatchView};
+pub(crate) use view::{
+    checkout_view_from_arc, dispatch_via_view, dispatch_via_view_json, BatchView,
+};
 // Shared LRU helpers live in `view` but are called from `context`'s
 // `get_ref` / `get_all_refs`; surface them at the module root so the sibling
 // reaches them via `use super::*`.

--- a/src/cli/batch/view.rs
+++ b/src/cli/batch/view.rs
@@ -161,6 +161,116 @@ pub(crate) fn dispatch_via_view(
     }
 }
 
+/// JSON-args sibling of [`dispatch_via_view`] (MCP Phase 1, D3-b).
+///
+/// Accepts a typed `arguments` object instead of an argv `args` array,
+/// deserializes it into the command's Phase-0 core struct
+/// ([`super::json_args::build_batch_cmd`]), and feeds the resulting `BatchCmd`
+/// into the SAME [`commands::dispatch`] the argv path uses. The ONLY argv step
+/// skipped is the clap token parse; the Refresh special-case, the downstream
+/// handler overlay/path gates, error redaction, and the envelope contract are
+/// all shared. The routing invariant: the JSON path never calls a `*_core` fn
+/// directly, so the overlay-root validation
+/// ([`BatchView::set_validated_overlay_request`]) and `read`'s traversal gate
+/// fire identically to argv.
+///
+/// Daemon callers MUST have already bumped `query_count` and run
+/// `check_idle_timeout` under the outer lock (as in [`dispatch_via_view`]);
+/// this function does not duplicate that work.
+pub(crate) fn dispatch_via_view_json(
+    view: &BatchView,
+    command: &str,
+    arguments: &serde_json::Value,
+    out: &mut impl std::io::Write,
+) {
+    use crate::cli::json_envelope::error_codes;
+
+    // Empty command is a no-op (parity with the argv path).
+    if command.is_empty() {
+        return;
+    }
+
+    // NUL byte rejection — same contract as the argv path, but over the JSON
+    // string values rather than argv tokens (serde decodes ` ` into a
+    // String, so a structural walk is the equivalent check).
+    if json_value_contains_nul(arguments) {
+        view.error_count.fetch_add(1, Ordering::Relaxed);
+        tracing::warn!(
+            code = error_codes::INVALID_INPUT,
+            "Daemon JSON-args dispatch: NUL byte in arguments"
+        );
+        let _ = write_envelope_error(out, error_codes::INVALID_INPUT, "Input contains null bytes");
+        return;
+    }
+    // query_count bumped after the NUL check, matching the argv path's contract
+    // (NUL rejection does not count as a query).
+    view.query_count.fetch_add(1, Ordering::Relaxed);
+
+    let cmd = match super::json_args::build_batch_cmd(command, arguments) {
+        Ok(cmd) => cmd,
+        Err(e) => {
+            view.error_count.fetch_add(1, Ordering::Relaxed);
+            let msg = format!("{e:#}");
+            tracing::warn!(
+                code = error_codes::INVALID_INPUT,
+                error = %msg,
+                "Daemon JSON-args dispatch: argument deserialization failed"
+            );
+            let _ = write_envelope_error(out, error_codes::INVALID_INPUT, &msg);
+            return;
+        }
+    };
+
+    // Refresh is the only daemon-dispatchable command that mutates BatchContext
+    // interior; it re-locks via the view's outer back-channel, exactly as the
+    // argv path does. (It carries no `arguments`, so this is unreachable on the
+    // JSON path today, but kept in lock-step so the two paths can't diverge if
+    // Refresh ever gains a JSON shape.)
+    if matches!(cmd, commands::BatchCmd::Refresh) {
+        match view.invalidate_via_outer() {
+            Ok(()) => {
+                let _ = write_json_line(
+                    out,
+                    &serde_json::json!({
+                        "status": "ok",
+                        "message": "Caches invalidated, Store re-opened",
+                    }),
+                );
+            }
+            Err(e) => {
+                view.error_count.fetch_add(1, Ordering::Relaxed);
+                let (code, msg) = crate::cli::json_envelope::redact_error(&e);
+                let _ = write_envelope_error(out, code.as_str(), &msg);
+            }
+        }
+        return;
+    }
+
+    match commands::dispatch(view, cmd) {
+        Ok(value) => {
+            let _ = write_json_line(out, &value);
+        }
+        Err(e) => {
+            view.error_count.fetch_add(1, Ordering::Relaxed);
+            let (code, msg) = crate::cli::json_envelope::redact_error(&e);
+            let _ = write_envelope_error(out, code.as_str(), &msg);
+        }
+    }
+}
+
+/// Recursively test whether any string in a JSON value contains a NUL byte.
+/// The JSON-args NUL gate (mirrors the argv `reject_null_tokens` contract).
+fn json_value_contains_nul(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::String(s) => s.contains('\0'),
+        serde_json::Value::Array(arr) => arr.iter().any(json_value_contains_nul),
+        serde_json::Value::Object(map) => map
+            .iter()
+            .any(|(k, v)| k.contains('\0') || json_value_contains_nul(v)),
+        _ => false,
+    }
+}
+
 /// Shared helper for `BatchContext::get_ref` and `BatchView::get_ref`.
 /// Operates directly on the LRU mutex so both paths see the same cache.
 pub(crate) fn get_ref_via_refs_lru(

--- a/src/cli/watch/adversarial_socket_tests.rs
+++ b/src/cli/watch/adversarial_socket_tests.rs
@@ -1006,3 +1006,214 @@ fn daemon_rejects_nonexistent_overlay_root_over_socket() {
     );
     join_worker(client, handle);
 }
+
+// ─────────────────────────────────────────────────────────────────────
+// JSON-args daemon path (MCP Phase 1, D3-b) — wire-level coverage.
+//
+// These drive the REAL `handle_socket_client` over a socket pair with an
+// `arguments` OBJECT instead of an `args` array, proving the new relay is
+// wired into the wire path AND that it routes through the same validated
+// `dispatch_via_view` → `dispatch_*` chain — not a `*_core` bypass. The
+// in-process `cli::batch::json_args::tests` cover the converter + dispatch
+// unit; these are the end-to-end socket guards.
+// ─────────────────────────────────────────────────────────────────────
+
+/// Seed a store with one caller→callee edge and a real `src/lib.rs` on disk,
+/// returning the tempdir and a daemon context. Mirrors the call-graph seed in
+/// `batch::json_args::tests` but produces an `Arc<Mutex<BatchContext>>` for the
+/// socket harness.
+fn seed_call_graph_ctx() -> (
+    tempfile::TempDir,
+    Arc<Mutex<crate::cli::batch::BatchContext>>,
+) {
+    use cqs::parser::{CallEdgeKind, CallSite, Chunk, ChunkType, FunctionCalls, Language};
+    use cqs::store::ModelInfo;
+    use std::path::{Path, PathBuf};
+
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let cqs_dir = dir.path().join(".cqs");
+    std::fs::create_dir_all(&cqs_dir).expect("mkdir .cqs");
+    std::fs::create_dir_all(dir.path().join("src")).expect("mkdir src");
+    std::fs::write(
+        dir.path().join("src/lib.rs"),
+        "fn caller_fn() { callee_fn(); }\nfn callee_fn() {}\n",
+    )
+    .expect("write src/lib.rs");
+    let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
+
+    let mut emb_vec = vec![0.0_f32; cqs::EMBEDDING_DIM];
+    emb_vec[0] = 1.0;
+    let embedding = cqs::embedder::Embedding::new(emb_vec);
+    let make = |id: &str, name: &str| -> Chunk {
+        let content = format!("fn {name}() {{ }}");
+        Chunk {
+            id: id.to_string(),
+            file: PathBuf::from("src/lib.rs"),
+            language: Language::Rust,
+            chunk_type: ChunkType::Function,
+            name: name.to_string(),
+            signature: format!("fn {name}()"),
+            content: content.clone(),
+            doc: None,
+            line_start: 1,
+            line_end: 5,
+            byte_start: 0,
+            content_hash: blake3::hash(content.as_bytes()).to_hex().to_string(),
+            canonical_hash: String::new(),
+            parent_id: None,
+            window_idx: None,
+            parent_type_name: None,
+            parser_version: 0,
+        }
+    };
+    {
+        let store = cqs::store::Store::open(&index_path).expect("open store");
+        store.init(&ModelInfo::default()).expect("init store");
+        store
+            .upsert_chunks_batch(
+                &[
+                    (make("src/lib.rs:1:caller", "caller_fn"), embedding.clone()),
+                    (make("src/lib.rs:2:callee", "callee_fn"), embedding.clone()),
+                ],
+                Some(0),
+            )
+            .expect("seed chunks");
+        let fc = FunctionCalls {
+            name: "caller_fn".to_string(),
+            line_start: 1,
+            calls: vec![CallSite {
+                callee_name: "callee_fn".to_string(),
+                line_number: 1,
+                kind: CallEdgeKind::Call,
+            }],
+        };
+        store
+            .upsert_function_calls(Path::new("src/lib.rs"), &[fc])
+            .expect("seed edge");
+    }
+    let ctx = crate::cli::batch::create_test_context(&cqs_dir).expect("create ctx");
+    (dir, Arc::new(Mutex::new(ctx)))
+}
+
+/// Happy path: a JSON-args `callers` request round-trips through the real
+/// socket handler and returns the seeded caller, proving the `arguments`-object
+/// relay is wired into `handle_socket_client` and dispatches correctly.
+#[test]
+fn daemon_json_args_callers_roundtrip() {
+    let (_dir, ctx) = seed_call_graph_ctx();
+    let (mut client, handle) = spawn_handler(Arc::clone(&ctx));
+    let request = serde_json::json!({
+        "command": "callers",
+        "arguments": {"name": "callee_fn"},
+    });
+    client
+        .write_all(format!("{request}\n").as_bytes())
+        .expect("write json-args callers request");
+    let line = read_line(&mut client);
+    let resp = parse_response(&line);
+    assert_eq!(
+        resp.get("status").and_then(|v| v.as_str()),
+        Some("ok"),
+        "json-args happy path must carry status:ok: {line}"
+    );
+    let callers = resp
+        .pointer("/output/data/callers")
+        .and_then(|v| v.as_array())
+        .unwrap_or_else(|| panic!("expected output.data.callers array: {line}"));
+    assert!(
+        callers.iter().any(|c| c["name"] == "caller_fn"),
+        "json-args callers must surface the seeded caller_fn: {line}"
+    );
+    join_worker(client, handle);
+}
+
+/// A foreign `overlay_root` carried in a JSON-args request is rejected by the
+/// SAME overlay-root validation gate the argv path uses, proven end-to-end over
+/// the socket. The relay routes through `dispatch_callers` →
+/// `resolve_graph_overlay` → `set_validated_overlay_request`, never a `*_core`
+/// bypass.
+#[test]
+fn daemon_json_args_rejects_foreign_overlay_root() {
+    let foreign = tempfile::TempDir::new().expect("foreign tempdir");
+    const SECRET: &str = "REDTEAM_JSON_OVERLAY_ESCAPE_CANARY_3b9f";
+    std::fs::write(
+        foreign.path().join("leak_me.rs"),
+        format!("pub fn x() {{ let s = \"{SECRET}\"; }}\n"),
+    )
+    .expect("plant secret file");
+    let foreign_path = foreign.path().to_string_lossy().into_owned();
+
+    let (_dir, ctx) = seed_call_graph_ctx();
+    let (mut client, handle) = spawn_handler(Arc::clone(&ctx));
+    let request = serde_json::json!({
+        "command": "callers",
+        "arguments": {
+            "name": "callee_fn",
+            "overlay": true,
+            "overlay_root": foreign_path,
+        },
+    });
+    client
+        .write_all(format!("{request}\n").as_bytes())
+        .expect("write json-args overlay-root attack");
+    let line = read_line(&mut client);
+    let resp = parse_response(&line);
+    assert!(
+        !line.contains(SECRET),
+        "SECURITY: foreign overlay_root content leaked over the JSON-args socket path: {line}"
+    );
+    let inner_err = resp.pointer("/output/error").is_some();
+    let top_err = resp.get("status").and_then(|v| v.as_str()) == Some("error");
+    assert!(
+        inner_err || top_err,
+        "a foreign overlay_root on the JSON-args path must be rejected loudly: {line}"
+    );
+    join_worker(client, handle);
+}
+
+/// A `read` with a path that escapes the project root is blocked on the
+/// JSON-args socket path by `read_core`'s canonicalize + starts_with gate.
+#[test]
+fn daemon_json_args_read_path_traversal_blocked() {
+    let (_dir, ctx) = seed_call_graph_ctx();
+    let (mut client, handle) = spawn_handler(Arc::clone(&ctx));
+    let request = serde_json::json!({
+        "command": "read",
+        "arguments": {"path": "../../../../etc/hostname"},
+    });
+    client
+        .write_all(format!("{request}\n").as_bytes())
+        .expect("write json-args traversal read");
+    let line = read_line(&mut client);
+    let resp = parse_response(&line);
+    let inner_err = resp.pointer("/output/error").is_some();
+    let top_err = resp.get("status").and_then(|v| v.as_str()) == Some("error");
+    assert!(
+        inner_err || top_err,
+        "a path-traversal read on the JSON-args path must be blocked: {line}"
+    );
+    join_worker(client, handle);
+}
+
+/// A non-object `arguments` (here an array) is rejected at the socket boundary
+/// rather than silently treated as an argv call.
+#[test]
+fn daemon_json_args_rejects_non_object_arguments() {
+    let (_dir, ctx) = seed_call_graph_ctx();
+    let (mut client, handle) = spawn_handler(Arc::clone(&ctx));
+    let request = serde_json::json!({
+        "command": "callers",
+        "arguments": ["callee_fn"],
+    });
+    client
+        .write_all(format!("{request}\n").as_bytes())
+        .expect("write non-object arguments");
+    let line = read_line(&mut client);
+    let resp = parse_response(&line);
+    assert_eq!(
+        resp.get("status").and_then(|v| v.as_str()),
+        Some("error"),
+        "a non-object `arguments` must be rejected at the socket boundary: {line}"
+    );
+    join_worker(client, handle);
+}

--- a/src/cli/watch/socket.rs
+++ b/src/cli/watch/socket.rs
@@ -173,12 +173,44 @@ pub(super) fn handle_socket_client(
         .get("command")
         .and_then(|v| v.as_str())
         .unwrap_or("");
+    // JSON-args path (MCP Phase 1, D3-b): an `arguments` OBJECT deserializes
+    // directly into the command's Phase-0 core struct, dispatched through the
+    // SAME validated downstream path as the argv form. Additive: the frame is
+    // untyped, so an absent `arguments` falls through to the historical argv
+    // `args` array unchanged (no wire-version bump). A non-object `arguments`
+    // (array / scalar) is rejected rather than silently ignored, so a
+    // malformed object can't read as an argv call.
+    let arguments = request.get("arguments");
+    let use_json_args = match arguments {
+        Some(serde_json::Value::Object(_)) => true,
+        Some(serde_json::Value::Null) | None => false,
+        Some(_) => {
+            tracing::warn!(
+                command,
+                "Daemon rejected request: `arguments` must be an object"
+            );
+            let delivered =
+                write_daemon_error_tracked(&mut stream, "`arguments` must be a JSON object");
+            tracing::info!(
+                status = "bad_args",
+                delivered,
+                latency_ms = start.elapsed().as_millis() as u64,
+                "Daemon query complete"
+            );
+            return;
+        }
+    };
     // Structurally validate args. Silently dropping non-string elements
     // (numbers, nested arrays, nulls) would leave surviving args that look
     // correct while the daemon runs a half-formed command. Instead: collect
     // the indices of non-string elements, warn on them, and reject the whole
     // request as malformed rather than execute on a truncated arg list.
-    let raw_args = request.get("args").and_then(|v| v.as_array());
+    // Skipped on the JSON-args path (the typed object replaces the array).
+    let raw_args = if use_json_args {
+        None
+    } else {
+        request.get("args").and_then(|v| v.as_array())
+    };
     // Fold validation + extraction into a single walk: one pass collects
     // both the typed `Vec<String>` and a parallel `Vec<usize>` of bad
     // indices.
@@ -281,7 +313,14 @@ pub(super) fn handle_socket_client(
         // re-locked briefly inside `dispatch_via_view` via the view's
         // `outer_lock` back-channel.
         let view = crate::cli::batch::checkout_view_from_arc(batch_ctx);
-        crate::cli::batch::dispatch_via_view(&view, command, &args, &mut output);
+        match arguments {
+            Some(args_obj) if use_json_args => {
+                crate::cli::batch::dispatch_via_view_json(&view, command, args_obj, &mut output);
+            }
+            _ => {
+                crate::cli::batch::dispatch_via_view(&view, command, &args, &mut output);
+            }
+        }
         // Parse the dispatch bytes into a JSON `Value` and embed it as a real
         // JSON field of the response envelope instead of round-tripping
         // through `String::from_utf8` and embedding as a string-in-string.


### PR DESCRIPTION
## MCP Phase 1, Lane 1 — daemon JSON-args dispatch path (D3-b)

Adds support for a JSON `arguments` object in the daemon socket frame
(`{"command","arguments":{...}}`) alongside the legacy argv form — the relay the
MCP bridge (Lane 2) will use. Additive: the request frame is untyped, so no
wire-version bump and the argv path is byte-identical.

**Design (the cornerstone for the eventual untrusted-MCP-client surface):** the
JSON path deserializes `arguments` into the Phase-0 `commands::*` core struct,
converts to the matching `args.rs` clap struct, builds the `BatchCmd`, and feeds
it into the **same `commands::dispatch`** — skipping only the clap token parse.
It never calls a `*_core` fn directly, so the overlay-root and `read`-traversal
gates (which live in the handlers) fire identically on the new path.

**Tests:** 11 unit (`json_args::tests`) + 4 wire-level (`adversarial_socket_tests`,
real socket): parity JSON==argv for 9 commands with a data-presence guard,
serde-default, overlay-root rejection with a no-leak canary, `read` traversal
block, non-object/unknown/argv-only/malformed/NUL errors. Regression suites green.

**Review:** opus code-reviewer — APPROVE, risk LOW, no blockers; security invariant
enforced by construction + covered by passing wire-level tests.

Promotes `ReadArgs` to a Phase-0 core (it had no adapter — `read_core` consumes it
directly). Part of the MCP re-introduction; Lane 2 (the `cqs mcp` bridge) rides on
this.
