### PR TITLE
feat(mcp): cqs mcp stdio bridge — MCP Phase 1 Lane 2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -271,6 +271,10 @@ src/
     files.rs    - File enumeration, lock files, path utilities
     json_envelope.rs - JSON output emission helpers: emit_json/emit_json_error (CLI direct, bare-vs-v1 via EnvelopeShape), wrap_value/wrap_error (slim batch/daemon JSONL), ErrorCode taxonomy + error_codes consts, redact_error (daemon error redaction), EnvelopeMeta (_meta worktree-stale + per-response stale_origins merge), NaN/Infinity sanitization
     limits.rs   - Shared clamp ceilings + env-overridable size limits for the CLI and batch/daemon dispatchers (keeps the two paths from drifting on `--limit`). Library-layer counterpart is `src/limits.rs`.
+    mcp/        - `cqs mcp` stdio↔daemon-socket MCP bridge (Phase 1, Lane 2): a GPU-free process that speaks MCP JSON-RPC over stdio and relays each tools/call to the warm daemon as the Lane 1 JSON-args frame. Bridge-only (requires a running daemon; no in-process fallback).
+      bridge.rs   - stdin→parse→route→stdout NDJSON loop, method dispatch, per-call daemon round-trip
+      lifecycle.rs - JSON-RPC envelope types, error codes, initialize/initialized (protocol 2025-11-25)
+      tools.rs    - tools/list (read-only registry × schemars inputSchemas, cqs_-prefixed names; context/explain withheld) + tools/call envelope→CallToolResult mapping (status:ok-wrapped handler error → isError:true)
     pipeline/   - Multi-threaded indexing pipeline
       mod.rs, embedding.rs, parsing.rs, types.rs, upsert.rs, windowing.rs
       reuse.rs    - Shared embedding-reuse resolver: global cache → per-slot store cache → split chunks into reuse-cached vs embed-fresh; used by both the bulk pipeline and the watch/daemon incremental path

--- a/src/cli/commands/dispatch_shims.rs
+++ b/src/cli/commands/dispatch_shims.rs
@@ -230,6 +230,19 @@ pub fn cmd_batch_dispatch(
     })
 }
 
+pub fn cmd_mcp_dispatch(
+    _cli: &Cli,
+    _ctx: Option<&CommandContext<'_, ReadOnly>>,
+    project_cqs_dir: &Path,
+    cmd: &Commands,
+) -> Result<()> {
+    // The MCP bridge relays to the daemon serving `project_cqs_dir` — the same
+    // `.cqs` dir the CLI's own daemon-forward path uses, derived from the cwd.
+    must_be!(cmd, Commands::Mcp => {
+        crate::cli::mcp::serve_stdio(project_cqs_dir)
+    })
+}
+
 pub fn cmd_chat_dispatch(
     _cli: &Cli,
     _ctx: Option<&CommandContext<'_, ReadOnly>>,

--- a/src/cli/definitions.rs
+++ b/src/cli/definitions.rs
@@ -501,6 +501,14 @@ pub(super) enum Commands {
     /// Batch mode: read commands from stdin, output JSONL
     #[cqs_cmd(group = "a", batch = "cli")]
     Batch,
+    /// MCP server: bridge stdio JSON-RPC to the running cqs daemon
+    ///
+    /// Exposes the read-only cqs commands as MCP tools over stdio. Requires a
+    /// running daemon (`cqs watch --serve`); the bridge forwards each tool call
+    /// over the daemon socket and loads no model itself, so stdout stays a clean
+    /// JSON-RPC channel.
+    #[cqs_cmd(group = "a", batch = "cli")]
+    Mcp,
     /// Semantic git blame: who changed a function, when, and why
     #[cqs_cmd(group = "b", batch = "daemon")]
     Blame {
@@ -1730,6 +1738,7 @@ mod tests {
             "impact-diff",
             "index",
             "init",
+            "mcp",
             "model",
             "neighbors",
             "notes",

--- a/src/cli/mcp/bridge.rs
+++ b/src/cli/mcp/bridge.rs
@@ -1,0 +1,207 @@
+//! The stdio JSON-RPC loop: read framed stdin → parse → route → write framed
+//! stdout. The bridge is a CLIENT of the cqs daemon (D4a) — every `tools/call`
+//! relays the Lane 1 JSON-args frame over the daemon's unix socket.
+//!
+//! ## Framing — newline-delimited JSON (NDJSON)
+//!
+//! One JSON-RPC message per line on stdin, one per line on stdout (matching the
+//! v0.10.0 stdio transport and the daemon socket, both JSONL). NDJSON has no
+//! escaping, so the response MUST be single-line: `serde_json::to_string`
+//! (never `to_string_pretty`) keeps an embedded `\n` out of the stream.
+//!
+//! ## stdout discipline
+//!
+//! stdout carries ONLY JSON-RPC. The bridge loads no GPU/hnsw/model, so there
+//! is no library stdout noise to gag; all `tracing` routes to stderr (the
+//! subscriber in `main.rs`). The 1 MiB request-line cap is reused from the old
+//! transport.
+
+use std::io::{BufRead, Write};
+use std::path::Path;
+
+use anyhow::Result;
+
+use super::lifecycle::{self, JsonRpcRequest, JsonRpcResponse};
+use super::tools::{self, CallOutcome};
+
+/// Maximum stdin line length (1 MiB) — reused from the v0.10.0 transport.
+const MAX_LINE_LENGTH: usize = 1_048_576;
+
+/// Run the `cqs mcp` stdio bridge against the daemon serving `cqs_dir`.
+///
+/// Reads JSON-RPC requests from stdin and writes responses to stdout until EOF.
+/// Returns `Ok(())` on clean EOF; an `Err` only on an unrecoverable stdout I/O
+/// failure (a broken pipe to the client).
+pub fn serve_stdio(cqs_dir: &Path) -> Result<()> {
+    let _span = tracing::info_span!("mcp_serve_stdio", cqs_dir = %cqs_dir.display()).entered();
+    tracing::info!("cqs MCP bridge starting (stdio ↔ daemon socket)");
+
+    let stdin = std::io::stdin();
+    let mut stdout = std::io::stdout();
+
+    for line in stdin.lock().lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(e) => {
+                // A stdin read error ends the session — the client's pipe is
+                // gone. Nothing to respond to.
+                tracing::info!(error = %e, "stdin closed; MCP bridge exiting");
+                break;
+            }
+        };
+
+        // Oversized line → parse error, no id (we can't trust the contents).
+        if line.len() > MAX_LINE_LENGTH {
+            let resp = lifecycle::error(
+                None,
+                lifecycle::PARSE_ERROR,
+                format!(
+                    "request too large: {} bytes (max {MAX_LINE_LENGTH})",
+                    line.len()
+                ),
+            );
+            write_response(&mut stdout, &resp)?;
+            continue;
+        }
+
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let request: JsonRpcRequest = match serde_json::from_str(&line) {
+            Ok(req) => req,
+            Err(e) => {
+                let resp =
+                    lifecycle::error(None, lifecycle::PARSE_ERROR, format!("parse error: {e}"));
+                write_response(&mut stdout, &resp)?;
+                continue;
+            }
+        };
+
+        let response = route(cqs_dir, request);
+
+        // Notifications (no id, null result) get NO response line.
+        if response.id.is_none()
+            && response.error.is_none()
+            && response.result.as_ref().is_some_and(|v| v.is_null())
+        {
+            continue;
+        }
+
+        write_response(&mut stdout, &response)?;
+    }
+
+    tracing::info!("MCP bridge stdin EOF; exiting");
+    Ok(())
+}
+
+/// Route one parsed request by method.
+fn route(cqs_dir: &Path, request: JsonRpcRequest) -> JsonRpcResponse {
+    let id = request.id.clone();
+    match request.method.as_str() {
+        "initialize" => lifecycle::success(id, lifecycle::handle_initialize(request.params)),
+        // The `initialized` notification (both spellings) — no reply.
+        "notifications/initialized" | "initialized" => lifecycle::notification_handled(id),
+        "tools/list" => lifecycle::success(id, tools::list()),
+        "tools/call" => match tools::call(cqs_dir, request.params) {
+            CallOutcome::Result(result) => lifecycle::success(id, result),
+            CallOutcome::ProtocolError(code, message) => lifecycle::error(id, code, message),
+        },
+        // `ping` is a JSON-RPC utility method (empty result), distinct from the
+        // `cqs ping` daemon command — clients may send it as a keepalive.
+        "ping" => lifecycle::success(id, serde_json::json!({})),
+        other => lifecycle::error(
+            id,
+            lifecycle::METHOD_NOT_FOUND,
+            format!("method not found: {other}"),
+        ),
+    }
+}
+
+/// Serialize one response as a single NDJSON line and flush. NEVER pretty-print
+/// (an embedded newline corrupts the stream).
+fn write_response(stdout: &mut impl Write, resp: &JsonRpcResponse) -> Result<()> {
+    let json = serde_json::to_string(resp)?;
+    writeln!(stdout, "{json}")?;
+    stdout.flush()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn req(method: &str, id: u64, params: serde_json::Value) -> JsonRpcRequest {
+        serde_json::from_value(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn route_initialize_returns_handshake() {
+        let resp = route(
+            &PathBuf::from("/x/.cqs"),
+            req(
+                "initialize",
+                1,
+                serde_json::json!({"protocolVersion": "2025-11-25"}),
+            ),
+        );
+        let result = resp.result.expect("result");
+        assert_eq!(
+            result.get("protocolVersion").and_then(|v| v.as_str()),
+            Some(lifecycle::MCP_PROTOCOL_VERSION)
+        );
+    }
+
+    #[test]
+    fn route_tools_list_returns_tools() {
+        let resp = route(
+            &PathBuf::from("/x/.cqs"),
+            req("tools/list", 2, serde_json::json!({})),
+        );
+        let result = resp.result.expect("result");
+        let tools = result
+            .get("tools")
+            .and_then(|t| t.as_array())
+            .expect("tools");
+        assert!(tools
+            .iter()
+            .any(|t| t.get("name").and_then(|n| n.as_str()) == Some("cqs_search")));
+        // context/explain withheld.
+        assert!(!tools
+            .iter()
+            .any(|t| t.get("name").and_then(|n| n.as_str()) == Some("cqs_context")));
+    }
+
+    #[test]
+    fn route_unknown_method_is_method_not_found() {
+        let resp = route(
+            &PathBuf::from("/x/.cqs"),
+            req("bogus/method", 3, serde_json::json!({})),
+        );
+        assert_eq!(
+            resp.error.as_ref().map(|e| e.code),
+            Some(lifecycle::METHOD_NOT_FOUND)
+        );
+    }
+
+    #[test]
+    fn route_initialized_is_notification() {
+        // A notification has no id and a null result; the loop suppresses it.
+        let mut r: JsonRpcRequest = serde_json::from_value(serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized"
+        }))
+        .unwrap();
+        r.id = None;
+        let resp = route(&PathBuf::from("/x/.cqs"), r);
+        assert!(resp.id.is_none());
+        assert!(resp.result.as_ref().is_some_and(|v| v.is_null()));
+    }
+}

--- a/src/cli/mcp/lifecycle.rs
+++ b/src/cli/mcp/lifecycle.rs
@@ -1,0 +1,225 @@
+//! MCP lifecycle: JSON-RPC envelope types + `initialize` / `initialized`.
+//!
+//! The JSON-RPC types are ported verbatim from the v0.10.0 MCP server
+//! (`git show 291ec6b0^:src/mcp/types.rs`) — they were correct, and reusing
+//! them keeps the wire shape identical to the surface clients already knew.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// MCP protocol version this bridge advertises (D4d).
+///
+/// We advertise `2025-11-25` and echo it back regardless of the client's
+/// requested version, but ACCEPT any client whose `protocolVersion` is
+/// `>= 2025-06-18` (see [`handle_initialize`]) rather than hard-rejecting.
+pub const MCP_PROTOCOL_VERSION: &str = "2025-11-25";
+
+/// Minimum client protocol version the bridge will negotiate with (D4d).
+const MIN_ACCEPTED_PROTOCOL_VERSION: &str = "2025-06-18";
+
+// ─── JSON-RPC envelope (ported from 291ec6b0^:src/mcp/types.rs) ──────────────
+
+/// A JSON-RPC 2.0 request (or notification, when `id` is absent).
+#[derive(Debug, Deserialize)]
+pub struct JsonRpcRequest {
+    #[allow(dead_code)]
+    pub jsonrpc: String,
+    pub id: Option<Value>,
+    pub method: String,
+    pub params: Option<Value>,
+}
+
+/// A JSON-RPC 2.0 response. Exactly one of `result` / `error` is `Some`.
+#[derive(Debug, Serialize)]
+pub struct JsonRpcResponse {
+    pub jsonrpc: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<JsonRpcError>,
+}
+
+/// A JSON-RPC 2.0 error object.
+#[derive(Debug, Serialize)]
+pub struct JsonRpcError {
+    pub code: i32,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+}
+
+// ─── JSON-RPC error codes ────────────────────────────────────────────────────
+//
+// Protocol / framing failures map to these `-32xxx` codes; handler-semantic
+// failures do NOT (they ride as `isError:true` inside a successful
+// `tools/call` result — see `tools::call`).
+
+/// Parse error: a stdin line that is not valid JSON, or exceeds the size cap.
+pub const PARSE_ERROR: i32 = -32700;
+/// Method not found: an unknown JSON-RPC method, or an unknown `tools/call`
+/// tool name.
+pub const METHOD_NOT_FOUND: i32 = -32601;
+/// Invalid params: `tools/call` arguments that fail to deserialize into the
+/// tool's core struct.
+pub const INVALID_PARAMS: i32 = -32602;
+/// Internal error: a transport failure talking to the daemon (socket missing,
+/// connect/read/write failure, malformed daemon response).
+pub const INTERNAL_ERROR: i32 = -32603;
+
+// ─── Constructors ────────────────────────────────────────────────────────────
+
+/// Build a success response carrying `result`.
+pub fn success(id: Option<Value>, result: Value) -> JsonRpcResponse {
+    JsonRpcResponse {
+        jsonrpc: "2.0".into(),
+        id,
+        result: Some(result),
+        error: None,
+    }
+}
+
+/// Build an error response. `id` is `None` for errors raised before an `id`
+/// could be parsed (e.g. a parse error).
+pub fn error(id: Option<Value>, code: i32, message: impl Into<String>) -> JsonRpcResponse {
+    JsonRpcResponse {
+        jsonrpc: "2.0".into(),
+        id,
+        result: None,
+        error: Some(JsonRpcError {
+            code,
+            message: message.into(),
+            data: None,
+        }),
+    }
+}
+
+/// The notification sentinel: a `Value::Null` result with no `id`. The bridge
+/// loop suppresses writing a response line for this shape (notifications get no
+/// reply).
+pub fn notification_handled(id: Option<Value>) -> JsonRpcResponse {
+    JsonRpcResponse {
+        jsonrpc: "2.0".into(),
+        id,
+        result: Some(Value::Null),
+        error: None,
+    }
+}
+
+// ─── initialize ──────────────────────────────────────────────────────────────
+
+/// Handle the `initialize` request (D4d).
+///
+/// Does not negotiate beyond a floor check: if the client requests a
+/// `protocolVersion` older than [`MIN_ACCEPTED_PROTOCOL_VERSION`], reply with
+/// our [`MCP_PROTOCOL_VERSION`] anyway (lexicographic date strings compare
+/// correctly), but log it. We advertise:
+/// - `protocolVersion`: [`MCP_PROTOCOL_VERSION`].
+/// - `capabilities.tools.listChanged: false` (the tool set is static).
+/// - `serverInfo`: `{name, version, title}`.
+/// - `instructions`: a short static usage string (new in 2025-11-25).
+pub fn handle_initialize(params: Option<Value>) -> Value {
+    let _span = tracing::info_span!("mcp_initialize").entered();
+
+    // The client's requested version + identity are read for compliance /
+    // logging only; we do not branch behavior on them (beyond the floor log).
+    let requested = params
+        .as_ref()
+        .and_then(|p| p.get("protocolVersion"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let client_name = params
+        .as_ref()
+        .and_then(|p| p.get("clientInfo"))
+        .and_then(|c| c.get("name"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+
+    if !requested.is_empty() && requested < MIN_ACCEPTED_PROTOCOL_VERSION {
+        tracing::warn!(
+            requested,
+            min = MIN_ACCEPTED_PROTOCOL_VERSION,
+            advertised = MCP_PROTOCOL_VERSION,
+            client = client_name,
+            "MCP client requested a protocol version below the accepted floor; \
+             responding with the advertised version anyway"
+        );
+    } else {
+        tracing::info!(requested, client = client_name, "MCP client connected");
+    }
+
+    serde_json::json!({
+        "protocolVersion": MCP_PROTOCOL_VERSION,
+        "capabilities": {
+            "tools": { "listChanged": false }
+        },
+        "serverInfo": {
+            "name": "cqs",
+            "version": env!("CARGO_PKG_VERSION"),
+            "title": "cqs"
+        },
+        "instructions":
+            "cqs semantic code search and call-graph navigation, exposed as \
+             read-only MCP tools. Each tool rides the corresponding `cqs` \
+             command over a warm daemon. Use cqs_search for concept queries, \
+             cqs_callers / cqs_callees / cqs_impact for the call graph, and \
+             cqs_scout / cqs_gather to assemble context."
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initialize_advertises_protocol_and_serverinfo() {
+        let result = handle_initialize(Some(serde_json::json!({
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": {"name": "test-client", "version": "1.0"}
+        })));
+        assert_eq!(
+            result.get("protocolVersion").and_then(|v| v.as_str()),
+            Some(MCP_PROTOCOL_VERSION)
+        );
+        assert_eq!(
+            result
+                .get("capabilities")
+                .and_then(|c| c.get("tools"))
+                .and_then(|t| t.get("listChanged"))
+                .and_then(|v| v.as_bool()),
+            Some(false)
+        );
+        assert_eq!(
+            result
+                .get("serverInfo")
+                .and_then(|s| s.get("name"))
+                .and_then(|v| v.as_str()),
+            Some("cqs")
+        );
+        assert!(result
+            .get("serverInfo")
+            .and_then(|s| s.get("title"))
+            .is_some());
+        assert!(result.get("instructions").is_some());
+    }
+
+    /// An old-but-accepted client version (>= floor) still gets our advertised
+    /// version echoed; an empty/absent version also works.
+    #[test]
+    fn initialize_accepts_floor_version_and_missing_params() {
+        let r1 = handle_initialize(Some(serde_json::json!({
+            "protocolVersion": "2025-06-18"
+        })));
+        assert_eq!(
+            r1.get("protocolVersion").and_then(|v| v.as_str()),
+            Some(MCP_PROTOCOL_VERSION)
+        );
+        let r2 = handle_initialize(None);
+        assert_eq!(
+            r2.get("protocolVersion").and_then(|v| v.as_str()),
+            Some(MCP_PROTOCOL_VERSION)
+        );
+    }
+}

--- a/src/cli/mcp/mod.rs
+++ b/src/cli/mcp/mod.rs
@@ -1,0 +1,175 @@
+//! `cqs mcp` — the stdio ↔ daemon-socket MCP bridge (Phase 1, Lane 2).
+//!
+//! A thin, GPU-free process that speaks MCP JSON-RPC over stdio to an MCP
+//! client (e.g. Claude Code) and forwards each `tools/call` to the warm `cqs`
+//! daemon over its unix socket. It RIDES the command cores: it never
+//! reimplements a tool, it deserializes the wire `arguments` object and relays
+//! it as the Lane 1 / D3-b JSON-args frame
+//! (`{"command": "<cmd>", "arguments": {...}}`) the daemon already accepts.
+//!
+//! ## Why bridge-only (D4a)
+//!
+//! There is NO in-process fallback. The bridge is the one process that emits
+//! MCP JSON-RPC on its own stdout, and the only process-wide stdout suppressor
+//! cqs has is the per-call `stdout_gag` fd-1 redirect — which does NOT cover an
+//! embedder/ORT/tokenizer load. An in-process core run would leak that load's
+//! stdout into the JSON-RPC channel. So the bridge requires a running daemon
+//! and fails clean if absent (a JSON-RPC protocol error per call). The bridge
+//! itself loads no model, so its stdout is trivially clean — every `tracing`
+//! line routes to stderr (configured in `main.rs`).
+//!
+//! ## Module layout
+//!
+//! - [`bridge`] — the stdin → parse → route → stdout loop. Owns NDJSON
+//!   framing, the JSON-RPC envelope, the method dispatch table, and the
+//!   per-`tools/call` daemon-socket round-trip.
+//! - [`lifecycle`] — `initialize` (advertise / accept protocol version) and the
+//!   `initialized` notification. Holds the protocol-version constant.
+//! - [`tools`] — `tools/list` generation (the read-only registry × Phase-0
+//!   `schemars` inputSchemas) and `tools/call` dispatch (deserialize-check →
+//!   relay → map the daemon envelope into a `CallToolResult`, with the
+//!   error-mapping invariant of Blocker #1).
+
+mod bridge;
+mod lifecycle;
+mod tools;
+
+pub use bridge::serve_stdio;
+
+#[cfg(test)]
+mod tests {
+    use super::tools;
+
+    /// `tools/list`-matches-registry guard.
+    ///
+    /// The exposed MCP tool set must equal the daemon's JSON-args-capable
+    /// command set (the 20 commands that carry a Phase-0 JsonSchema core, per
+    /// `cli::batch::json_args::build_batch_cmd`) MINUS the explicitly withheld
+    /// set (`context`, `explain` — RT-RELAY doc/signature scan gap, D4b). This
+    /// fails if a JSON-args command is added or removed without updating the
+    /// MCP surface, or if a withheld command leaks into `tools/list`.
+    #[test]
+    fn tools_list_matches_json_args_registry() {
+        // The canonical JSON-args-capable command set, mirrored from
+        // `build_batch_cmd`'s match arms. If Lane 1 adds a command there, this
+        // list must grow with it (and the tool table in `tools.rs`).
+        let json_args_capable: std::collections::BTreeSet<&str> = [
+            "search", "gather", "scout", "onboard", "similar", "callers", "callees", "deps",
+            "impact", "test-map", "trace", "blame", "context", "diff", "drift", "dead", "ci",
+            "review", "plan", "read",
+        ]
+        .into_iter()
+        .collect();
+
+        // The P1 withheld set (D4b): unscanned doc/signature relay surfaces.
+        let withheld: std::collections::BTreeSet<&str> =
+            ["context", "explain"].into_iter().collect();
+
+        let expected: std::collections::BTreeSet<String> = json_args_capable
+            .difference(&withheld)
+            .map(|s| s.to_string())
+            .collect();
+
+        let exposed: std::collections::BTreeSet<String> = tools::tool_table()
+            .iter()
+            .map(|t| {
+                let name = t.name.to_string();
+                // The MCP tool name carries the `cqs_` prefix (D1) and uses
+                // underscores; map it back to the bare daemon command name for
+                // the registry comparison. `test-map` is the lone hyphenated
+                // command — its MCP name is `cqs_test_map`.
+                tools::mcp_name_to_command(&name)
+            })
+            .collect();
+
+        assert_eq!(
+            exposed, expected,
+            "MCP tools/list set must equal the JSON-args registry minus the withheld set.\n\
+             exposed (mapped to commands): {exposed:?}\n\
+             expected:                     {expected:?}"
+        );
+    }
+
+    /// Every exposed tool carries the `cqs_` prefix (D1), an `inputSchema` that
+    /// is a non-empty JSON object, and a `readOnly` annotation (all P1 tools
+    /// are reads).
+    #[test]
+    fn every_tool_is_well_formed() {
+        for t in tools::tool_table() {
+            assert!(
+                t.name.starts_with("cqs_"),
+                "tool `{}` must carry the `cqs_` prefix (D1)",
+                t.name
+            );
+            let schema = (t.input_schema)();
+            assert_eq!(
+                schema.get("type").and_then(|v| v.as_str()),
+                Some("object"),
+                "tool `{}` inputSchema must be a JSON object",
+                t.name
+            );
+            assert!(
+                schema.get("properties").is_some(),
+                "tool `{}` inputSchema must carry a `properties` object",
+                t.name
+            );
+            assert!(
+                !t.description.is_empty(),
+                "tool `{}` must carry a non-empty description",
+                t.name
+            );
+        }
+    }
+
+    /// `context`/`explain` must be ABSENT from the exposed surface (D4b).
+    #[test]
+    fn withheld_tools_absent() {
+        let names: Vec<&'static str> = tools::tool_table().iter().map(|t| t.name).collect();
+        assert!(
+            !names.contains(&"cqs_context"),
+            "cqs_context must be withheld from P1 tools/list"
+        );
+        assert!(
+            !names.contains(&"cqs_explain"),
+            "cqs_explain must be withheld from P1 tools/list"
+        );
+    }
+
+    /// Schema ↔ wire consistency: a tool whose `inputSchema` advertises a
+    /// non-empty `required` array carries a core with at least one field that
+    /// genuinely lacks a serde default (e.g. `plan.description`,
+    /// `callers.name`). The MCP `required` list is honest — it must reflect what
+    /// the daemon will actually reject when omitted. This guards against a
+    /// schema that claims a field is optional while the daemon errors on its
+    /// absence (or vice versa), which would silently mislead the model.
+    ///
+    /// The invariant is checked structurally: every `required` entry must be a
+    /// declared property of the same schema. (A fully-`serde(default)` core like
+    /// `QueryArgs` has no `required` array at all — that path is trivially
+    /// consistent.)
+    #[test]
+    fn tool_required_fields_are_declared_properties() {
+        for t in tools::tool_table() {
+            let schema = (t.input_schema)();
+            let props = schema
+                .get("properties")
+                .and_then(|p| p.as_object())
+                .unwrap_or_else(|| panic!("tool `{}`: schema has no properties", t.name));
+            if let Some(req) = schema.get("required") {
+                let arr = req
+                    .as_array()
+                    .unwrap_or_else(|| panic!("tool `{}`: `required` not an array", t.name));
+                for field in arr {
+                    let name = field.as_str().unwrap_or_else(|| {
+                        panic!("tool `{}`: `required` entry not a string", t.name)
+                    });
+                    assert!(
+                        props.contains_key(name),
+                        "tool `{}`: required field `{name}` is not a declared property",
+                        t.name
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/cli/mcp/tools.rs
+++ b/src/cli/mcp/tools.rs
@@ -1,0 +1,701 @@
+//! `tools/list` generation and `tools/call` dispatch.
+//!
+//! ## The tool surface (D1, D4b)
+//!
+//! The exposed tools are exactly the daemon's JSON-args-capable commands (the
+//! 20 with a Phase-0 `schemars::JsonSchema` core, per
+//! `cli::batch::json_args::build_batch_cmd`) MINUS the withheld set
+//! (`context`, `explain` — their relay carries UNSCANNED doc/signature content,
+//! RT-RELAY doc/signature gap; D4b). `explain` is not JSON-args-capable in the
+//! first place, so the withhold materially removes only `context`. Each tool:
+//! - Carries the `cqs_`-prefixed, underscore, noun-first name (D1):
+//!   `cqs_search`, `cqs_callers`, `cqs_notes_add` (none in P1), … — the v0.10.0
+//!   precedent. The lone hyphenated command `test-map` becomes `cqs_test_map`.
+//! - Advertises an `inputSchema` generated from its Phase-0 core via
+//!   `schemars::schema_for!` — the SAME struct the daemon deserializes the
+//!   relayed `arguments` into, so the schema and the wire contract cannot drift.
+//! - Is annotated `readOnly` (every P1 tool is a read).
+//!
+//! ## tools/call (Blocker #1, #5; D4c)
+//!
+//! `arguments` is deserialized into the core struct (a shape pre-check; the
+//! authoritative deserialize happens daemon-side), then relayed as the Lane 1
+//! JSON-args frame. The daemon's two-layer envelope is classified:
+//! - Socket-layer transport/parse failure → a JSON-RPC protocol error.
+//! - A handler error riding under `status:"ok"`
+//!   (`output = {data:null, error:{...}}`, mirrored from `classify_slim_envelope`)
+//!   → `CallToolResult{isError:true}` with the redacted message — NOT a
+//!   protocol error (Blocker #1).
+//! - A success (`output = {data:..., (opt)_meta:...}`) → `CallToolResult` with
+//!   `structuredContent` = `data`, a `content[text]` mirror, and the envelope
+//!   `_meta` hoisted to `CallToolResult._meta`. Per-result signals
+//!   (`rank_signals`/`trust_level`) live inside `data` and ride through
+//!   `structuredContent` automatically — the envelope `_meta` carries only
+//!   `stale_origins`/`worktree_overlay`/`worktree_stale` (Blocker #5).
+//! - A success whose `data` is empty BUT carries `candidates` → `isError:true`
+//!   so the model retries with a candidate; a genuinely-empty / no-candidate /
+//!   `dead`-verdict result is empty-but-ok (D4c).
+
+use std::path::Path;
+
+use serde_json::Value;
+
+use super::lifecycle;
+
+/// A statically-declared MCP tool. `input_schema` is a fn pointer that
+/// generates the JSON Schema on demand (schemars `schema_for!` is not `const`).
+pub struct ToolDef {
+    /// The `cqs_`-prefixed MCP tool name (D1).
+    pub name: &'static str,
+    /// The bare daemon command name this tool relays to (e.g. `test-map`).
+    pub command: &'static str,
+    /// One-line description surfaced in `tools/list`.
+    pub description: &'static str,
+    /// Generates the `inputSchema` (JSON Schema 2020-12) from the command's
+    /// Phase-0 core struct.
+    pub input_schema: fn() -> Value,
+}
+
+/// Render the schema for a core `T` as a `serde_json::Value`. schemars 1.x
+/// `schema_for!` produces a 2020-12 schema; `serde(default)` cores yield no
+/// `required` array (every param optional on the wire).
+fn schema<T: schemars::JsonSchema>() -> Value {
+    serde_json::to_value(schemars::schema_for!(T)).unwrap_or_else(|_| {
+        // schemars schema serialization is infallible in practice; fall back to
+        // a minimal object so a hypothetical failure can't poison tools/list.
+        serde_json::json!({"type": "object", "properties": {}})
+    })
+}
+
+// Core struct aliases — identical import paths to
+// `cli::batch::json_args`, so the schema source and the daemon deserialize
+// target are provably the same type.
+use crate::cli::args::ReadArgs;
+use crate::cli::commands::blame::BlameArgs as BlameCore;
+use crate::cli::commands::diff::DiffArgs as DiffCore;
+use crate::cli::commands::drift::DriftArgs as DriftCore;
+use crate::cli::commands::search::gather::GatherArgs as GatherCore;
+use crate::cli::commands::search::onboard::OnboardArgs as OnboardCore;
+use crate::cli::commands::search::query::QueryArgs;
+use crate::cli::commands::search::scout::ScoutArgs as ScoutCore;
+use crate::cli::commands::search::similar::SimilarArgs as SimilarCore;
+use crate::cli::commands::{
+    CalleesArgs as CalleesCore, CallersCoreArgs, CiArgs as CiCore, DeadArgs as DeadCore,
+    DepsCoreArgs, ImpactCoreArgs, PlanArgs as PlanCore, ReviewArgs as ReviewCore, TestMapCoreArgs,
+    TraceCoreArgs,
+};
+
+/// The P1 tool table — single source of truth for `tools/list`. Every row is a
+/// JSON-args-capable command with a Phase-0 core, EXCEPT the withheld
+/// `context`/`explain` (D4b). The registry-parity guard in `mod.rs` pins this
+/// set against `build_batch_cmd`'s arms.
+pub fn tool_table() -> &'static [ToolDef] {
+    &[
+        ToolDef {
+            name: "cqs_search",
+            command: "search",
+            description:
+                "Semantic code search (hybrid RRF). Find functions/methods by concept, not just \
+                 name — e.g. 'retry with exponential backoff' finds retry logic regardless of \
+                 naming. Use name_only for fast 'where is X defined?' lookups.",
+            input_schema: schema::<QueryArgs>,
+        },
+        ToolDef {
+            name: "cqs_gather",
+            command: "gather",
+            description:
+                "Assemble context: a seed semantic search expanded along the call graph (BFS). \
+                 Returns the seed hits plus their callers/callees up to a depth.",
+            input_schema: schema::<GatherCore>,
+        },
+        ToolDef {
+            name: "cqs_scout",
+            command: "scout",
+            description:
+                "Investigation brief for a task: search + callers + tests + staleness + notes in \
+                 one call. The first step before implementing.",
+            input_schema: schema::<ScoutCore>,
+        },
+        ToolDef {
+            name: "cqs_onboard",
+            command: "onboard",
+            description:
+                "Guided tour of a concept: entry point → call chain → types → tests. For exploring \
+                 unfamiliar code.",
+            input_schema: schema::<OnboardCore>,
+        },
+        ToolDef {
+            name: "cqs_similar",
+            command: "similar",
+            description:
+                "Find functions structurally/semantically similar to a named function (nearest \
+                 neighbors by embedding).",
+            input_schema: schema::<SimilarCore>,
+        },
+        ToolDef {
+            name: "cqs_callers",
+            command: "callers",
+            description:
+                "Who calls this function? Direct callers from the call graph, each tagged with an \
+                 edge_kind (call / serde_callback / macro_heuristic / fn_pointer / doc_reference).",
+            input_schema: schema::<CallersCoreArgs>,
+        },
+        ToolDef {
+            name: "cqs_callees",
+            command: "callees",
+            description: "What does this function call? Its direct callees from the call graph.",
+            input_schema: schema::<CalleesCore>,
+        },
+        ToolDef {
+            name: "cqs_deps",
+            command: "deps",
+            description: "Type/symbol dependencies of a function (or, with reverse, its reverse \
+                 dependencies).",
+            input_schema: schema::<DepsCoreArgs>,
+        },
+        ToolDef {
+            name: "cqs_impact",
+            command: "impact",
+            description:
+                "Blast radius of changing a function: callers, transitively-affected functions, \
+                 and the tests that cover them. The pre-edit safety check.",
+            input_schema: schema::<ImpactCoreArgs>,
+        },
+        ToolDef {
+            name: "cqs_test_map",
+            command: "test-map",
+            description: "Which tests exercise this function (directly or transitively)?",
+            input_schema: schema::<TestMapCoreArgs>,
+        },
+        ToolDef {
+            name: "cqs_trace",
+            command: "trace",
+            description:
+                "Shortest call path(s) between a source and a target function, if one exists.",
+            input_schema: schema::<TraceCoreArgs>,
+        },
+        ToolDef {
+            name: "cqs_blame",
+            command: "blame",
+            description:
+                "Semantic git blame for a function: who changed it, when, and why (commit \
+                 messages), plus optional caller context.",
+            input_schema: schema::<BlameCore>,
+        },
+        ToolDef {
+            name: "cqs_diff",
+            command: "diff",
+            description:
+                "Semantic diff between two indexed references (or a reference and the project): \
+                 added / removed / modified functions.",
+            input_schema: schema::<DiffCore>,
+        },
+        ToolDef {
+            name: "cqs_drift",
+            command: "drift",
+            description:
+                "Functions whose implementation has drifted from a reference index, ranked by \
+                 semantic distance.",
+            input_schema: schema::<DriftCore>,
+        },
+        ToolDef {
+            name: "cqs_dead",
+            command: "dead",
+            description: "Find dead code (zero callers), each carrying a verdict (test-only / \
+                 low-confidence-live / known-gap / dead) — only `dead` is a confident absence \
+                 claim.",
+            input_schema: schema::<DeadCore>,
+        },
+        ToolDef {
+            name: "cqs_ci",
+            command: "ci",
+            description:
+                "Bundled pre-merge review for the current diff: review + dead-code gate, with a \
+                 pass/fail verdict.",
+            input_schema: schema::<CiCore>,
+        },
+        ToolDef {
+            name: "cqs_review",
+            command: "review",
+            description:
+                "Risk-ranked review of the current diff: which changed functions have the most \
+                 callers / least test coverage.",
+            input_schema: schema::<ReviewCore>,
+        },
+        ToolDef {
+            name: "cqs_plan",
+            command: "plan",
+            description:
+                "Task-planning brief for a described change: scout + gather + impact + suggested \
+                 file placement.",
+            input_schema: schema::<PlanCore>,
+        },
+        ToolDef {
+            name: "cqs_read",
+            command: "read",
+            description:
+                "Read a project file with cqs notes injected (or, with focus, just one function \
+                 plus its type dependencies).",
+            input_schema: schema::<ReadArgs>,
+        },
+    ]
+}
+
+/// Map an MCP tool name (`cqs_test_map`) back to the bare daemon command
+/// (`test-map`). The mapping is the inverse of the table's `name`/`command`
+/// columns; this helper exists for the registry-parity guard, which compares
+/// command names. Falls back to a `cqs_`-stripped, underscore→hyphen form for
+/// an unknown name so the guard fails loudly rather than silently matching.
+#[cfg(test)]
+pub fn mcp_name_to_command(mcp_name: &str) -> String {
+    if let Some(def) = tool_table().iter().find(|t| t.name == mcp_name) {
+        return def.command.to_string();
+    }
+    mcp_name
+        .strip_prefix("cqs_")
+        .unwrap_or(mcp_name)
+        .replace('_', "-")
+}
+
+/// Look up a tool by its MCP name.
+fn find_tool(name: &str) -> Option<&'static ToolDef> {
+    tool_table().iter().find(|t| t.name == name)
+}
+
+/// Build the `tools/list` result: `{tools: [{name, description, inputSchema,
+/// annotations}, ...]}`.
+pub fn list() -> Value {
+    let tools: Vec<Value> = tool_table()
+        .iter()
+        .map(|t| {
+            serde_json::json!({
+                "name": t.name,
+                "description": t.description,
+                "inputSchema": (t.input_schema)(),
+                "annotations": {
+                    // Hints, not enforcement (the daemon's path/overlay gates
+                    // are the real boundary). Every P1 tool is a pure read.
+                    "readOnlyHint": true,
+                    "idempotentHint": true,
+                    "destructiveHint": false,
+                    "openWorldHint": false
+                }
+            })
+        })
+        .collect();
+    serde_json::json!({ "tools": tools })
+}
+
+/// The outcome of a `tools/call`: either a `CallToolResult` value (the JSON-RPC
+/// `result`, which may itself carry `isError:true` for a handler error) or a
+/// JSON-RPC protocol error `(code, message)`.
+pub enum CallOutcome {
+    Result(Value),
+    ProtocolError(i32, String),
+}
+
+/// Handle a `tools/call` request. `cqs_dir` is the resolved `.cqs` directory
+/// whose daemon socket the bridge relays to.
+pub fn call(cqs_dir: &Path, params: Option<Value>) -> CallOutcome {
+    let _span = tracing::info_span!("mcp_tools_call").entered();
+
+    let params = match params {
+        Some(p) => p,
+        None => {
+            return CallOutcome::ProtocolError(
+                lifecycle::INVALID_PARAMS,
+                "tools/call requires params".to_string(),
+            )
+        }
+    };
+
+    // 1. name → tool.
+    let name = match params.get("name").and_then(|v| v.as_str()) {
+        Some(n) => n,
+        None => {
+            return CallOutcome::ProtocolError(
+                lifecycle::INVALID_PARAMS,
+                "tools/call params missing string `name`".to_string(),
+            )
+        }
+    };
+    let tool = match find_tool(name) {
+        Some(t) => t,
+        None => {
+            return CallOutcome::ProtocolError(
+                lifecycle::METHOD_NOT_FOUND,
+                format!("unknown tool: {name}"),
+            )
+        }
+    };
+
+    // 2. arguments (default to an empty object; serde(default) cores accept it).
+    let arguments = match params.get("arguments") {
+        None | Some(Value::Null) => Value::Object(Default::default()),
+        Some(Value::Object(o)) => Value::Object(o.clone()),
+        Some(_) => {
+            return CallOutcome::ProtocolError(
+                lifecycle::INVALID_PARAMS,
+                "tools/call `arguments` must be an object".to_string(),
+            )
+        }
+    };
+
+    // 3. shape pre-check: deserialize into the core. This catches a bad-typed
+    //    field as a JSON-RPC -32602 BEFORE a socket round-trip, with a clearer
+    //    message than the daemon's redacted echo. The daemon re-deserializes
+    //    authoritatively (it is the validation boundary, not this check).
+    if let Err(e) = validate_arguments(tool.command, &arguments) {
+        return CallOutcome::ProtocolError(
+            lifecycle::INVALID_PARAMS,
+            format!("invalid arguments for {name}: {e}"),
+        );
+    }
+
+    // 4. relay as the Lane 1 JSON-args frame, then classify the envelope.
+    relay_and_classify(cqs_dir, tool.command, &arguments)
+}
+
+/// Deserialize-check `arguments` against the command's Phase-0 core. Returns
+/// `Ok(())` if the object is shape-valid. Mirrors the type set in
+/// `build_batch_cmd` so the pre-check accepts exactly what the daemon will.
+fn validate_arguments(command: &str, arguments: &Value) -> Result<(), String> {
+    fn check<T: serde::de::DeserializeOwned>(arguments: &Value) -> Result<(), String> {
+        serde_json::from_value::<T>(arguments.clone())
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    }
+    match command {
+        "search" => check::<QueryArgs>(arguments),
+        "gather" => check::<GatherCore>(arguments),
+        "scout" => check::<ScoutCore>(arguments),
+        "onboard" => check::<OnboardCore>(arguments),
+        "similar" => check::<SimilarCore>(arguments),
+        "callers" => check::<CallersCoreArgs>(arguments),
+        "callees" => check::<CalleesCore>(arguments),
+        "deps" => check::<DepsCoreArgs>(arguments),
+        "impact" => check::<ImpactCoreArgs>(arguments),
+        "test-map" => check::<TestMapCoreArgs>(arguments),
+        "trace" => check::<TraceCoreArgs>(arguments),
+        "blame" => check::<BlameCore>(arguments),
+        "diff" => check::<DiffCore>(arguments),
+        "drift" => check::<DriftCore>(arguments),
+        "dead" => check::<DeadCore>(arguments),
+        "ci" => check::<CiCore>(arguments),
+        "review" => check::<ReviewCore>(arguments),
+        "plan" => check::<PlanCore>(arguments),
+        "read" => check::<ReadArgs>(arguments),
+        // Unreachable: every table command is covered above. A new tool with no
+        // arm fails the pre-check loudly rather than silently skipping it.
+        other => Err(format!("no argument schema for command {other}")),
+    }
+}
+
+/// Relay the JSON-args frame to the daemon and map the response envelope into a
+/// `CallToolResult` (Blocker #1, #5; D4c).
+#[cfg(unix)]
+fn relay_and_classify(cqs_dir: &Path, command: &str, arguments: &Value) -> CallOutcome {
+    use cqs::daemon_translate::{daemon_json_args_request, DaemonRpcError};
+
+    let envelope = match daemon_json_args_request(cqs_dir, command, arguments) {
+        Ok(env) => env,
+        Err(DaemonRpcError::SocketMissing(msg)) => {
+            // D4a: bridge-only, no in-process fallback. A missing daemon is a
+            // transport failure → JSON-RPC internal error with operator advice.
+            return CallOutcome::ProtocolError(
+                lifecycle::INTERNAL_ERROR,
+                format!("cqs daemon not running: {msg}. Start `cqs watch --serve`."),
+            );
+        }
+        Err(DaemonRpcError::Transport(msg)) => {
+            return CallOutcome::ProtocolError(
+                lifecycle::INTERNAL_ERROR,
+                format!("cqs daemon transport failure: {msg}"),
+            );
+        }
+        Err(DaemonRpcError::DaemonError(msg)) => {
+            // Socket-layer `status:"error"` — a bad relay / NUL / missing
+            // command. Our request was malformed at the transport layer.
+            return CallOutcome::ProtocolError(
+                lifecycle::INVALID_PARAMS,
+                format!("cqs daemon rejected the request: {msg}"),
+            );
+        }
+        Err(DaemonRpcError::BadResponse(msg)) => {
+            return CallOutcome::ProtocolError(
+                lifecycle::INTERNAL_ERROR,
+                format!("cqs daemon returned a malformed response: {msg}"),
+            );
+        }
+    };
+
+    // The success envelope is `{"status":"ok","output":<dispatch>}`. Peel the
+    // socket layer to reach the dispatch slim envelope.
+    let output = match envelope.get("output") {
+        Some(o) => o,
+        None => {
+            return CallOutcome::ProtocolError(
+                lifecycle::INTERNAL_ERROR,
+                "daemon response missing `output`".to_string(),
+            )
+        }
+    };
+
+    CallOutcome::Result(classify_output(output))
+}
+
+/// Non-unix stub: the daemon socket is unix-only, so the bridge has no
+/// transport. (The `cqs mcp` subcommand is itself unix-gated at the CLI layer.)
+#[cfg(not(unix))]
+fn relay_and_classify(_cqs_dir: &Path, _command: &str, _arguments: &Value) -> CallOutcome {
+    CallOutcome::ProtocolError(
+        lifecycle::INTERNAL_ERROR,
+        "the cqs MCP bridge requires a unix daemon socket".to_string(),
+    )
+}
+
+/// Classify the dispatch-layer `output` into a `CallToolResult` (Blocker #1,
+/// #5; D4c). `output` is the slim envelope: `{data, (opt)_meta}` on success or
+/// `{error:{code,message}, (opt)_meta}` on a handler error riding under
+/// `status:"ok"`.
+fn classify_output(output: &Value) -> Value {
+    use cqs::daemon_translate::{classify_slim_envelope, SlimEnvelope};
+
+    match classify_slim_envelope(output) {
+        // Handler error under status:"ok" (Blocker #1) → isError:true.
+        Some(SlimEnvelope::Error { code, message }) => {
+            tracing::warn!(code = %code, "MCP tool handler error mapped to isError:true");
+            serde_json::json!({
+                "content": [{ "type": "text", "text": message }],
+                "isError": true,
+                "_meta": { "error": { "code": code } }
+            })
+        }
+        // Success → structuredContent + content[text] mirror + _meta hoist.
+        Some(SlimEnvelope::Data { payload, meta }) => success_result(payload, meta),
+        // Not a recognized slim envelope — pass the raw output through as
+        // structuredContent so a non-standard handler shape still reaches the
+        // client rather than being dropped.
+        None => success_result(output, None),
+    }
+}
+
+/// Build a successful `CallToolResult` from the dispatch `data` payload and the
+/// optional envelope `_meta` (Blocker #5, D4c).
+fn success_result(payload: &Value, meta: Option<&Value>) -> Value {
+    // D4c: empty-with-candidates → isError:true so the model retries with a
+    // candidate. Genuinely-empty / no-candidate / dead-verdict → empty-but-ok.
+    if is_empty_with_candidates(payload) {
+        let text = serde_json::to_string(payload)
+            .unwrap_or_else(|_| "no exact match; candidates available".to_string());
+        return serde_json::json!({
+            "content": [{
+                "type": "text",
+                "text": format!("no exact match — retry with one of the candidates: {text}")
+            }],
+            "structuredContent": payload,
+            "isError": true
+        });
+    }
+
+    // The text mirror is the JSON-stringified data, for clients that don't read
+    // structuredContent. Per-result signals (rank_signals/trust_level) live
+    // inside `payload`, so structuredContent carries them automatically
+    // (Blocker #5) — only the envelope-level _meta is hoisted separately.
+    let text = serde_json::to_string(payload).unwrap_or_else(|_| "<unserializable>".to_string());
+    let mut result = serde_json::json!({
+        "content": [{ "type": "text", "text": text }],
+        "structuredContent": payload,
+        "isError": false
+    });
+    if let Some(m) = meta {
+        if !m.is_null() {
+            // Hoist the envelope _meta (stale_origins / worktree_overlay /
+            // worktree_stale) — NOT the per-result signals (those ride in
+            // structuredContent). See Blocker #5.
+            if let Some(obj) = result.as_object_mut() {
+                obj.insert("_meta".to_string(), m.clone());
+            }
+        }
+    }
+    result
+}
+
+/// D4c shape probe: a result that is "empty BUT carries candidates" — an
+/// object whose primary collection is empty while a `candidates` array is
+/// non-empty (the not-found-with-suggestions shape callers/impact/etc. emit so
+/// the model can retry). A genuinely-empty result (no candidates, or a `dead`
+/// verdict) is NOT flagged.
+fn is_empty_with_candidates(payload: &Value) -> bool {
+    let obj = match payload.as_object() {
+        Some(o) => o,
+        None => return false,
+    };
+    // Candidates must be present and non-empty.
+    let has_candidates = obj
+        .get("candidates")
+        .and_then(|c| c.as_array())
+        .is_some_and(|a| !a.is_empty());
+    if !has_candidates {
+        return false;
+    }
+    // And the result's primary payload must be empty: every other array/object
+    // field is empty (so this is a "no hit, here are near-misses" answer, not a
+    // hit that happens to also list candidates).
+    let primary_empty = obj.iter().all(|(k, v)| {
+        if k == "candidates" || k == "_meta" {
+            return true;
+        }
+        match v {
+            Value::Array(a) => a.is_empty(),
+            Value::Object(o) => o.is_empty(),
+            Value::Null => true,
+            // Scalars (counts, names, flags) don't count as "primary content".
+            _ => true,
+        }
+    });
+    primary_empty
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_emits_well_formed_tools() {
+        let v = list();
+        let tools = v
+            .get("tools")
+            .and_then(|t| t.as_array())
+            .expect("tools array");
+        assert!(!tools.is_empty());
+        for t in tools {
+            assert!(t
+                .get("name")
+                .and_then(|n| n.as_str())
+                .unwrap()
+                .starts_with("cqs_"));
+            assert!(t.get("inputSchema").is_some());
+            assert_eq!(
+                t.get("annotations")
+                    .and_then(|a| a.get("readOnlyHint"))
+                    .and_then(|v| v.as_bool()),
+                Some(true)
+            );
+        }
+    }
+
+    /// Blocker #1: a handler error riding under status:"ok" (slim envelope with
+    /// an `error` key and no `data`) maps to isError:true, NOT a false success.
+    #[test]
+    fn handler_error_maps_to_is_error() {
+        let output = serde_json::json!({
+            "error": { "code": "not_found", "message": "function 'nope' not found" }
+        });
+        let result = classify_output(&output);
+        assert_eq!(result.get("isError").and_then(|v| v.as_bool()), Some(true));
+        assert_eq!(
+            result
+                .get("_meta")
+                .and_then(|m| m.get("error"))
+                .and_then(|e| e.get("code"))
+                .and_then(|c| c.as_str()),
+            Some("not_found")
+        );
+        // The redacted message reaches the client via content[text].
+        let text = result
+            .get("content")
+            .and_then(|c| c.as_array())
+            .and_then(|a| a.first())
+            .and_then(|b| b.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains("not found"));
+    }
+
+    /// A success envelope maps to isError:false with structuredContent == data.
+    #[test]
+    fn data_maps_to_structured_content() {
+        let output = serde_json::json!({
+            "data": { "callers": [{ "name": "foo" }] },
+            "_meta": { "stale_origins": ["src/a.rs"] }
+        });
+        let result = classify_output(&output);
+        assert_eq!(result.get("isError").and_then(|v| v.as_bool()), Some(false));
+        assert_eq!(
+            result.get("structuredContent"),
+            Some(&serde_json::json!({ "callers": [{ "name": "foo" }] }))
+        );
+        // Blocker #5: the envelope _meta is hoisted.
+        assert_eq!(
+            result.get("_meta").and_then(|m| m.get("stale_origins")),
+            Some(&serde_json::json!(["src/a.rs"]))
+        );
+    }
+
+    /// D4c: empty-with-candidates → isError:true (model should retry).
+    #[test]
+    fn empty_with_candidates_is_error() {
+        let output = serde_json::json!({
+            "data": { "callers": [], "candidates": ["foo_bar", "foo_baz"] }
+        });
+        let result = classify_output(&output);
+        assert_eq!(result.get("isError").and_then(|v| v.as_bool()), Some(true));
+        // structuredContent still carries the candidates for the retry.
+        assert!(result.get("structuredContent").is_some());
+    }
+
+    /// D4c: a genuinely-empty result (no candidates) is empty-but-ok.
+    #[test]
+    fn genuinely_empty_is_ok() {
+        let output = serde_json::json!({ "data": { "callers": [] } });
+        let result = classify_output(&output);
+        assert_eq!(result.get("isError").and_then(|v| v.as_bool()), Some(false));
+    }
+
+    /// A dead-verdict result with results present is NOT flagged as
+    /// empty-with-candidates even if it lists no candidates.
+    #[test]
+    fn dead_verdict_not_flagged() {
+        let output = serde_json::json!({
+            "data": { "dead_functions": [{ "name": "x", "verdict": "dead" }] }
+        });
+        let result = classify_output(&output);
+        assert_eq!(result.get("isError").and_then(|v| v.as_bool()), Some(false));
+    }
+
+    #[test]
+    fn mcp_name_round_trips_to_command() {
+        assert_eq!(mcp_name_to_command("cqs_test_map"), "test-map");
+        assert_eq!(mcp_name_to_command("cqs_search"), "search");
+        assert_eq!(mcp_name_to_command("cqs_callers"), "callers");
+    }
+
+    /// An unknown tool name is a -32601 protocol error, not a panic.
+    #[test]
+    fn unknown_tool_is_protocol_error() {
+        let outcome = call(
+            Path::new("/nonexistent/.cqs"),
+            Some(serde_json::json!({ "name": "cqs_bogus", "arguments": {} })),
+        );
+        match outcome {
+            CallOutcome::ProtocolError(code, _) => assert_eq!(code, lifecycle::METHOD_NOT_FOUND),
+            CallOutcome::Result(_) => panic!("expected protocol error for unknown tool"),
+        }
+    }
+
+    /// Malformed arguments (wrong-typed field) are a -32602 protocol error
+    /// caught by the pre-check, before any socket round-trip.
+    #[test]
+    fn malformed_arguments_is_invalid_params() {
+        let outcome = call(
+            Path::new("/nonexistent/.cqs"),
+            // callers.name is a String; a number fails the pre-check.
+            Some(serde_json::json!({ "name": "cqs_callers", "arguments": { "name": 42 } })),
+        );
+        match outcome {
+            CallOutcome::ProtocolError(code, _) => assert_eq!(code, lifecycle::INVALID_PARAMS),
+            CallOutcome::Result(_) => panic!("expected invalid-params for malformed arguments"),
+        }
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -12,6 +12,7 @@ mod enrichment;
 mod files;
 pub(crate) mod json_envelope;
 mod limits;
+mod mcp;
 mod pipeline;
 mod signal;
 pub(crate) mod staleness;

--- a/src/daemon_translate.rs
+++ b/src/daemon_translate.rs
@@ -811,6 +811,131 @@ fn daemon_request<T: serde::de::DeserializeOwned>(
     daemon_request_with_timeout(cqs_dir, command, args, payload_label, None)
 }
 
+/// Raw socket round-trip for the MCP bridge: send a JSON-args frame
+/// (`{"command": <cmd>, "arguments": {...}}`, the Lane 1 / D3-b shape) and
+/// return the FULL daemon response envelope as a `serde_json::Value` —
+/// `{"status":"ok","output":<dispatch envelope>}` on success or a typed
+/// error on a transport/parse failure.
+///
+/// Unlike [`daemon_request`], this does NOT peel the dispatch layer via
+/// [`unwrap_dispatch_payload`]: the bridge must inspect the un-peeled `output`
+/// to distinguish a handler error riding under `status:"ok"`
+/// (`{"data":null,"error":{...}}`) from a success (`{"data":...}`), and to
+/// carry the envelope `_meta` through. Peeling would collapse both into a
+/// bare payload and discard `_meta`.
+///
+/// Uses a 1 MiB response cap and the shared [`resolve_daemon_timeout_ms`]
+/// timeout because tool responses (search, gather, task) are far larger than
+/// the small ping/status RPCs the typed helper serves.
+///
+/// Returns a typed [`DaemonRpcError`] on a transport/parse failure — the
+/// bridge maps `SocketMissing`/`Transport`/`DaemonError`/`BadResponse` to the
+/// appropriate JSON-RPC protocol error.
+#[cfg(unix)]
+pub fn daemon_json_args_request(
+    cqs_dir: &std::path::Path,
+    command: &str,
+    arguments: &serde_json::Value,
+) -> Result<serde_json::Value, DaemonRpcError> {
+    use std::io::{BufRead, Read as _, Write};
+    use std::os::unix::net::UnixStream;
+
+    let sock_path = daemon_socket_path(cqs_dir);
+    let _span = tracing::info_span!(
+        "daemon_json_args_request",
+        command,
+        path = %sock_path.display()
+    )
+    .entered();
+
+    if !sock_path.exists() {
+        return Err(DaemonRpcError::SocketMissing(format!(
+            "no daemon running (socket {} does not exist)",
+            sock_path.display()
+        )));
+    }
+
+    let mut stream = UnixStream::connect(&sock_path).map_err(|e| {
+        tracing::warn!(stage = "connect", error = %e, command, "daemon json-args request failed");
+        DaemonRpcError::Transport(format!("connect to {} failed: {e}", sock_path.display()))
+    })?;
+
+    let timeout = resolve_daemon_timeout_ms();
+    if let Err(e) = stream.set_read_timeout(Some(timeout)) {
+        tracing::warn!(stage = "set_read_timeout", error = %e, command, "daemon json-args request failed");
+        return Err(DaemonRpcError::Transport(format!(
+            "set_read_timeout failed: {e}"
+        )));
+    }
+    if let Err(e) = stream.set_write_timeout(Some(timeout)) {
+        tracing::warn!(stage = "set_write_timeout", error = %e, command, "daemon json-args request failed");
+        return Err(DaemonRpcError::Transport(format!(
+            "set_write_timeout failed: {e}"
+        )));
+    }
+
+    // The Lane 1 (D3-b) JSON-args frame: an `arguments` OBJECT deserializes
+    // directly into the command's Phase-0 core struct on the daemon side.
+    let request = serde_json::json!({"command": command, "arguments": arguments});
+    writeln!(stream, "{}", request).map_err(|e| {
+        tracing::warn!(stage = "write", error = %e, command, "daemon json-args request failed");
+        DaemonRpcError::Transport(format!("write request failed: {e}"))
+    })?;
+    stream.flush().map_err(|e| {
+        tracing::warn!(stage = "flush", error = %e, command, "daemon json-args request failed");
+        DaemonRpcError::Transport(format!("flush failed: {e}"))
+    })?;
+
+    // 1 MiB read cap — tool responses (search/gather/task) are materially
+    // larger than the few-KB ping/status payloads, but still bounded against a
+    // buggy daemon. Mirrors the MCP request-line cap.
+    let mut reader = std::io::BufReader::new(&stream).take(1024 * 1024);
+    let mut response_line = String::new();
+    reader.read_line(&mut response_line).map_err(|e| {
+        tracing::warn!(stage = "read", error = %e, command, "daemon json-args request failed");
+        DaemonRpcError::Transport(format!("read response failed: {e}"))
+    })?;
+
+    let envelope: serde_json::Value = serde_json::from_str(response_line.trim()).map_err(|e| {
+        tracing::warn!(stage = "parse", error = %e, command, "daemon json-args request failed");
+        DaemonRpcError::BadResponse(format!("parse envelope failed: {e}"))
+    })?;
+
+    let status = envelope
+        .get("status")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            tracing::warn!(
+                stage = "parse",
+                command,
+                "daemon json-args request failed: missing status field"
+            );
+            DaemonRpcError::BadResponse("missing 'status' field in daemon response".to_string())
+        })?;
+
+    if status != "ok" {
+        // A non-ok status is a transport/parse failure on the socket layer
+        // (NUL bytes, bad relay, missing command). The daemon's `message` is
+        // already privacy-redacted. Handler-semantic errors do NOT come this
+        // way — they ride under status:"ok" inside `output` (Blocker #1).
+        let msg = envelope
+            .get("message")
+            .and_then(|m| m.as_str())
+            .unwrap_or("daemon error")
+            .to_string();
+        tracing::warn!(
+            stage = "parse",
+            status,
+            command,
+            "daemon json-args request failed: non-ok status"
+        );
+        return Err(DaemonRpcError::DaemonError(msg));
+    }
+
+    // Return the full envelope un-peeled — the bridge classifies `output`.
+    Ok(envelope)
+}
+
 /// Like [`daemon_request`] but accepts a per-call read/write timeout
 /// override. `None` uses the default 5 s; `Some(d)` sets both timeouts
 /// to `d`. Used by [`wait_for_fresh`] where the daemon holds the connection

--- a/tests/cli_mcp_bridge_test.rs
+++ b/tests/cli_mcp_bridge_test.rs
@@ -1,0 +1,477 @@
+//! Integration smoke for the `cqs mcp` stdio↔daemon-socket bridge
+//! (MCP Phase 1, Lane 2).
+//!
+//! HERMETIC: this does NOT touch the installed daemon / systemd service. It
+//! spawns the just-built `cqs mcp` binary as a child, pointed (via a private
+//! `XDG_RUNTIME_DIR`) at a MOCK daemon bound at the exact socket path the
+//! bridge computes for the temp project. The mock returns canned daemon
+//! envelopes, so the test exercises the bridge end-to-end — stdio NDJSON
+//! framing, JSON-RPC routing, the Lane 1 JSON-args frame it sends, and the
+//! envelope→`CallToolResult` classification (including the Blocker #1
+//! error-mapping invariant) — without a GPU/model load. The real json-args
+//! dispatch is Lane 1's tested territory; this lane owns the bridge.
+//!
+//! `#![cfg(unix)]`: the daemon socket is unix-only.
+#![cfg(unix)]
+
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+/// Build the temp project: a `.git` marker (so the child's `find_project_root`
+/// stops here deterministically) and a `.cqs/` dir (so `resolve_index_dir`
+/// returns `<root>/.cqs` rather than walking a worktree fallback). Returns the
+/// CANONICAL project root (the bytes the socket-path hash is taken over must
+/// match between the mock side and the child side).
+fn make_project() -> (TempDir, PathBuf, PathBuf) {
+    let dir = TempDir::new().expect("tempdir");
+    let root = dunce::canonicalize(dir.path()).expect("canonicalize root");
+    std::fs::create_dir_all(root.join(".git")).expect("mkdir .git");
+    std::fs::create_dir_all(root.join(".cqs")).expect("mkdir .cqs");
+    let cqs_dir = root.join(".cqs");
+    (dir, root, cqs_dir)
+}
+
+/// A canned daemon: bind a `UnixListener` at `socket_path`, accept connections
+/// in a loop, and reply to each with an envelope chosen by the request's
+/// `command`. Returns a handle to stop it and join.
+struct MockDaemon {
+    stop: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl MockDaemon {
+    fn start(socket_path: PathBuf) -> Self {
+        // Clean any stale socket.
+        let _ = std::fs::remove_file(&socket_path);
+        let listener = UnixListener::bind(&socket_path).expect("bind mock daemon socket");
+        listener
+            .set_nonblocking(true)
+            .expect("set listener nonblocking");
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_thread = Arc::clone(&stop);
+        let handle = std::thread::spawn(move || {
+            while !stop_thread.load(Ordering::Relaxed) {
+                match listener.accept() {
+                    Ok((stream, _)) => {
+                        // Each daemon connection is one request → one response.
+                        handle_conn(stream);
+                    }
+                    Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+        MockDaemon {
+            stop,
+            handle: Some(handle),
+        }
+    }
+}
+
+impl Drop for MockDaemon {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+/// Read one request line, choose a canned envelope by `command`, write it back.
+fn handle_conn(mut stream: UnixStream) {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .expect("set read timeout");
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+    let mut line = String::new();
+    if reader.read_line(&mut line).is_err() || line.trim().is_empty() {
+        return;
+    }
+    let req: Value = match serde_json::from_str(line.trim()) {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+    let command = req.get("command").and_then(|c| c.as_str()).unwrap_or("");
+    // The bridge MUST send the Lane 1 JSON-args frame: an `arguments` object,
+    // never an argv `args` array. Echo nothing if the contract is violated so
+    // the test's response assertion fails loudly.
+    let has_arguments_object = matches!(req.get("arguments"), Some(Value::Object(_)));
+
+    let envelope = if !has_arguments_object {
+        json!({"status": "error", "message": "expected an `arguments` object frame"})
+    } else {
+        match command {
+            // A normal success: data + envelope _meta.
+            "callers" => json!({
+                "status": "ok",
+                "output": {
+                    "data": {
+                        "function": "callee_fn",
+                        "callers": [{ "name": "caller_fn", "edge_kind": "call" }]
+                    },
+                    "_meta": { "stale_origins": [] }
+                }
+            }),
+            // A handler error riding under status:"ok" (Blocker #1).
+            "impact" => json!({
+                "status": "ok",
+                "output": {
+                    "error": { "code": "not_found", "message": "function 'ghost' not found" }
+                }
+            }),
+            // search: minimal data payload, used for the structuredContent check.
+            "search" => json!({
+                "status": "ok",
+                "output": { "data": { "results": [{ "name": "hit", "score": 0.9 }] } }
+            }),
+            _ => json!({"status": "error", "message": format!("unexpected command {command}")}),
+        }
+    };
+    let mut buf = serde_json::to_vec(&envelope).expect("serialize envelope");
+    buf.push(b'\n');
+    let _ = stream.write_all(&buf);
+    let _ = stream.flush();
+}
+
+/// A live `cqs mcp` child plus its piped stdin/stdout, with a line reader.
+struct Bridge {
+    child: Child,
+    stdin: std::process::ChildStdin,
+    reader: BufReader<std::process::ChildStdout>,
+}
+
+impl Bridge {
+    /// Spawn `cqs mcp` with cwd = project root and `XDG_RUNTIME_DIR` =
+    /// `socket_dir`, so the child computes the same daemon socket path the mock
+    /// bound. `CQS_NO_DAEMON` is intentionally NOT set (the bridge is itself the
+    /// daemon client; the env knob governs the *other* daemon-forward path).
+    fn spawn(root: &Path, socket_dir: &Path) -> Self {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_cqs"))
+            .arg("mcp")
+            .current_dir(root)
+            .env("XDG_RUNTIME_DIR", socket_dir)
+            // Keep the child's timeout snappy so a missing reply fails the test
+            // fast rather than hanging.
+            .env("CQS_DAEMON_TIMEOUT_MS", "5000")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn cqs mcp");
+        let stdin = child.stdin.take().expect("child stdin");
+        let stdout = child.stdout.take().expect("child stdout");
+        Bridge {
+            child,
+            stdin,
+            reader: BufReader::new(stdout),
+        }
+    }
+
+    /// Send one JSON-RPC request line.
+    fn send(&mut self, msg: &Value) {
+        let line = serde_json::to_string(msg).expect("serialize request");
+        writeln!(self.stdin, "{line}").expect("write to child stdin");
+        self.stdin.flush().expect("flush child stdin");
+    }
+
+    /// Read one response line, parsed as JSON. Panics on EOF / timeout.
+    fn recv(&mut self) -> Value {
+        let mut line = String::new();
+        let n = self.reader.read_line(&mut line).expect("read child stdout");
+        assert!(n > 0, "bridge closed stdout before responding");
+        serde_json::from_str(line.trim())
+            .unwrap_or_else(|e| panic!("bridge response not JSON ({e}): {line}"))
+    }
+}
+
+impl Drop for Bridge {
+    fn drop(&mut self) {
+        // Closing stdin → the bridge's stdin loop hits EOF and exits.
+        // (Take and drop the stdin handle explicitly.)
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// End-to-end session: initialize → tools/list → tools/call (success) drives
+/// the full bridge with a mock daemon behind the socket.
+#[test]
+fn stdio_round_trip_smoke() {
+    let (_dir, root, cqs_dir) = make_project();
+    // The mock daemon and the child both resolve the socket path from
+    // `XDG_RUNTIME_DIR = socket_dir` + the canonical cqs_dir bytes.
+    let socket_dir = root.clone();
+    // Compute the socket path WITHOUT mutating process-wide env (which races
+    // across parallel tests). The thread-local override sets the dir on this
+    // test thread; the child gets the matching dir via `Command::env`
+    // (`XDG_RUNTIME_DIR`). Both compute `socket_dir/cqs-<hash(cqs_dir)>.sock`.
+    cqs::daemon_translate::set_socket_dir_override_for_test(Some(socket_dir.clone()));
+    let socket_path = cqs::daemon_translate::daemon_socket_path(&cqs_dir);
+    let _daemon = MockDaemon::start(socket_path);
+
+    let mut bridge = Bridge::spawn(&root, &socket_dir);
+
+    // 1. initialize → handshake.
+    bridge.send(&json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": { "protocolVersion": "2025-11-25", "capabilities": {}, "clientInfo": {"name":"smoke","version":"1"} }
+    }));
+    let init = bridge.recv();
+    assert_eq!(init.get("id").and_then(|v| v.as_u64()), Some(1));
+    let result = init.get("result").expect("initialize result");
+    assert_eq!(
+        result.get("protocolVersion").and_then(|v| v.as_str()),
+        Some("2025-11-25"),
+        "handshake must advertise the P1 protocol version"
+    );
+    assert_eq!(
+        result
+            .get("serverInfo")
+            .and_then(|s| s.get("name"))
+            .and_then(|v| v.as_str()),
+        Some("cqs")
+    );
+
+    // 2. notifications/initialized → NO response (notification).
+    bridge.send(&json!({"jsonrpc":"2.0","method":"notifications/initialized"}));
+
+    // 3. tools/list → cqs_search present, context/explain absent, schemas present.
+    bridge.send(&json!({"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}));
+    let listed = bridge.recv();
+    assert_eq!(listed.get("id").and_then(|v| v.as_u64()), Some(2));
+    let tools = listed
+        .get("result")
+        .and_then(|r| r.get("tools"))
+        .and_then(|t| t.as_array())
+        .expect("tools array");
+    let names: Vec<&str> = tools
+        .iter()
+        .filter_map(|t| t.get("name").and_then(|n| n.as_str()))
+        .collect();
+    assert!(names.contains(&"cqs_search"), "cqs_search must be listed");
+    assert!(names.contains(&"cqs_callers"), "cqs_callers must be listed");
+    assert!(
+        !names.contains(&"cqs_context"),
+        "cqs_context must be withheld (D4b)"
+    );
+    assert!(
+        !names.contains(&"cqs_explain"),
+        "cqs_explain must be withheld (D4b)"
+    );
+    // Every listed tool carries an inputSchema object.
+    for t in tools {
+        let schema = t.get("inputSchema").expect("inputSchema");
+        assert_eq!(
+            schema.get("type").and_then(|v| v.as_str()),
+            Some("object"),
+            "tool {} inputSchema must be an object",
+            t.get("name").and_then(|n| n.as_str()).unwrap_or("?")
+        );
+    }
+
+    // 4. tools/call cqs_search → valid CallToolResult with structuredContent.
+    bridge.send(&json!({
+        "jsonrpc":"2.0","id":3,"method":"tools/call",
+        "params": { "name": "cqs_search", "arguments": { "query": "anything" } }
+    }));
+    let called = bridge.recv();
+    assert_eq!(called.get("id").and_then(|v| v.as_u64()), Some(3));
+    let call_result = called.get("result").expect("tools/call result");
+    assert_eq!(
+        call_result.get("isError").and_then(|v| v.as_bool()),
+        Some(false),
+        "a successful search must not be an error"
+    );
+    let structured = call_result
+        .get("structuredContent")
+        .expect("structuredContent present on success");
+    assert!(
+        structured.get("results").is_some(),
+        "structuredContent must carry the handler data"
+    );
+    // The content[text] mirror is also present.
+    assert!(call_result
+        .get("content")
+        .and_then(|c| c.as_array())
+        .and_then(|a| a.first())
+        .and_then(|b| b.get("text"))
+        .is_some());
+}
+
+/// Blocker #1: a handler error riding under the daemon's outer `status:"ok"`
+/// becomes a `CallToolResult{isError:true}`, NOT a JSON-RPC protocol error and
+/// NOT a false success. Driven end-to-end through the child.
+#[test]
+fn handler_error_becomes_is_error_true() {
+    let (_dir, root, cqs_dir) = make_project();
+    let socket_dir = root.clone();
+    // Compute the socket path WITHOUT mutating process-wide env (which races
+    // across parallel tests). The thread-local override sets the dir on this
+    // test thread; the child gets the matching dir via `Command::env`
+    // (`XDG_RUNTIME_DIR`). Both compute `socket_dir/cqs-<hash(cqs_dir)>.sock`.
+    cqs::daemon_translate::set_socket_dir_override_for_test(Some(socket_dir.clone()));
+    let socket_path = cqs::daemon_translate::daemon_socket_path(&cqs_dir);
+    let _daemon = MockDaemon::start(socket_path);
+
+    let mut bridge = Bridge::spawn(&root, &socket_dir);
+    bridge.send(&json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}));
+    let _ = bridge.recv();
+
+    // cqs_impact on a ghost symbol → the mock returns a status:"ok"-wrapped
+    // handler error.
+    bridge.send(&json!({
+        "jsonrpc":"2.0","id":7,"method":"tools/call",
+        "params": { "name": "cqs_impact", "arguments": { "name": "ghost" } }
+    }));
+    let resp = bridge.recv();
+    // It is a SUCCESS at the JSON-RPC layer (has `result`, no `error`)...
+    assert!(
+        resp.get("error").is_none(),
+        "handler error must NOT be a JSON-RPC protocol error: {resp}"
+    );
+    let result = resp.get("result").expect("tools/call result");
+    // ...but the CallToolResult is flagged isError:true.
+    assert_eq!(
+        result.get("isError").and_then(|v| v.as_bool()),
+        Some(true),
+        "a status:ok-wrapped handler error must map to isError:true (Blocker #1): {result}"
+    );
+    // The redacted message reaches the client.
+    let text = result
+        .get("content")
+        .and_then(|c| c.as_array())
+        .and_then(|a| a.first())
+        .and_then(|b| b.get("text"))
+        .and_then(|t| t.as_str())
+        .unwrap_or("");
+    assert!(
+        text.contains("not found"),
+        "error text must surface: {text}"
+    );
+}
+
+/// Protocol-layer failures: an unknown method → -32601, malformed JSON →
+/// -32700, an unknown tool → -32601. Driven through the child; no daemon needed
+/// for the method/parse cases.
+#[test]
+fn protocol_errors_map_to_jsonrpc_codes() {
+    let (_dir, root, cqs_dir) = make_project();
+    let socket_dir = root.clone();
+    // Compute the socket path WITHOUT mutating process-wide env (which races
+    // across parallel tests). The thread-local override sets the dir on this
+    // test thread; the child gets the matching dir via `Command::env`
+    // (`XDG_RUNTIME_DIR`). Both compute `socket_dir/cqs-<hash(cqs_dir)>.sock`.
+    cqs::daemon_translate::set_socket_dir_override_for_test(Some(socket_dir.clone()));
+    let socket_path = cqs::daemon_translate::daemon_socket_path(&cqs_dir);
+    let _daemon = MockDaemon::start(socket_path);
+
+    let mut bridge = Bridge::spawn(&root, &socket_dir);
+    bridge.send(&json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}));
+    let _ = bridge.recv();
+
+    // Unknown method → -32601.
+    bridge.send(&json!({"jsonrpc":"2.0","id":2,"method":"no/such/method","params":{}}));
+    let r = bridge.recv();
+    assert_eq!(
+        r.get("error")
+            .and_then(|e| e.get("code"))
+            .and_then(|c| c.as_i64()),
+        Some(-32601),
+        "unknown method must be -32601: {r}"
+    );
+
+    // Unknown tool name → -32601.
+    bridge.send(&json!({
+        "jsonrpc":"2.0","id":3,"method":"tools/call",
+        "params": { "name": "cqs_does_not_exist", "arguments": {} }
+    }));
+    let r = bridge.recv();
+    assert_eq!(
+        r.get("error")
+            .and_then(|e| e.get("code"))
+            .and_then(|c| c.as_i64()),
+        Some(-32601),
+        "unknown tool must be -32601: {r}"
+    );
+
+    // Malformed JSON line → -32700 (parse error, no id).
+    write_raw_line(&mut bridge, "{ this is not json");
+    let r = bridge.recv();
+    assert_eq!(
+        r.get("error")
+            .and_then(|e| e.get("code"))
+            .and_then(|c| c.as_i64()),
+        Some(-32700),
+        "malformed JSON must be -32700: {r}"
+    );
+
+    // Malformed arguments (wrong-typed field) → -32602 invalid params.
+    bridge.send(&json!({
+        "jsonrpc":"2.0","id":5,"method":"tools/call",
+        "params": { "name": "cqs_callers", "arguments": { "name": 42 } }
+    }));
+    let r = bridge.recv();
+    assert_eq!(
+        r.get("error")
+            .and_then(|e| e.get("code"))
+            .and_then(|c| c.as_i64()),
+        Some(-32602),
+        "malformed arguments must be -32602: {r}"
+    );
+}
+
+/// D4a: with NO daemon running, a `tools/call` fails clean with a transport
+/// protocol error (no in-process fallback, no GPU load, no stdout leak).
+#[test]
+fn no_daemon_fails_clean() {
+    let (_dir, root, _cqs_dir) = make_project();
+    let socket_dir = root.clone();
+    // Intentionally do NOT start a mock daemon — the socket does not exist. The
+    // child gets `XDG_RUNTIME_DIR` via `Command::env`, so it computes a socket
+    // path that points at nothing (no process-env mutation needed here).
+
+    let mut bridge = Bridge::spawn(&root, &socket_dir);
+    bridge.send(&json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}));
+    let _ = bridge.recv();
+
+    bridge.send(&json!({
+        "jsonrpc":"2.0","id":2,"method":"tools/call",
+        "params": { "name": "cqs_callers", "arguments": { "name": "foo" } }
+    }));
+    let r = bridge.recv();
+    // No daemon → internal/transport protocol error (-32603), with advice.
+    assert_eq!(
+        r.get("error")
+            .and_then(|e| e.get("code"))
+            .and_then(|c| c.as_i64()),
+        Some(-32603),
+        "missing daemon must be -32603: {r}"
+    );
+    let msg = r
+        .get("error")
+        .and_then(|e| e.get("message"))
+        .and_then(|m| m.as_str())
+        .unwrap_or("");
+    assert!(
+        msg.contains("daemon"),
+        "the error must mention the daemon: {msg}"
+    );
+}
+
+/// Write a raw (possibly invalid-JSON) line straight to the child stdin,
+/// bypassing the `Value` serializer.
+fn write_raw_line(bridge: &mut Bridge, raw: &str) {
+    writeln!(bridge.stdin, "{raw}").expect("write raw line");
+    bridge.stdin.flush().expect("flush raw line");
+}


### PR DESCRIPTION
## MCP Phase 1, Lane 2 — the `cqs mcp` stdio↔daemon-socket bridge

Re-introduces an MCP interface for cqs (removed in v0.10.0) — but riding the command cores this time, so the tools layer is ~10× smaller than the old per-tool server and **cannot drift from the CLI** (one implementation).

`cqs mcp` is a thin stdio JSON-RPC bridge: each `tools/call` deserializes the wire `arguments` and forwards the Lane 1 JSON-args frame to the warm daemon, then maps the response to a `CallToolResult`. New `src/cli/mcp/{bridge,lifecycle,tools}.rs`.

- **19 read-only `cqs_`-prefixed tools** (the 20 JSON-args-capable commands minus `context`, withheld pending the RT-RELAY doc-scan fix #2020; `explain` isn't JSON-args-capable). All `readOnlyHint:true`. Mutating commands (index/notes/gc) deferred to Phase 2.
- **Error mapping (the critical invariant):** handler errors ride under outer `status:"ok"` with the slim `{"error":{…}}` envelope; the bridge classifies the inner output → `isError:true` (not a false success), transport/unknown-tool/bad-args → JSON-RPC `-32xxx`. A new `daemon_json_args_request` returns the full un-peeled envelope precisely so the bridge can do this classification.
- **Lifecycle:** advertises `2025-11-25`, floor-accepts client `>= 2025-06-18`; `-32601`/`-32700` for unknown/malformed.
- **not_found (shape-driven):** empty-with-candidates → `isError:true` (retry); genuinely-empty / `dead` verdict → ok.
- **stdout discipline:** the bridge loads no GPU/hnsw; tracing → stderr; responses single-line; notifications suppressed.

**Tests:** 19 unit + 4 hermetic integration (mock daemon at the computed socket path, exercises the real `cqs mcp` child end-to-end, asserts an `arguments` *object* frame). Registry-parity guard (set-difference, proven to bite). Full `--tests` sweep green (new CLI variant = surface change). clippy/fmt/provenance clean.

**Review:** opus code-reviewer — APPROVE, risk LOW-MEDIUM; Blocker #1 verified against the authentic `wrap_error` envelope, new transport safe + additive, stdout clean. Two non-blocking nits (a slightly-wrong docstring; the parity guard is hand-mirrored not derived) → follow-up.

This makes **MCP Phase 1 functionally complete** — cqs is invokable over MCP. CHANGELOG is compiled at release (project convention); follow-ups: the command-core completion (#2021), the `max_nodes` schema-honesty residual, and the two review nits.
