### PR TITLE
feat(mcp): gated notes-mutation tools (MCP Phase 2a)

### DIFF
--- a/README.md
+++ b/README.md
@@ -888,6 +888,7 @@ Quick index by domain (everything is searchable in the table below):
 | `CQS_MAX_FILE_SIZE` | `1048576` (1 MB) | Per-file size cap (bytes) for indexing. Files above this are skipped with an `info!` log; bump for generated code (`bindings.rs`, compiled TS, migrations). |
 | `CQS_MAX_QUERY_BYTES` | `32768` | Max query input bytes for embedding |
 | `CQS_MAX_SEQ_LENGTH` | (auto) | Override max sequence length for custom ONNX models |
+| `CQS_MCP_ENABLE_MUTATIONS` | (unset = off) | Operator opt-in for the `cqs mcp` bridge's gated mutation channel (Phase 2a). When unset, `tools/list` exposes only the read tools and the daemon rejects notes-mutation requests. Set to `1` to additionally expose `cqs_notes_add` / `cqs_notes_update` / `cqs_notes_remove` (which write `docs/notes.toml`; the watch loop reindexes). The destructive set (`gc`, `slot remove`, `index --force`, `model swap`, `cache clear`) is withheld unconditionally — no value of this flag re-enables it. Read by both the bridge (tool surface) and the daemon (dispatch enforcement). |
 | `CQS_MD_MAX_SECTION_LINES` | `150` | Max markdown section lines before overflow split |
 | `CQS_MD_MIN_SECTION_LINES` | `30` | Min markdown section lines (smaller sections merge) |
 | `CQS_MIGRATE_KEEP_BACKUPS` | `3` | Number of version-tagged migration backups retained in the DB's parent directory; older ones are pruned after every successful migrate. `3` = the current run's backup plus the two prior runs'. `0` is honored verbatim (prune all after a successful migrate) for tight-quota mounts. |

--- a/src/cli/batch/commands.rs
+++ b/src/cli/batch/commands.rs
@@ -234,6 +234,27 @@ pub(crate) enum BatchCmd {
         #[allow(dead_code, reason = "Task #8: --json accepted for CLI parity")]
         output: TextJsonArgs,
     },
+    /// Add a note (MCP Phase 2a gated mutation channel).
+    ///
+    /// `#[command(skip)]` — NOT argv-reachable on the daemon socket. The only
+    /// constructor is `json_args::build_batch_cmd`, gated behind
+    /// `CQS_MCP_ENABLE_MUTATIONS`. The handler writes `docs/notes.toml` (a file,
+    /// not the `Store<ReadOnly>`); the watch loop reindexes — so the daemon's
+    /// read-only Store typestate is preserved.
+    #[command(skip)]
+    NotesAdd {
+        args: crate::cli::commands::notes::NotesAddArgs,
+    },
+    /// Update a note (MCP Phase 2a gated mutation channel). See `NotesAdd`.
+    #[command(skip)]
+    NotesUpdate {
+        args: crate::cli::commands::notes::NotesUpdateArgs,
+    },
+    /// Remove a note (MCP Phase 2a gated mutation channel). See `NotesAdd`.
+    #[command(skip)]
+    NotesRemove {
+        args: crate::cli::commands::notes::NotesRemoveArgs,
+    },
     /// One-shot implementation context (terminal — no pipeline chaining)
     Task {
         #[command(flatten)]
@@ -420,6 +441,9 @@ macro_rules! for_each_batch_cmd {
                 (Stale,      dispatch_stale,        false)
                 (Drift,      dispatch_drift,        false)
                 (Notes,      dispatch_notes,        false)
+                (NotesAdd,    dispatch_notes_add,    false)
+                (NotesUpdate, dispatch_notes_update, false)
+                (NotesRemove, dispatch_notes_remove, false)
                 (Task,       dispatch_task,         false)
                 (Review,     dispatch_review,       false)
                 (Ci,         dispatch_ci,           false)

--- a/src/cli/batch/handlers/misc.rs
+++ b/src/cli/batch/handlers/misc.rs
@@ -195,6 +195,54 @@ pub(in crate::cli::batch) fn dispatch_notes(
     ))
 }
 
+/// Daemon handler for `notes add` (MCP Phase 2a gated mutation channel).
+///
+/// Writes `docs/notes.toml` via the shared [`notes_add_core`] — a plain file
+/// write under the file lock, NOT a `Store` write. The watch loop reindexes the
+/// file on its next tick. This is the load-bearing invariant: the daemon holds
+/// a `Store<ReadOnly>` (`ctx.store()` returns `Arc<Store<ReadOnly>>`), and this
+/// handler never acquires a writable store, so the typestate guarantee that the
+/// daemon cannot mutate the index DB is preserved.
+///
+/// Reachable only when `build_batch_cmd` constructed `BatchCmd::NotesAdd`, which
+/// is gated behind `CQS_MCP_ENABLE_MUTATIONS` (the operator opt-in).
+pub(in crate::cli::batch) fn dispatch_notes_add(
+    ctx: &BatchView,
+    args: &crate::cli::commands::notes::NotesAddArgs,
+) -> Result<serde_json::Value> {
+    let _span = tracing::info_span!("batch_notes_add").entered();
+    let core = crate::cli::commands::notes::notes_add_core(&ctx.root, args)?;
+    Ok(crate::cli::commands::notes::notes_mutation_daemon_json(
+        &core,
+    ))
+}
+
+/// Daemon handler for `notes update` (MCP Phase 2a). See [`dispatch_notes_add`]
+/// for the `Store<ReadOnly>` invariant — this writes the file, watch reindexes.
+pub(in crate::cli::batch) fn dispatch_notes_update(
+    ctx: &BatchView,
+    args: &crate::cli::commands::notes::NotesUpdateArgs,
+) -> Result<serde_json::Value> {
+    let _span = tracing::info_span!("batch_notes_update").entered();
+    let core = crate::cli::commands::notes::notes_update_core(&ctx.root, args)?;
+    Ok(crate::cli::commands::notes::notes_mutation_daemon_json(
+        &core,
+    ))
+}
+
+/// Daemon handler for `notes remove` (MCP Phase 2a). See [`dispatch_notes_add`]
+/// for the `Store<ReadOnly>` invariant — this writes the file, watch reindexes.
+pub(in crate::cli::batch) fn dispatch_notes_remove(
+    ctx: &BatchView,
+    args: &crate::cli::commands::notes::NotesRemoveArgs,
+) -> Result<serde_json::Value> {
+    let _span = tracing::info_span!("batch_notes_remove").entered();
+    let core = crate::cli::commands::notes::notes_remove_core(&ctx.root, args)?;
+    Ok(crate::cli::commands::notes::notes_mutation_daemon_json(
+        &core,
+    ))
+}
+
 /// Dispatches a task execution within a batch context, optionally with token budgeting.
 /// This function executes a task based on a natural language description, retrieving relevant code chunks and generating a JSON representation of the results. When a token budget is specified, it applies waterfall budgeting similar to the CLI; otherwise, it returns the standard task JSON representation.
 /// # Arguments

--- a/src/cli/batch/handlers/mod.rs
+++ b/src/cli/batch/handlers/mod.rs
@@ -31,8 +31,9 @@ pub(super) use info::{
 };
 pub(super) use misc::{
     dispatch_diff, dispatch_drift, dispatch_gather, dispatch_gc, dispatch_help, dispatch_notes,
-    dispatch_ping, dispatch_plan, dispatch_reconcile, dispatch_refresh, dispatch_scout,
-    dispatch_status, dispatch_task, dispatch_wait_fresh, dispatch_where,
+    dispatch_notes_add, dispatch_notes_remove, dispatch_notes_update, dispatch_ping, dispatch_plan,
+    dispatch_reconcile, dispatch_refresh, dispatch_scout, dispatch_status, dispatch_task,
+    dispatch_wait_fresh, dispatch_where,
 };
 pub(super) use search::dispatch_search;
 

--- a/src/cli/batch/json_args.rs
+++ b/src/cli/batch/json_args.rs
@@ -301,12 +301,51 @@ pub(super) fn build_batch_cmd(command: &str, arguments: &serde_json::Value) -> R
                 output: text_json(),
             }
         }
+        // ─── MCP Phase 2a: the gated notes-mutation channel ────────────────────
+        //
+        // These reverse the historical "notes mutations not on daemon" rejection,
+        // but ONLY behind the operator opt-in `CQS_MCP_ENABLE_MUTATIONS=1`
+        // (`mcp::mutations_enabled`). The handlers write `docs/notes.toml` (a
+        // file, not the `Store<ReadOnly>`); the watch loop reindexes — so the
+        // daemon's read-only-Store typestate is preserved. The flag is checked
+        // here too (not just in the bridge's `tools/list`) so a raw socket client
+        // that bypasses the tool list still cannot mutate without the opt-in.
+        // The destructive set stays withheld by ABSENCE — no arm exists for it.
+        "notes-add" => {
+            require_mutations_enabled(command)?;
+            let c: crate::cli::commands::notes::NotesAddArgs = parse_core(command, arguments)?;
+            BatchCmd::NotesAdd { args: c }
+        }
+        "notes-update" => {
+            require_mutations_enabled(command)?;
+            let c: crate::cli::commands::notes::NotesUpdateArgs = parse_core(command, arguments)?;
+            BatchCmd::NotesUpdate { args: c }
+        }
+        "notes-remove" => {
+            require_mutations_enabled(command)?;
+            let c: crate::cli::commands::notes::NotesRemoveArgs = parse_core(command, arguments)?;
+            BatchCmd::NotesRemove { args: c }
+        }
         other => bail!(
             "command '{other}' does not accept a JSON `arguments` object \
              (no Phase-0 core struct); use the argv `args` form"
         ),
     };
     Ok(cmd)
+}
+
+/// Reject a gated mutation command when the operator has not opted in via
+/// `CQS_MCP_ENABLE_MUTATIONS=1`. The boundary is enforced daemon-side, not only
+/// in the bridge's `tools/list`, so a raw socket client cannot bypass it.
+fn require_mutations_enabled(command: &str) -> Result<()> {
+    if !crate::cli::mcp::mutations_enabled() {
+        bail!(
+            "command '{command}' is a gated MCP mutation; set \
+             {}=1 to enable the notes-mutation channel",
+            crate::cli::mcp::MUTATIONS_ENV
+        );
+    }
+    Ok(())
 }
 
 // ─── Core → args.rs converters ─────────────────────────────────────────────
@@ -815,11 +854,193 @@ mod tests {
     /// error on the JSON-args path rather than dispatching or panicking.
     #[test]
     fn argv_only_command_rejected_on_json_path() {
-        // `notes` / `where` / `explain` are argv-only in Phase 1.
+        // `where` / `explain` are argv-only. (`notes-*` mutations now have a
+        // gated core — covered by the MCP Phase-2a tests below.)
         let err = build_batch_cmd("where", &json!({"description": "x"}));
         assert!(
             err.is_err(),
             "an argv-only command must be rejected on the JSON-args path"
+        );
+    }
+
+    // ─── MCP Phase 2a: gated notes-mutation channel ────────────────────────────
+
+    /// RAII guard for `CQS_MCP_ENABLE_MUTATIONS`, restoring the prior value on
+    /// drop. Pairs with `#[serial_test::serial(mcp_mutations_env)]`.
+    struct MutEnvGuard {
+        prior: Option<String>,
+    }
+    impl MutEnvGuard {
+        fn set(on: bool) -> Self {
+            let prior = std::env::var("CQS_MCP_ENABLE_MUTATIONS").ok();
+            if on {
+                std::env::set_var("CQS_MCP_ENABLE_MUTATIONS", "1");
+            } else {
+                std::env::remove_var("CQS_MCP_ENABLE_MUTATIONS");
+            }
+            Self { prior }
+        }
+    }
+    impl Drop for MutEnvGuard {
+        fn drop(&mut self) {
+            match &self.prior {
+                Some(v) => std::env::set_var("CQS_MCP_ENABLE_MUTATIONS", v),
+                None => std::env::remove_var("CQS_MCP_ENABLE_MUTATIONS"),
+            }
+        }
+    }
+
+    /// Read `docs/notes.toml` text under a project root, "" if absent.
+    fn read_notes_toml(root: &std::path::Path) -> String {
+        std::fs::read_to_string(root.join("docs/notes.toml")).unwrap_or_default()
+    }
+
+    /// With the flag OFF, every notes mutation is rejected by `build_batch_cmd`
+    /// — the daemon-side enforcement that a raw socket client can't bypass the
+    /// bridge's `tools/list` gating. No file is written.
+    #[test]
+    #[serial_test::serial(mcp_mutations_env)]
+    fn notes_mutations_rejected_when_flag_off() {
+        let _guard = MutEnvGuard::set(false);
+        let (dir, ctx) = seed_ctx();
+        for (command, arguments) in [
+            ("notes-add", json!({"text": "a note", "sentiment": -0.5})),
+            (
+                "notes-update",
+                json!({"text": "a note", "new_text": "b note"}),
+            ),
+            ("notes-remove", json!({"text": "a note"})),
+        ] {
+            // build_batch_cmd refuses without the opt-in.
+            assert!(
+                build_batch_cmd(command, &arguments).is_err(),
+                "`{command}` must be rejected when CQS_MCP_ENABLE_MUTATIONS is unset"
+            );
+            // And the full dispatch returns an error envelope, no file written.
+            let mut out = Vec::new();
+            dispatch_via_view_json(&ctx.build_view(None), command, &arguments, &mut out);
+            let v: serde_json::Value = serde_json::from_slice(&out).expect("JSON");
+            assert!(
+                v.get("error").is_some_and(|e| !e.is_null()),
+                "`{command}` flag-off must return an error envelope, got: {v}"
+            );
+        }
+        assert!(
+            read_notes_toml(dir.path()).is_empty(),
+            "no notes.toml must be written while the flag is off"
+        );
+    }
+
+    /// With the flag ON, `notes-add` over the JSON-args path actually appends to
+    /// the temp `docs/notes.toml` (the gate-safe file write) and returns a
+    /// success envelope marked `reindex_deferred` (the daemon does NOT reindex
+    /// — the watch loop does).
+    #[test]
+    #[serial_test::serial(mcp_mutations_env)]
+    fn notes_add_round_trip_writes_file() {
+        let _guard = MutEnvGuard::set(true);
+        let (dir, ctx) = seed_ctx();
+        let mut out = Vec::new();
+        dispatch_via_view_json(
+            &ctx.build_view(None),
+            "notes-add",
+            &json!({"text": "daemon wrote this", "sentiment": -0.5, "mentions": ["json_args.rs"]}),
+            &mut out,
+        );
+        let v: serde_json::Value = serde_json::from_slice(&out).expect("JSON");
+        // Success envelope (data present, no error).
+        assert!(
+            v.get("data").is_some_and(|d| !d.is_null()),
+            "notes-add must return a data envelope, got: {v}"
+        );
+        let data = &v["data"];
+        assert_eq!(data["status"], "added");
+        assert_eq!(
+            data["reindex_deferred"], true,
+            "daemon path defers reindex to the watch loop"
+        );
+        assert_eq!(
+            data["indexed"], false,
+            "daemon path does not reindex from the handler"
+        );
+        // The file was actually written with the note text.
+        let toml = read_notes_toml(dir.path());
+        assert!(
+            toml.contains("daemon wrote this"),
+            "notes.toml must contain the appended note, got:\n{toml}"
+        );
+        assert!(
+            toml.contains("json_args.rs"),
+            "notes.toml must contain the mention, got:\n{toml}"
+        );
+    }
+
+    /// Flag ON: a full add → update → remove round-trip over the JSON-args path,
+    /// each mutation reflected in the temp file.
+    #[test]
+    #[serial_test::serial(mcp_mutations_env)]
+    fn notes_add_update_remove_round_trip() {
+        let _guard = MutEnvGuard::set(true);
+        let (dir, ctx) = seed_ctx();
+        let run = |command: &str, arguments: serde_json::Value| -> serde_json::Value {
+            let mut out = Vec::new();
+            dispatch_via_view_json(&ctx.build_view(None), command, &arguments, &mut out);
+            serde_json::from_slice(&out).expect("JSON")
+        };
+
+        // add
+        let v = run("notes-add", json!({"text": "first", "sentiment": 0.0}));
+        assert_eq!(v["data"]["status"], "added");
+        assert!(read_notes_toml(dir.path()).contains("first"));
+
+        // update (idempotent rewrite)
+        let v = run(
+            "notes-update",
+            json!({"text": "first", "new_text": "second"}),
+        );
+        assert_eq!(v["data"]["status"], "updated");
+        let toml = read_notes_toml(dir.path());
+        assert!(toml.contains("second"), "updated text present");
+        assert!(!toml.contains("\"first\""), "old text gone");
+
+        // remove
+        let v = run("notes-remove", json!({"text": "second"}));
+        assert_eq!(v["data"]["status"], "removed");
+        assert!(
+            !read_notes_toml(dir.path()).contains("second"),
+            "removed note gone from file"
+        );
+
+        // remove again → not-found error (idempotent no-op surfaces as error).
+        let v = run("notes-remove", json!({"text": "second"}));
+        assert!(
+            v.get("error").is_some_and(|e| !e.is_null()),
+            "removing an absent note must error, got: {v}"
+        );
+    }
+
+    /// The daemon notes-write path preserves `Store<ReadOnly>`: it never
+    /// acquires a writable store. We assert this by type — `ctx.store()` returns
+    /// `Arc<Store<ReadOnly>>`, and the round-trip above mutates the FILE while
+    /// the same view's store stays read-only and usable.
+    #[test]
+    #[serial_test::serial(mcp_mutations_env)]
+    fn notes_write_keeps_store_read_only() {
+        let _guard = MutEnvGuard::set(true);
+        let (_dir, ctx) = seed_ctx();
+        let view = ctx.build_view(None);
+        // Type assertion: the view's store is read-only (compile-time proof the
+        // handler had no writable store to reach for).
+        let store: std::sync::Arc<cqs::store::Store<cqs::store::ReadOnly>> = view.store();
+        let mut out = Vec::new();
+        dispatch_via_view_json(&view, "notes-add", &json!({"text": "ro check"}), &mut out);
+        let v: serde_json::Value = serde_json::from_slice(&out).expect("JSON");
+        assert_eq!(v["data"]["status"], "added");
+        // The read-only store is still live after the file mutation (a read
+        // succeeds — the typestate was never traded for a writable handle).
+        assert!(
+            store.chunk_count().is_ok(),
+            "the daemon's Store<ReadOnly> must stay usable across a notes write"
         );
     }
 

--- a/src/cli/commands/io/notes.rs
+++ b/src/cli/commands/io/notes.rs
@@ -70,6 +70,317 @@ struct NotesListOutput {
     count: usize,
 }
 
+// ─── Mutation cores (surface-agnostic, MCP-ready) ──────────────────────────────
+
+/// Input for [`notes_add_core`]: the field surface a note-add consumer sets.
+/// Derives `serde::Deserialize` + `schemars::JsonSchema` so it doubles as the
+/// MCP `cqs_notes_add` `inputSchema` source and the daemon deserialize target.
+///
+/// `#[serde(default)]` on the struct so a wire/MCP caller can supply just
+/// `text` and inherit the production defaults for the rest.
+#[derive(Debug, Clone, PartialEq, Default, serde::Deserialize, schemars::JsonSchema)]
+#[serde(default)]
+pub(crate) struct NotesAddArgs {
+    /// Note text (natural language). Required; whitespace-only is rejected.
+    pub text: String,
+    /// Sentiment on the discrete grid {-1, -0.5, 0, 0.5, 1}; off-grid values
+    /// snap to the nearest.
+    pub sentiment: f32,
+    /// File paths or concepts this note relates to.
+    pub mentions: Option<Vec<String>>,
+    /// Structured kind tag (`todo`, `design-decision`, `known-bug`, …);
+    /// kebab-case lowercase by convention. Empty string is treated as absent.
+    pub kind: Option<String>,
+}
+
+/// Input for [`notes_update_core`]: the exact match-text plus the optional new
+/// fields. At least one `new_*` field must be set (enforced in the core).
+#[derive(Debug, Clone, PartialEq, Default, serde::Deserialize, schemars::JsonSchema)]
+#[serde(default)]
+pub(crate) struct NotesUpdateArgs {
+    /// Exact (trimmed) text of the note to update — the match key.
+    pub text: String,
+    /// Replacement text. When omitted, the existing text is kept.
+    pub new_text: Option<String>,
+    /// Replacement sentiment (snapped to the discrete grid). When omitted, kept.
+    pub new_sentiment: Option<f32>,
+    /// Replacement mentions (replaces the whole list). When omitted, kept.
+    pub new_mentions: Option<Vec<String>>,
+    /// Replacement kind tag. Pass an empty string to clear; omit to keep.
+    pub new_kind: Option<String>,
+}
+
+/// Input for [`notes_remove_core`]: the exact match-text of the note to delete.
+#[derive(Debug, Clone, PartialEq, Default, serde::Deserialize, schemars::JsonSchema)]
+#[serde(default)]
+pub(crate) struct NotesRemoveArgs {
+    /// Exact (trimmed) text of the note to remove — the match key.
+    pub text: String,
+}
+
+/// What a mutation core produced for the adapter to format. Carries the
+/// post-write facts (status, the preview text, the sentiment/label for `add`)
+/// but does NOT perform any reindex — the gate-safe daemon path leaves the
+/// `docs/notes.toml` reindex to the watch loop, and the CLI adapter runs its
+/// own reindex on top of this.
+pub(crate) struct NoteMutationCore {
+    /// `"added"` / `"updated"` / `"removed"`.
+    pub status: &'static str,
+    /// Text-preview for the confirmation (already truncated).
+    pub text_preview: String,
+    /// The coarse sentiment label (`"warning"`/`"pattern"`/`"observation"`),
+    /// set for `add` only — `update`/`remove` leave it `None`.
+    pub note_type: Option<&'static str>,
+    /// The snapped sentiment, set for `add` only.
+    pub sentiment: Option<f32>,
+}
+
+/// Surface-agnostic core for `cqs notes add`: validate text/sentiment/mentions/
+/// kind, then append to `docs/notes.toml` under the file lock (creating the file
+/// with header if absent). Rejects whitespace-only text, over-cap text/mentions,
+/// and exact (post-trim) duplicates.
+///
+/// **No reindex.** This is the load-bearing gate-safe path: the daemon
+/// (`Store<ReadOnly>`) drives this core, writes the `notes.toml` *file*, and
+/// relies on the watch loop to reindex — it never acquires a writable `Store`.
+/// The CLI adapter calls this core and then reindexes itself.
+pub(crate) fn notes_add_core(
+    root: &std::path::Path,
+    args: &NotesAddArgs,
+) -> Result<NoteMutationCore> {
+    let _span = tracing::info_span!(
+        "notes_add_core",
+        text_len = args.text.len(),
+        sentiment = args.sentiment,
+        kind = args.kind.as_deref().unwrap_or(""),
+    )
+    .entered();
+    let text = validate_note_text(&args.text, "Note text")?;
+    // Snap to the discrete grid BEFORE the TOML write so the file, the
+    // confirmation, and (after reindex) the DB all agree — snapping only on
+    // read-back would leave the raw value in notes.toml and disagree with the DB.
+    let sentiment = cqs::note::snap_sentiment(args.sentiment);
+    let mentions = validate_mentions(args.mentions.as_deref().unwrap_or(&[]), "mentions")?;
+    let kind = normalize_kind(args.kind.as_deref());
+
+    let note_entry = NoteEntry {
+        sentiment,
+        text: text.to_string(),
+        mentions,
+        kind,
+    };
+
+    let notes_path = ensure_notes_file(root)?;
+    // Duplicate check inside the rewrite closure so it runs under the same
+    // exclusive lock as the append (no read-then-write race).
+    rewrite_notes_file(&notes_path, |entries| {
+        if entries.iter().any(|e| e.text.trim() == text) {
+            return Err(cqs::NoteError::Duplicate(format!(
+                "a note with this text already exists in docs/notes.toml: '{}' \
+                 (use 'cqs notes update' or 'cqs notes remove' instead)",
+                text_preview(text)
+            )));
+        }
+        entries.push(note_entry.clone());
+        Ok(())
+    })
+    .context("Failed to add note")?;
+
+    let note_type = if sentiment < -0.3 {
+        "warning"
+    } else if sentiment > 0.3 {
+        "pattern"
+    } else {
+        "observation"
+    };
+    Ok(NoteMutationCore {
+        status: "added",
+        text_preview: text_preview(text),
+        note_type: Some(note_type),
+        sentiment: Some(sentiment),
+    })
+}
+
+/// Surface-agnostic core for `cqs notes update`: match by exact trimmed text,
+/// apply the supplied new fields to the FIRST match, rewrite `docs/notes.toml`.
+/// Requires at least one `new_*` field. No reindex (see [`notes_add_core`]).
+pub(crate) fn notes_update_core(
+    root: &std::path::Path,
+    args: &NotesUpdateArgs,
+) -> Result<NoteMutationCore> {
+    let _span = tracing::info_span!(
+        "notes_update_core",
+        text_len = args.text.len(),
+        new_text_len = args.new_text.as_deref().map(str::len),
+    )
+    .entered();
+    if args.text.trim().is_empty() {
+        bail!("Note text cannot be empty or whitespace-only");
+    }
+    if args.new_text.is_none()
+        && args.new_sentiment.is_none()
+        && args.new_mentions.is_none()
+        && args.new_kind.is_none()
+    {
+        bail!(
+            "At least one of new_text, new_sentiment, new_mentions, or new_kind \
+             must be provided"
+        );
+    }
+    let new_text = args
+        .new_text
+        .as_deref()
+        .map(|t| validate_note_text(t, "new_text"))
+        .transpose()?;
+
+    let notes_path = root.join("docs/notes.toml");
+    if !notes_path.exists() {
+        bail!("No notes.toml found. Use 'cqs notes add' to create notes first.");
+    }
+
+    let text_trimmed = args.text.trim();
+    let new_text_owned = new_text.map(|s| s.to_string());
+    let new_sentiment_clamped = args.new_sentiment.map(cqs::note::snap_sentiment);
+    let new_mentions_owned = args
+        .new_mentions
+        .as_deref()
+        .map(|m| validate_mentions(m, "new_mentions"))
+        .transpose()?;
+    // `Some(None)` = clear the kind; `None` = leave existing.
+    let new_kind_norm: Option<Option<String>> = args.new_kind.as_deref().map(|k| {
+        let trimmed = k.trim().to_ascii_lowercase();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed)
+        }
+    });
+
+    rewrite_notes_file(&notes_path, |entries| {
+        let entry = entries
+            .iter_mut()
+            .find(|e| e.text.trim() == text_trimmed)
+            .ok_or_else(|| {
+                cqs::NoteError::NotFound(format!(
+                    "No note with text: '{}'",
+                    text_preview(text_trimmed)
+                ))
+            })?;
+        if let Some(ref t) = new_text_owned {
+            entry.text = t.clone();
+        }
+        if let Some(s) = new_sentiment_clamped {
+            entry.sentiment = s;
+        }
+        if let Some(ref m) = new_mentions_owned {
+            entry.mentions = m.clone();
+        }
+        if let Some(ref k) = new_kind_norm {
+            entry.kind = k.clone();
+        }
+        Ok(())
+    })
+    .context("Failed to update note")?;
+
+    let final_text = new_text.unwrap_or(args.text.as_str());
+    Ok(NoteMutationCore {
+        status: "updated",
+        text_preview: text_preview(final_text),
+        note_type: None,
+        sentiment: None,
+    })
+}
+
+/// Surface-agnostic core for `cqs notes remove`: match by exact trimmed text,
+/// delete the FIRST match from `docs/notes.toml`. No reindex (see
+/// [`notes_add_core`]).
+pub(crate) fn notes_remove_core(
+    root: &std::path::Path,
+    args: &NotesRemoveArgs,
+) -> Result<NoteMutationCore> {
+    let _span = tracing::info_span!("notes_remove_core", text_len = args.text.len()).entered();
+    if args.text.trim().is_empty() {
+        bail!("Note text cannot be empty or whitespace-only");
+    }
+
+    let notes_path = root.join("docs/notes.toml");
+    if !notes_path.exists() {
+        bail!("No notes.toml found");
+    }
+
+    let text_trimmed = args.text.trim();
+    let mut removed_text = String::new();
+    rewrite_notes_file(&notes_path, |entries| {
+        let pos = entries
+            .iter()
+            .position(|e| e.text.trim() == text_trimmed)
+            .ok_or_else(|| {
+                cqs::NoteError::NotFound(format!(
+                    "No note with text: '{}'",
+                    text_preview(text_trimmed)
+                ))
+            })?;
+        removed_text = entries[pos].text.clone();
+        entries.remove(pos);
+        Ok(())
+    })
+    .context("Failed to remove note")?;
+
+    Ok(NoteMutationCore {
+        status: "removed",
+        text_preview: text_preview(&removed_text),
+        note_type: None,
+        sentiment: None,
+    })
+}
+
+/// Serialize a [`NoteMutationCore`] into the daemon-path JSON `data` payload.
+///
+/// Same envelope shape as the CLI's `--json` output (`status` / `type` /
+/// `sentiment` / `text_preview` / `file`), but `indexed:false` and
+/// `total_notes:0` because the daemon (MCP Phase 2a) does NOT reindex from the
+/// handler — it wrote the `notes.toml` *file* and leaves the reindex to the
+/// watch loop (the `Store<ReadOnly>` invariant). The `reindex_deferred` flag is
+/// the honest signal that the index lags the file until the next watch tick.
+pub(crate) fn notes_mutation_daemon_json(core: &NoteMutationCore) -> serde_json::Value {
+    let result = NoteMutationOutput {
+        status: core.status.into(),
+        note_type: core.note_type.map(str::to_string),
+        sentiment: core.sentiment,
+        text_preview: core.text_preview.clone(),
+        file: "docs/notes.toml".into(),
+        indexed: false,
+        total_notes: 0,
+        index_error: None,
+    };
+    let mut value = serde_json::to_value(&result).unwrap_or_else(|e| {
+        // to_value on a #[derive(Serialize)] struct of owned primitives cannot
+        // fail in practice; degrade rather than panic on the unreachable path.
+        tracing::warn!(error = %e, "notes_mutation_daemon_json serialization failed");
+        serde_json::json!({ "status": core.status, "file": "docs/notes.toml" })
+    });
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert(
+            "reindex_deferred".to_string(),
+            serde_json::Value::Bool(true),
+        );
+    }
+    value
+}
+
+/// Normalize a `--kind` value: trim, lowercase, empty → None. Shared by the
+/// add core and the CLI/daemon paths so add/parse stay in sync.
+fn normalize_kind(raw: Option<&str>) -> Option<String> {
+    raw.and_then(|k| {
+        let trimmed = k.trim().to_ascii_lowercase();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed)
+        }
+    })
+}
+
 // ─── Surface-agnostic core ────────────────────────────────────────────────────
 
 /// Surface-agnostic JSON core for `cqs notes list`. Both the CLI
@@ -453,81 +764,28 @@ fn cmd_notes_add(
         no_reindex
     )
     .entered();
-    let text = validate_note_text(text, "Note text")?;
-
-    // Snap to the discrete grid {-1, -0.5, 0, 0.5, 1} BEFORE writing the TOML,
-    // not just before the DB write. `parse_notes_str` snaps on read-back so the
-    // DB stays clean either way, but snapping only there would leave the raw
-    // value (e.g. 0.7) in notes.toml and in the printed confirmation while the
-    // DB holds 0.5 — a permanent file/DB disagreement.
-    let sentiment = cqs::note::snap_sentiment(sentiment);
-    let mentions = validate_mentions(mentions.unwrap_or(&[]), "--mentions")?;
-    // Normalize kind (trim + lowercase + reject empty). Mirrors the
-    // parser's `normalize_kind` semantics so add and parse stay in sync —
-    // `--kind ""` is silently absent, not stored as Some("").
-    let kind: Option<String> = kind.and_then(|raw| {
-        let trimmed = raw.trim().to_ascii_lowercase();
-        if trimmed.is_empty() {
-            None
-        } else {
-            Some(trimmed)
-        }
-    });
-
-    let note_entry = NoteEntry {
-        sentiment,
-        text: text.to_string(),
-        mentions,
-        kind,
-    };
 
     let root = resolve_root(ctx);
-    let notes_path = ensure_notes_file(&root)?;
+    // The file-write + validation lives in the shared core (also the daemon's
+    // gate-safe path); the CLI adds the reindex + rendering on top.
+    let core = notes_add_core(
+        &root,
+        &NotesAddArgs {
+            text: text.to_string(),
+            sentiment,
+            mentions: mentions.map(<[String]>::to_vec),
+            kind: kind.map(str::to_string),
+        },
+    )?;
 
-    // Duplicate check lives inside the rewrite closure so it runs under the
-    // same exclusive lock as the append — no read-then-write race with a
-    // concurrent add. Notes carry search-ranking sentiment, and update/remove
-    // mutate only the first text match, so a duplicate would survive a
-    // "remove" and keep skewing rankings; reject it outright.
-    rewrite_notes_file(&notes_path, |entries| {
-        if entries.iter().any(|e| e.text.trim() == text) {
-            return Err(cqs::NoteError::Duplicate(format!(
-                "a note with this text already exists in docs/notes.toml: '{}' \
-                 (use 'cqs notes update' or 'cqs notes remove' instead)",
-                text_preview(text)
-            )));
-        }
-        entries.push(note_entry.clone());
-        Ok(())
-    })
-    .context("Failed to add note")?;
-
-    let (indexed, index_error) = if no_reindex {
-        (0, None)
-    } else {
-        // Open read-write store lazily *only* when a mutation actually runs,
-        // so list-only invocations never pay the cost of a second connection
-        // (avoid double-connecting during pure reads).
-        match open_rw_store(&root) {
-            Ok(store) => reindex_notes(root.as_path(), &store),
-            Err(e) => (0, Some(format!("{e}"))),
-        }
-    };
-
-    let sentiment_label = if sentiment < -0.3 {
-        "warning"
-    } else if sentiment > 0.3 {
-        "pattern"
-    } else {
-        "observation"
-    };
+    let (indexed, index_error) = reindex_after_mutation(&root, no_reindex);
 
     if cli.json || output_json {
         let result = NoteMutationOutput {
-            status: "added".into(),
-            note_type: Some(sentiment_label.into()),
-            sentiment: Some(sentiment),
-            text_preview: text_preview(text),
+            status: core.status.into(),
+            note_type: core.note_type.map(str::to_string),
+            sentiment: core.sentiment,
+            text_preview: core.text_preview.clone(),
             file: "docs/notes.toml".into(),
             indexed: indexed > 0,
             total_notes: indexed,
@@ -537,9 +795,9 @@ fn cmd_notes_add(
     } else {
         println!(
             "Added {} (sentiment: {:+.1}): {}",
-            sentiment_label,
-            sentiment,
-            text_preview(text)
+            core.note_type.unwrap_or("observation"),
+            core.sentiment.unwrap_or(0.0),
+            core.text_preview
         );
         if indexed > 0 {
             println!("Indexed {} notes.", indexed);
@@ -554,6 +812,22 @@ fn cmd_notes_add(
     }
 
     Ok(())
+}
+
+/// CLI-only post-mutation reindex: open a read-write store lazily and re-parse +
+/// re-index `docs/notes.toml`. Returns `(indexed_count, optional_error)`.
+/// Skipped when `no_reindex` is set. The daemon path does NOT call this — it
+/// leaves reindexing to the watch loop (the `Store<ReadOnly>` invariant).
+fn reindex_after_mutation(root: &std::path::Path, no_reindex: bool) -> (usize, Option<String>) {
+    if no_reindex {
+        return (0, None);
+    }
+    // Open read-write store lazily *only* when a mutation actually runs, so
+    // list-only invocations never pay for a second connection.
+    match open_rw_store(root) {
+        Ok(store) => reindex_notes(root, &store),
+        Err(e) => (0, Some(format!("{e}"))),
+    }
 }
 
 /// Update a note: match by text, apply new text/sentiment/mentions/kind, optionally reindex.
@@ -589,96 +863,29 @@ fn cmd_notes_update(
         no_reindex
     )
     .entered();
-    // Trimmed-empty rejection (not just `is_empty`): a whitespace-only query
-    // would trim to "" and match any whitespace-only entry a hand-edited
-    // file might contain.
-    if text.trim().is_empty() {
-        bail!("Note text cannot be empty or whitespace-only");
-    }
-    if new_text.is_none() && new_sentiment.is_none() && new_mentions.is_none() && new_kind.is_none()
-    {
-        bail!(
-            "At least one of --new-text, --new-sentiment, --new-mentions, or --new-kind \
-             must be provided"
-        );
-    }
-    let new_text = new_text
-        .map(|t| validate_note_text(t, "--new-text"))
-        .transpose()?;
 
     let root = resolve_root(ctx);
-    let notes_path = root.join("docs/notes.toml");
-    if !notes_path.exists() {
-        bail!("No notes.toml found. Use 'cqs notes add' to create notes first.");
-    }
+    // The match + file-rewrite + validation lives in the shared core (also the
+    // daemon's gate-safe path); the CLI adds the reindex + rendering on top.
+    let core = notes_update_core(
+        &root,
+        &NotesUpdateArgs {
+            text: text.to_string(),
+            new_text: new_text.map(str::to_string),
+            new_sentiment,
+            new_mentions: new_mentions.map(<[String]>::to_vec),
+            new_kind: new_kind.map(str::to_string),
+        },
+    )?;
 
-    let text_trimmed = text.trim();
-    let new_text_owned = new_text.map(|s| s.to_string());
-    // Snap to the discrete grid before the TOML write — same rationale as
-    // `notes add`: keep the file, the confirmation output, and the DB all
-    // showing the same value.
-    let new_sentiment_clamped = new_sentiment.map(cqs::note::snap_sentiment);
-    let new_mentions_owned = new_mentions
-        .map(|m| validate_mentions(m, "--new-mentions"))
-        .transpose()?;
-    // Apply the same normalization `notes add --kind` uses: trim,
-    // lowercase, empty → None. `Some(None)` means "the user passed
-    // `--new-kind` with an empty/whitespace value, intending to
-    // clear the field"; `None` means "the flag wasn't passed, leave
-    // existing kind alone."
-    let new_kind_norm: Option<Option<String>> = new_kind.map(|k| {
-        let trimmed = k.trim().to_ascii_lowercase();
-        if trimmed.is_empty() {
-            None
-        } else {
-            Some(trimmed)
-        }
-    });
+    let (indexed, index_error) = reindex_after_mutation(&root, no_reindex);
 
-    rewrite_notes_file(&notes_path, |entries| {
-        let entry = entries
-            .iter_mut()
-            .find(|e| e.text.trim() == text_trimmed)
-            .ok_or_else(|| {
-                cqs::NoteError::NotFound(format!(
-                    "No note with text: '{}'",
-                    text_preview(text_trimmed)
-                ))
-            })?;
-
-        if let Some(ref t) = new_text_owned {
-            entry.text = t.clone();
-        }
-        if let Some(s) = new_sentiment_clamped {
-            entry.sentiment = s;
-        }
-        if let Some(ref m) = new_mentions_owned {
-            entry.mentions = m.clone();
-        }
-        if let Some(ref k) = new_kind_norm {
-            entry.kind = k.clone();
-        }
-        Ok(())
-    })
-    .context("Failed to update note")?;
-
-    let (indexed, index_error) = if no_reindex {
-        (0, None)
-    } else {
-        // Open read-write store lazily *only* when a mutation actually runs.
-        match open_rw_store(&root) {
-            Ok(store) => reindex_notes(root.as_path(), &store),
-            Err(e) => (0, Some(format!("{e}"))),
-        }
-    };
-
-    let final_text = new_text.unwrap_or(text);
     if cli.json || output_json {
         let result = NoteMutationOutput {
-            status: "updated".into(),
+            status: core.status.into(),
             note_type: None,
             sentiment: None,
-            text_preview: text_preview(final_text),
+            text_preview: core.text_preview.clone(),
             file: "docs/notes.toml".into(),
             indexed: indexed > 0,
             total_notes: indexed,
@@ -686,7 +893,7 @@ fn cmd_notes_update(
         };
         crate::cli::json_envelope::emit_json(&result)?;
     } else {
-        println!("Updated: {}", text_preview(final_text));
+        println!("Updated: {}", core.text_preview);
         if indexed > 0 {
             println!("Indexed {} notes.", indexed);
         }
@@ -716,54 +923,25 @@ fn cmd_notes_remove(
     // Per-subhandler span — see `cmd_notes_add`.
     let _span =
         tracing::info_span!("cmd_notes_remove", text_len = text.len(), no_reindex).entered();
-    // Trimmed-empty rejection — see `cmd_notes_update` for the
-    // whitespace-only wildcard rationale.
-    if text.trim().is_empty() {
-        bail!("Note text cannot be empty or whitespace-only");
-    }
 
     let root = resolve_root(ctx);
-    let notes_path = root.join("docs/notes.toml");
-    if !notes_path.exists() {
-        bail!("No notes.toml found");
-    }
+    // The match + file-rewrite lives in the shared core (also the daemon's
+    // gate-safe path); the CLI adds the reindex + rendering on top.
+    let core = notes_remove_core(
+        &root,
+        &NotesRemoveArgs {
+            text: text.to_string(),
+        },
+    )?;
 
-    let text_trimmed = text.trim();
-    let mut removed_text = String::new();
-
-    rewrite_notes_file(&notes_path, |entries| {
-        let pos = entries
-            .iter()
-            .position(|e| e.text.trim() == text_trimmed)
-            .ok_or_else(|| {
-                cqs::NoteError::NotFound(format!(
-                    "No note with text: '{}'",
-                    text_preview(text_trimmed)
-                ))
-            })?;
-
-        removed_text = entries[pos].text.clone();
-        entries.remove(pos);
-        Ok(())
-    })
-    .context("Failed to remove note")?;
-
-    let (indexed, index_error) = if no_reindex {
-        (0, None)
-    } else {
-        // Open read-write store lazily *only* when a mutation actually runs.
-        match open_rw_store(&root) {
-            Ok(store) => reindex_notes(root.as_path(), &store),
-            Err(e) => (0, Some(format!("{e}"))),
-        }
-    };
+    let (indexed, index_error) = reindex_after_mutation(&root, no_reindex);
 
     if cli.json || output_json {
         let result = NoteMutationOutput {
-            status: "removed".into(),
+            status: core.status.into(),
             note_type: None,
             sentiment: None,
-            text_preview: text_preview(&removed_text),
+            text_preview: core.text_preview.clone(),
             file: "docs/notes.toml".into(),
             indexed: indexed > 0,
             total_notes: indexed,
@@ -771,7 +949,7 @@ fn cmd_notes_remove(
         };
         crate::cli::json_envelope::emit_json(&result)?;
     } else {
-        println!("Removed: {}", text_preview(&removed_text));
+        println!("Removed: {}", core.text_preview);
         if indexed > 0 {
             println!("Indexed {} notes.", indexed);
         }

--- a/src/cli/commands/search/query.rs
+++ b/src/cli/commands/search/query.rs
@@ -3384,11 +3384,18 @@ mod jsonschema_smoke {
 
     #[test]
     fn command_core_structs_are_mcp_inputschema_ready() {
-        // (a)+(b)+(c) over four representative cores.
+        use crate::cli::commands::notes::{NotesAddArgs, NotesRemoveArgs, NotesUpdateArgs};
+        // (a)+(b)+(c) over four representative read cores.
         assert_inputschema_shape::<QueryArgs>("QueryArgs");
         assert_inputschema_shape::<ImpactArgs>("ImpactArgs");
         assert_inputschema_shape::<GatherArgs>("GatherArgs");
         assert_inputschema_shape::<DeadArgs>("DeadArgs");
+        // The Phase-2a notes-mutation cores are MCP inputSchema sources too —
+        // hold them to the same shape (serde(default) ⇒ wire-optional, 2020-12,
+        // `///`-derived descriptions).
+        assert_inputschema_shape::<NotesAddArgs>("NotesAddArgs");
+        assert_inputschema_shape::<NotesUpdateArgs>("NotesUpdateArgs");
+        assert_inputschema_shape::<NotesRemoveArgs>("NotesRemoveArgs");
 
         // (d) A MINIMAL wire object deserializes — wire-optionality is real, not
         // just declared in the schema. The search struct takes only `query`.

--- a/src/cli/mcp/mod.rs
+++ b/src/cli/mcp/mod.rs
@@ -36,23 +36,66 @@ mod tools;
 
 pub use bridge::serve_stdio;
 
+/// The operator opt-in for the MCP gated-mutation channel (Phase 2a).
+///
+/// Default OFF. When unset, `tools/list` emits exactly the Phase-1 read tools
+/// (zero delta) and the daemon's JSON-args path rejects notes mutations as
+/// before. When set to `1`, the `cqs_notes_add`/`cqs_notes_update`/
+/// `cqs_notes_remove` tools are advertised AND the daemon accepts their
+/// mutating dispatch. The destructive set (`gc`, `slot remove`, …) is withheld
+/// by ABSENCE regardless of this flag — no flag re-enables it in Phase 2a.
+pub(crate) const MUTATIONS_ENV: &str = "CQS_MCP_ENABLE_MUTATIONS";
+
+/// Whether the MCP gated-mutation channel is enabled ([`MUTATIONS_ENV`] == `1`).
+///
+/// Read at both layers so the boundary holds end-to-end: the bridge gates the
+/// advertised tool surface (`tool_table`), and the daemon gates the actual
+/// mutating dispatch (`json_args::build_batch_cmd`). Both read the SAME process
+/// env var, so a raw socket client that bypasses `tools/list` still cannot
+/// trigger a notes write unless the operator opted the daemon in.
+pub(crate) fn mutations_enabled() -> bool {
+    std::env::var(MUTATIONS_ENV).as_deref() == Ok("1")
+}
+
 #[cfg(test)]
 mod tests {
-    use super::tools;
+    use super::{tools, MUTATIONS_ENV};
 
-    /// `tools/list`-matches-registry guard.
-    ///
-    /// The exposed MCP tool set must equal the daemon's JSON-args-capable
-    /// command set (the 20 commands that carry a Phase-0 JsonSchema core, per
-    /// `cli::batch::json_args::build_batch_cmd`) MINUS the explicitly withheld
-    /// set (`context`, `explain` — RT-RELAY doc/signature scan gap, D4b). This
-    /// fails if a JSON-args command is added or removed without updating the
-    /// MCP surface, or if a withheld command leaks into `tools/list`.
-    #[test]
-    fn tools_list_matches_json_args_registry() {
-        // The canonical JSON-args-capable command set, mirrored from
-        // `build_batch_cmd`'s match arms. If Lane 1 adds a command there, this
-        // list must grow with it (and the tool table in `tools.rs`).
+    /// RAII guard that sets [`MUTATIONS_ENV`] for the duration of a test and
+    /// restores the prior value (or unset) on drop. Pairs with
+    /// `#[serial_test::serial(mcp_mutations_env)]` so concurrent tests don't
+    /// race the process-global env var.
+    struct MutationsEnvGuard {
+        prior: Option<String>,
+    }
+    impl MutationsEnvGuard {
+        fn set(on: bool) -> Self {
+            let prior = std::env::var(MUTATIONS_ENV).ok();
+            if on {
+                std::env::set_var(MUTATIONS_ENV, "1");
+            } else {
+                std::env::remove_var(MUTATIONS_ENV);
+            }
+            Self { prior }
+        }
+    }
+    impl Drop for MutationsEnvGuard {
+        fn drop(&mut self) {
+            match &self.prior {
+                Some(v) => std::env::set_var(MUTATIONS_ENV, v),
+                None => std::env::remove_var(MUTATIONS_ENV),
+            }
+        }
+    }
+
+    /// The command names that map to the exposed MCP read tools — the daemon's
+    /// JSON-args-capable read set MINUS the withheld doc/signature-relay set.
+    /// Returns the bare daemon command names (the registry comparison key).
+    fn expected_read_commands() -> std::collections::BTreeSet<String> {
+        // The canonical JSON-args-capable read command set, mirrored from
+        // `build_batch_cmd`'s match arms (the notes-mutation arms are accounted
+        // for separately by the flag-gated rows). If Lane 1 adds a read command
+        // there, this list must grow with it (and the tool table in `tools.rs`).
         let json_args_capable: std::collections::BTreeSet<&str> = [
             "search", "gather", "scout", "onboard", "similar", "callers", "callees", "deps",
             "impact", "test-map", "trace", "blame", "context", "diff", "drift", "dead", "ci",
@@ -60,41 +103,137 @@ mod tests {
         ]
         .into_iter()
         .collect();
-
-        // The P1 withheld set (D4b): unscanned doc/signature relay surfaces.
-        let withheld: std::collections::BTreeSet<&str> =
-            ["context", "explain"].into_iter().collect();
-
-        let expected: std::collections::BTreeSet<String> = json_args_capable
+        // The withheld set: the P1 doc/signature relay surfaces (`context`,
+        // `explain`) PLUS the destructive mutators that are withheld by absence
+        // in Phase 2a — naming them here makes the guard ENFORCE §1.3 (a future
+        // hand that adds `cqs_gc` to the table fails this test).
+        let withheld: std::collections::BTreeSet<&str> = [
+            "context",
+            "explain",
+            "gc",
+            "slot-remove",
+            "index-force",
+            "model-swap",
+            "cache-clear",
+        ]
+        .into_iter()
+        .collect();
+        json_args_capable
             .difference(&withheld)
             .map(|s| s.to_string())
-            .collect();
+            .collect()
+    }
 
-        let exposed: std::collections::BTreeSet<String> = tools::tool_table()
+    /// Map the exposed tool table to its bare daemon command names.
+    fn exposed_commands() -> std::collections::BTreeSet<String> {
+        tools::tool_table()
             .iter()
             .map(|t| {
-                let name = t.name.to_string();
                 // The MCP tool name carries the `cqs_` prefix (D1) and uses
                 // underscores; map it back to the bare daemon command name for
                 // the registry comparison. `test-map` is the lone hyphenated
                 // command — its MCP name is `cqs_test_map`.
-                tools::mcp_name_to_command(&name)
+                tools::mcp_name_to_command(t.name)
             })
-            .collect();
+            .collect()
+    }
 
+    /// `tools/list`-matches-registry guard (flag OFF).
+    ///
+    /// With `CQS_MCP_ENABLE_MUTATIONS` unset, the exposed MCP tool set must
+    /// equal the daemon's JSON-args-capable read command set MINUS the withheld
+    /// set — byte-identical to Phase 1 (19 read tools, zero mutation delta).
+    /// Fails if a JSON-args command is added/removed without updating the MCP
+    /// surface, or if a withheld command leaks into `tools/list`.
+    #[test]
+    #[serial_test::serial(mcp_mutations_env)]
+    fn tools_list_matches_json_args_registry() {
+        let _guard = MutationsEnvGuard::set(false);
+        let expected = expected_read_commands();
+        let exposed = exposed_commands();
         assert_eq!(
             exposed, expected,
-            "MCP tools/list set must equal the JSON-args registry minus the withheld set.\n\
-             exposed (mapped to commands): {exposed:?}\n\
-             expected:                     {expected:?}"
+            "MCP tools/list (flag off) must equal the JSON-args read registry minus the \
+             withheld set.\nexposed (mapped to commands): {exposed:?}\nexpected: {expected:?}"
+        );
+        // Phase 1 = exactly 19 read tools.
+        assert_eq!(
+            exposed.len(),
+            19,
+            "flag-off tools/list must expose 19 tools"
         );
     }
 
-    /// Every exposed tool carries the `cqs_` prefix (D1), an `inputSchema` that
-    /// is a non-empty JSON object, and a `readOnly` annotation (all P1 tools
-    /// are reads).
+    /// Flag-gating guard: the notes-mutation tools are present IFF
+    /// `CQS_MCP_ENABLE_MUTATIONS=1`. With the flag on, the exposed set is the
+    /// read set PLUS exactly the three notes mutators (22 total).
     #[test]
+    #[serial_test::serial(mcp_mutations_env)]
+    fn mutation_tools_present_iff_flag_set() {
+        // Flag off → no mutation tools.
+        {
+            let _guard = MutationsEnvGuard::set(false);
+            let off = exposed_commands();
+            for cmd in ["notes-add", "notes-update", "notes-remove"] {
+                assert!(
+                    !off.contains(cmd),
+                    "flag-off tools/list must NOT contain `{cmd}`"
+                );
+            }
+        }
+        // Flag on → read set + the three notes mutators.
+        {
+            let _guard = MutationsEnvGuard::set(true);
+            let on = exposed_commands();
+            for cmd in ["notes-add", "notes-update", "notes-remove"] {
+                assert!(on.contains(cmd), "flag-on tools/list must contain `{cmd}`");
+            }
+            let mut want = expected_read_commands();
+            want.insert("notes-add".to_string());
+            want.insert("notes-update".to_string());
+            want.insert("notes-remove".to_string());
+            assert_eq!(
+                on, want,
+                "flag-on tools/list must be the read set plus exactly the 3 notes mutators"
+            );
+            assert_eq!(on.len(), 22, "flag-on tools/list must expose 22 tools");
+        }
+    }
+
+    /// Destructive-set-absent guard: `gc` / `slot remove` / `index --force` /
+    /// `model swap` / `cache clear` must NEVER appear in `tools/list`,
+    /// REGARDLESS of the mutation flag — boundary by absence (§1.3, §2.2). No
+    /// flag re-enables the destructive set in Phase 2a.
+    #[test]
+    #[serial_test::serial(mcp_mutations_env)]
+    fn destructive_set_absent_regardless_of_flag() {
+        let destructive_tools = [
+            "cqs_gc",
+            "cqs_slot_remove",
+            "cqs_index",
+            "cqs_model_swap",
+            "cqs_cache_clear",
+            "cqs_audit_mode",
+        ];
+        for on in [false, true] {
+            let _guard = MutationsEnvGuard::set(on);
+            let names: Vec<&'static str> = tools::tool_table().iter().map(|t| t.name).collect();
+            for d in destructive_tools {
+                assert!(
+                    !names.contains(&d),
+                    "destructive tool `{d}` must be absent from tools/list (flag={on})"
+                );
+            }
+        }
+    }
+
+    /// Every exposed tool carries the `cqs_` prefix (D1), an `inputSchema` that
+    /// is a non-empty JSON object, and a non-empty description. Runs with the
+    /// mutation flag ON so the notes-mutator rows are covered too.
+    #[test]
+    #[serial_test::serial(mcp_mutations_env)]
     fn every_tool_is_well_formed() {
+        let _guard = MutationsEnvGuard::set(true);
         for t in tools::tool_table() {
             assert!(
                 t.name.starts_with("cqs_"),
@@ -121,18 +260,70 @@ mod tests {
         }
     }
 
-    /// `context`/`explain` must be ABSENT from the exposed surface (D4b).
+    /// Annotation honesty (§3): the exposed annotations in `tools/list` match
+    /// the per-command table. Read tools are read-only/idempotent/
+    /// non-destructive; `notes_add` is additive (mutating, non-idempotent,
+    /// non-destructive); `notes_update` is idempotent but mutating;
+    /// `notes_remove` is the lone `destructiveHint:true`.
     #[test]
+    #[serial_test::serial(mcp_mutations_env)]
+    fn tool_annotations_match_table() {
+        let _guard = MutationsEnvGuard::set(true);
+        let listed = tools::list();
+        let arr = listed
+            .get("tools")
+            .and_then(|t| t.as_array())
+            .expect("tools array");
+        let find = |name: &str| -> serde_json::Value {
+            arr.iter()
+                .find(|t| t.get("name").and_then(|n| n.as_str()) == Some(name))
+                .and_then(|t| t.get("annotations").cloned())
+                .unwrap_or_else(|| panic!("tool `{name}` not in tools/list"))
+        };
+        let hint = |a: &serde_json::Value, k: &str| a.get(k).and_then(|v| v.as_bool());
+
+        // A representative read tool — the read quartet.
+        let search = find("cqs_search");
+        assert_eq!(hint(&search, "readOnlyHint"), Some(true));
+        assert_eq!(hint(&search, "destructiveHint"), Some(false));
+        assert_eq!(hint(&search, "openWorldHint"), Some(false));
+
+        let add = find("cqs_notes_add");
+        assert_eq!(hint(&add, "readOnlyHint"), Some(false));
+        assert_eq!(hint(&add, "destructiveHint"), Some(false));
+        assert_eq!(hint(&add, "idempotentHint"), Some(false));
+
+        let update = find("cqs_notes_update");
+        assert_eq!(hint(&update, "readOnlyHint"), Some(false));
+        assert_eq!(hint(&update, "destructiveHint"), Some(false));
+        assert_eq!(hint(&update, "idempotentHint"), Some(true));
+
+        let remove = find("cqs_notes_remove");
+        assert_eq!(hint(&remove, "readOnlyHint"), Some(false));
+        assert_eq!(
+            hint(&remove, "destructiveHint"),
+            Some(true),
+            "notes_remove is the lone destructiveHint:true in the exposed set"
+        );
+    }
+
+    /// `context`/`explain` must be ABSENT from the exposed surface (D4b),
+    /// regardless of the mutation flag.
+    #[test]
+    #[serial_test::serial(mcp_mutations_env)]
     fn withheld_tools_absent() {
-        let names: Vec<&'static str> = tools::tool_table().iter().map(|t| t.name).collect();
-        assert!(
-            !names.contains(&"cqs_context"),
-            "cqs_context must be withheld from P1 tools/list"
-        );
-        assert!(
-            !names.contains(&"cqs_explain"),
-            "cqs_explain must be withheld from P1 tools/list"
-        );
+        for on in [false, true] {
+            let _guard = MutationsEnvGuard::set(on);
+            let names: Vec<&'static str> = tools::tool_table().iter().map(|t| t.name).collect();
+            assert!(
+                !names.contains(&"cqs_context"),
+                "cqs_context must be withheld from tools/list (flag={on})"
+            );
+            assert!(
+                !names.contains(&"cqs_explain"),
+                "cqs_explain must be withheld from tools/list (flag={on})"
+            );
+        }
     }
 
     /// Schema ↔ wire consistency: a tool whose `inputSchema` advertises a
@@ -148,7 +339,9 @@ mod tests {
     /// `QueryArgs` has no `required` array at all — that path is trivially
     /// consistent.)
     #[test]
+    #[serial_test::serial(mcp_mutations_env)]
     fn tool_required_fields_are_declared_properties() {
+        let _guard = MutationsEnvGuard::set(true);
         for t in tools::tool_table() {
             let schema = (t.input_schema)();
             let props = schema

--- a/src/cli/mcp/tools.rs
+++ b/src/cli/mcp/tools.rs
@@ -42,6 +42,44 @@ use serde_json::Value;
 
 use super::lifecycle;
 
+/// The four MCP tool-annotation hints (MCP 2025-11-25). Advisory metadata for
+/// clients that honor them — NOT a security boundary (the daemon's path/overlay
+/// gates and the §2 opt-in flag are the real boundary). cqs overrides the
+/// spec's destructive-by-default per command semantics rather than accepting it.
+pub struct ToolAnnotations {
+    /// The tool only reads state. Every Phase-1 tool is a pure read.
+    pub read_only: bool,
+    /// Re-running with the same args has the same effect as running once.
+    pub idempotent: bool,
+    /// The tool may destroy state (data loss). The lone destructive flag in the
+    /// exposed Phase-2a set is `cqs_notes_remove`.
+    pub destructive: bool,
+    /// The tool reaches the open world (network). All cqs tools are local-only.
+    pub open_world: bool,
+}
+
+impl ToolAnnotations {
+    /// The read-quartet every Phase-1 tool carries: read-only, idempotent,
+    /// non-destructive, local-only. Same values the bridge hardcoded in P1,
+    /// now expressed per-row.
+    const READ: ToolAnnotations = ToolAnnotations {
+        read_only: true,
+        idempotent: true,
+        destructive: false,
+        open_world: false,
+    };
+
+    /// Render to the `tools/list` annotations object.
+    fn to_json(&self) -> Value {
+        serde_json::json!({
+            "readOnlyHint": self.read_only,
+            "idempotentHint": self.idempotent,
+            "destructiveHint": self.destructive,
+            "openWorldHint": self.open_world,
+        })
+    }
+}
+
 /// A statically-declared MCP tool. `input_schema` is a fn pointer that
 /// generates the JSON Schema on demand (schemars `schema_for!` is not `const`).
 pub struct ToolDef {
@@ -54,6 +92,9 @@ pub struct ToolDef {
     /// Generates the `inputSchema` (JSON Schema 2020-12) from the command's
     /// Phase-0 core struct.
     pub input_schema: fn() -> Value,
+    /// Per-tool annotation hints (§3). Read tools carry [`ToolAnnotations::READ`];
+    /// the Phase-2a mutators carry per-command hints.
+    pub annotations: ToolAnnotations,
 }
 
 /// Render the schema for a core `T` as a `serde_json::Value`. schemars 1.x
@@ -85,11 +126,24 @@ use crate::cli::commands::{
     TraceCoreArgs,
 };
 
-/// The P1 tool table — single source of truth for `tools/list`. Every row is a
-/// JSON-args-capable command with a Phase-0 core, EXCEPT the withheld
-/// `context`/`explain` (D4b). The registry-parity guard in `mod.rs` pins this
-/// set against `build_batch_cmd`'s arms.
-pub fn tool_table() -> &'static [ToolDef] {
+/// The composed tool table for `tools/list` — the Phase-1 read tools, plus the
+/// Phase-2a notes mutators when `CQS_MCP_ENABLE_MUTATIONS=1`
+/// ([`crate::cli::mcp::mutations_enabled`]). When the flag is unset the result
+/// is byte-identical to Phase 1 (zero delta). The registry-parity guard in
+/// `mod.rs` pins this set against `build_batch_cmd`'s arms.
+pub fn tool_table() -> Vec<&'static ToolDef> {
+    let mut tools: Vec<&'static ToolDef> = read_tools().iter().collect();
+    if crate::cli::mcp::mutations_enabled() {
+        tools.extend(mutation_tools().iter());
+    }
+    tools
+}
+
+/// The Phase-1 read tools — single source of truth for the unconditional part
+/// of `tools/list`. Every row is a JSON-args-capable command with a Phase-0
+/// core, EXCEPT the withheld `context`/`explain` (D4b). Each carries the
+/// read-quartet annotation.
+fn read_tools() -> &'static [ToolDef] {
     &[
         ToolDef {
             name: "cqs_search",
@@ -99,6 +153,7 @@ pub fn tool_table() -> &'static [ToolDef] {
                  name — e.g. 'retry with exponential backoff' finds retry logic regardless of \
                  naming. Use name_only for fast 'where is X defined?' lookups.",
             input_schema: schema::<QueryArgs>,
+            annotations: ToolAnnotations::READ,
         },
         ToolDef {
             name: "cqs_gather",
@@ -107,6 +162,7 @@ pub fn tool_table() -> &'static [ToolDef] {
                 "Assemble context: a seed semantic search expanded along the call graph (BFS). \
                  Returns the seed hits plus their callers/callees up to a depth.",
             input_schema: schema::<GatherCore>,
+            annotations: ToolAnnotations::READ,
         },
         ToolDef {
             name: "cqs_scout",
@@ -115,6 +171,7 @@ pub fn tool_table() -> &'static [ToolDef] {
                 "Investigation brief for a task: search + callers + tests + staleness + notes in \
                  one call. The first step before implementing.",
             input_schema: schema::<ScoutCore>,
+            annotations: ToolAnnotations::READ,
         },
         ToolDef {
             name: "cqs_onboard",
@@ -123,6 +180,7 @@ pub fn tool_table() -> &'static [ToolDef] {
                 "Guided tour of a concept: entry point → call chain → types → tests. For exploring \
                  unfamiliar code.",
             input_schema: schema::<OnboardCore>,
+            annotations: ToolAnnotations::READ,
         },
         ToolDef {
             name: "cqs_similar",
@@ -131,6 +189,7 @@ pub fn tool_table() -> &'static [ToolDef] {
                 "Find functions structurally/semantically similar to a named function (nearest \
                  neighbors by embedding).",
             input_schema: schema::<SimilarCore>,
+            annotations: ToolAnnotations::READ,
         },
         ToolDef {
             name: "cqs_callers",
@@ -139,12 +198,14 @@ pub fn tool_table() -> &'static [ToolDef] {
                 "Who calls this function? Direct callers from the call graph, each tagged with an \
                  edge_kind (call / serde_callback / macro_heuristic / fn_pointer / doc_reference).",
             input_schema: schema::<CallersCoreArgs>,
+            annotations: ToolAnnotations::READ,
         },
         ToolDef {
             name: "cqs_callees",
             command: "callees",
             description: "What does this function call? Its direct callees from the call graph.",
             input_schema: schema::<CalleesCore>,
+            annotations: ToolAnnotations::READ,
         },
         ToolDef {
             name: "cqs_deps",
@@ -152,6 +213,7 @@ pub fn tool_table() -> &'static [ToolDef] {
             description: "Type/symbol dependencies of a function (or, with reverse, its reverse \
                  dependencies).",
             input_schema: schema::<DepsCoreArgs>,
+            annotations: ToolAnnotations::READ,
         },
         ToolDef {
             name: "cqs_impact",
@@ -160,12 +222,14 @@ pub fn tool_table() -> &'static [ToolDef] {
                 "Blast radius of changing a function: callers, transitively-affected functions, \
                  and the tests that cover them. The pre-edit safety check.",
             input_schema: schema::<ImpactCoreArgs>,
+            annotations: ToolAnnotations::READ,
         },
         ToolDef {
             name: "cqs_test_map",
             command: "test-map",
             description: "Which tests exercise this function (directly or transitively)?",
             input_schema: schema::<TestMapCoreArgs>,
+            annotations: ToolAnnotations::READ,
         },
         ToolDef {
             name: "cqs_trace",
@@ -173,6 +237,7 @@ pub fn tool_table() -> &'static [ToolDef] {
             description:
                 "Shortest call path(s) between a source and a target function, if one exists.",
             input_schema: schema::<TraceCoreArgs>,
+            annotations: ToolAnnotations::READ,
         },
         ToolDef {
             name: "cqs_blame",
@@ -181,6 +246,7 @@ pub fn tool_table() -> &'static [ToolDef] {
                 "Semantic git blame for a function: who changed it, when, and why (commit \
                  messages), plus optional caller context.",
             input_schema: schema::<BlameCore>,
+            annotations: ToolAnnotations::READ,
         },
         ToolDef {
             name: "cqs_diff",
@@ -189,6 +255,7 @@ pub fn tool_table() -> &'static [ToolDef] {
                 "Semantic diff between two indexed references (or a reference and the project): \
                  added / removed / modified functions.",
             input_schema: schema::<DiffCore>,
+            annotations: ToolAnnotations::READ,
         },
         ToolDef {
             name: "cqs_drift",
@@ -197,6 +264,7 @@ pub fn tool_table() -> &'static [ToolDef] {
                 "Functions whose implementation has drifted from a reference index, ranked by \
                  semantic distance.",
             input_schema: schema::<DriftCore>,
+            annotations: ToolAnnotations::READ,
         },
         ToolDef {
             name: "cqs_dead",
@@ -205,6 +273,7 @@ pub fn tool_table() -> &'static [ToolDef] {
                  low-confidence-live / known-gap / dead) — only `dead` is a confident absence \
                  claim.",
             input_schema: schema::<DeadCore>,
+            annotations: ToolAnnotations::READ,
         },
         ToolDef {
             name: "cqs_ci",
@@ -213,6 +282,7 @@ pub fn tool_table() -> &'static [ToolDef] {
                 "Bundled pre-merge review for the current diff: review + dead-code gate, with a \
                  pass/fail verdict.",
             input_schema: schema::<CiCore>,
+            annotations: ToolAnnotations::READ,
         },
         ToolDef {
             name: "cqs_review",
@@ -221,6 +291,7 @@ pub fn tool_table() -> &'static [ToolDef] {
                 "Risk-ranked review of the current diff: which changed functions have the most \
                  callers / least test coverage.",
             input_schema: schema::<ReviewCore>,
+            annotations: ToolAnnotations::READ,
         },
         ToolDef {
             name: "cqs_plan",
@@ -229,6 +300,7 @@ pub fn tool_table() -> &'static [ToolDef] {
                 "Task-planning brief for a described change: scout + gather + impact + suggested \
                  file placement.",
             input_schema: schema::<PlanCore>,
+            annotations: ToolAnnotations::READ,
         },
         ToolDef {
             name: "cqs_read",
@@ -237,6 +309,68 @@ pub fn tool_table() -> &'static [ToolDef] {
                 "Read a project file with cqs notes injected (or, with focus, just one function \
                  plus its type dependencies).",
             input_schema: schema::<ReadArgs>,
+            annotations: ToolAnnotations::READ,
+        },
+    ]
+}
+
+/// The Phase-2a gated notes-mutation tools (§3). Appended to `tool_table` ONLY
+/// when `CQS_MCP_ENABLE_MUTATIONS=1`. Each carries per-command annotations:
+/// `add` is additive (non-destructive, non-idempotent), `update` is idempotent
+/// but mutating, `remove` is the lone `destructiveHint:true` in the set. The
+/// `command` column maps to the `json_args::build_batch_cmd` notes arms
+/// (`notes-add`/`notes-update`/`notes-remove`) — also gated daemon-side.
+///
+/// The DESTRUCTIVE set (`gc`/`slot remove`/`index --force`/`model swap`/
+/// `cache clear`) is NOT here and has no flag that re-enables it: boundary by
+/// absence, the same mechanism that withholds `context`.
+fn mutation_tools() -> &'static [ToolDef] {
+    use crate::cli::commands::notes::{NotesAddArgs, NotesRemoveArgs, NotesUpdateArgs};
+    &[
+        ToolDef {
+            name: "cqs_notes_add",
+            command: "notes-add",
+            description:
+                "Add a project note (a sentiment-tagged observation that biases code-search \
+                 ranking and is injected into `read`). Appends to docs/notes.toml; the watch \
+                 loop reindexes. Additive — calling twice writes two notes.",
+            input_schema: schema::<NotesAddArgs>,
+            annotations: ToolAnnotations {
+                read_only: false,
+                idempotent: false,
+                destructive: false,
+                open_world: false,
+            },
+        },
+        ToolDef {
+            name: "cqs_notes_update",
+            command: "notes-update",
+            description:
+                "Update an existing note matched by its exact text: replace its text, sentiment, \
+                 mentions, or kind. Rewrites docs/notes.toml; the watch loop reindexes.",
+            input_schema: schema::<NotesUpdateArgs>,
+            annotations: ToolAnnotations {
+                read_only: false,
+                // Re-applying the same update converges to the same rewrite.
+                idempotent: true,
+                destructive: false,
+                open_world: false,
+            },
+        },
+        ToolDef {
+            name: "cqs_notes_remove",
+            command: "notes-remove",
+            description:
+                "Remove a note matched by its exact text from docs/notes.toml (no soft-delete); \
+                 the watch loop reindexes. Removing an absent note is a no-op error.",
+            input_schema: schema::<NotesRemoveArgs>,
+            annotations: ToolAnnotations {
+                read_only: false,
+                idempotent: true,
+                // The note text is gone — the lone destructive flag in the set.
+                destructive: true,
+                open_world: false,
+            },
         },
     ]
 }
@@ -248,7 +382,7 @@ pub fn tool_table() -> &'static [ToolDef] {
 /// an unknown name so the guard fails loudly rather than silently matching.
 #[cfg(test)]
 pub fn mcp_name_to_command(mcp_name: &str) -> String {
-    if let Some(def) = tool_table().iter().find(|t| t.name == mcp_name) {
+    if let Some(def) = tool_table().into_iter().find(|t| t.name == mcp_name) {
         return def.command.to_string();
     }
     mcp_name
@@ -257,9 +391,10 @@ pub fn mcp_name_to_command(mcp_name: &str) -> String {
         .replace('_', "-")
 }
 
-/// Look up a tool by its MCP name.
+/// Look up a tool by its MCP name. Respects the mutation flag — a notes-mutation
+/// tool is not findable (and so not callable) when the flag is off.
 fn find_tool(name: &str) -> Option<&'static ToolDef> {
-    tool_table().iter().find(|t| t.name == name)
+    tool_table().into_iter().find(|t| t.name == name)
 }
 
 /// Build the `tools/list` result: `{tools: [{name, description, inputSchema,
@@ -272,14 +407,10 @@ pub fn list() -> Value {
                 "name": t.name,
                 "description": t.description,
                 "inputSchema": (t.input_schema)(),
-                "annotations": {
-                    // Hints, not enforcement (the daemon's path/overlay gates
-                    // are the real boundary). Every P1 tool is a pure read.
-                    "readOnlyHint": true,
-                    "idempotentHint": true,
-                    "destructiveHint": false,
-                    "openWorldHint": false
-                }
+                // Per-tool annotations (§3) — hints, not enforcement (the
+                // daemon's path/overlay gates + the §2 opt-in flag are the real
+                // boundary). Read tools carry the read-quartet; mutators differ.
+                "annotations": t.annotations.to_json()
             })
         })
         .collect();
@@ -385,6 +516,12 @@ fn validate_arguments(command: &str, arguments: &Value) -> Result<(), String> {
         "review" => check::<ReviewCore>(arguments),
         "plan" => check::<PlanCore>(arguments),
         "read" => check::<ReadArgs>(arguments),
+        // Phase-2a gated notes mutators. Only reachable when the mutation tools
+        // are in the table (flag on), since `find_tool` gates on the same flag —
+        // but the pre-check arm is unconditional so a flag-on call shape-checks.
+        "notes-add" => check::<crate::cli::commands::notes::NotesAddArgs>(arguments),
+        "notes-update" => check::<crate::cli::commands::notes::NotesUpdateArgs>(arguments),
+        "notes-remove" => check::<crate::cli::commands::notes::NotesRemoveArgs>(arguments),
         // Unreachable: every table command is covered above. A new tool with no
         // arm fails the pre-check loudly rather than silently skipping it.
         other => Err(format!("no argument schema for command {other}")),
@@ -561,8 +698,17 @@ fn is_empty_with_candidates(payload: &Value) -> bool {
 mod tests {
     use super::*;
 
+    /// With the mutation flag OFF (Phase-1 surface), every exposed tool is a
+    /// read — `readOnlyHint:true`. Serial-gated in the shared `mcp_mutations_env`
+    /// group because `list()` reads the process-global flag; an ungated parallel
+    /// run can observe a flag a serial test set, flipping a mutator into view.
     #[test]
+    #[serial_test::serial(mcp_mutations_env)]
     fn list_emits_well_formed_tools() {
+        // SAFETY: serial group + restore via the prior value below.
+        let prior = std::env::var(crate::cli::mcp::MUTATIONS_ENV).ok();
+        std::env::remove_var(crate::cli::mcp::MUTATIONS_ENV);
+
         let v = list();
         let tools = v
             .get("tools")
@@ -582,6 +728,11 @@ mod tests {
                     .and_then(|v| v.as_bool()),
                 Some(true)
             );
+        }
+
+        match prior {
+            Some(p) => std::env::set_var(crate::cli::mcp::MUTATIONS_ENV, p),
+            None => std::env::remove_var(crate::cli::mcp::MUTATIONS_ENV),
         }
     }
 

--- a/tests/cli_mcp_bridge_test.rs
+++ b/tests/cli_mcp_bridge_test.rs
@@ -135,6 +135,20 @@ fn handle_conn(mut stream: UnixStream) {
                 "status": "ok",
                 "output": { "data": { "results": [{ "name": "hit", "score": 0.9 }] } }
             }),
+            // notes-add (Phase 2a gated mutation): the daemon's notes-write
+            // success envelope. The bridge relayed the `notes-add` json-args
+            // frame, proving the gated mutation tool reaches the daemon.
+            "notes-add" => json!({
+                "status": "ok",
+                "output": { "data": {
+                    "status": "added",
+                    "text_preview": "from the bridge",
+                    "file": "docs/notes.toml",
+                    "indexed": false,
+                    "total_notes": 0,
+                    "reindex_deferred": true
+                } }
+            }),
             _ => json!({"status": "error", "message": format!("unexpected command {command}")}),
         }
     };
@@ -157,8 +171,15 @@ impl Bridge {
     /// bound. `CQS_NO_DAEMON` is intentionally NOT set (the bridge is itself the
     /// daemon client; the env knob governs the *other* daemon-forward path).
     fn spawn(root: &Path, socket_dir: &Path) -> Self {
-        let mut child = Command::new(env!("CARGO_BIN_EXE_cqs"))
-            .arg("mcp")
+        Self::spawn_with_env(root, socket_dir, &[])
+    }
+
+    /// Spawn with extra env pairs (e.g. `CQS_MCP_ENABLE_MUTATIONS=1` for the
+    /// Phase-2a gated-mutation path). Each child has its OWN process env, so
+    /// setting the flag here does not race other tests' process env.
+    fn spawn_with_env(root: &Path, socket_dir: &Path, extra_env: &[(&str, &str)]) -> Self {
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_cqs"));
+        cmd.arg("mcp")
             .current_dir(root)
             .env("XDG_RUNTIME_DIR", socket_dir)
             // Keep the child's timeout snappy so a missing reply fails the test
@@ -166,9 +187,11 @@ impl Bridge {
             .env("CQS_DAEMON_TIMEOUT_MS", "5000")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::null())
-            .spawn()
-            .expect("spawn cqs mcp");
+            .stderr(Stdio::null());
+        for (k, v) in extra_env {
+            cmd.env(k, v);
+        }
+        let mut child = cmd.spawn().expect("spawn cqs mcp");
         let stdin = child.stdin.take().expect("child stdin");
         let stdout = child.stdout.take().expect("child stdout");
         Bridge {
@@ -466,6 +489,135 @@ fn no_daemon_fails_clean() {
     assert!(
         msg.contains("daemon"),
         "the error must mention the daemon: {msg}"
+    );
+}
+
+/// MCP Phase 2a: with `CQS_MCP_ENABLE_MUTATIONS=1` in the child env, the bridge
+/// advertises `cqs_notes_add` in `tools/list` (with mutating annotations) and a
+/// `tools/call cqs_notes_add` relays the `notes-add` json-args frame to the
+/// daemon, mapping the success envelope to `isError:false`. Driven end-to-end
+/// through the child — proves the gated mutation channel works over the bridge.
+#[test]
+fn gated_notes_add_round_trips_when_flag_set() {
+    let (_dir, root, cqs_dir) = make_project();
+    let socket_dir = root.clone();
+    cqs::daemon_translate::set_socket_dir_override_for_test(Some(socket_dir.clone()));
+    let socket_path = cqs::daemon_translate::daemon_socket_path(&cqs_dir);
+    let _daemon = MockDaemon::start(socket_path);
+
+    let mut bridge =
+        Bridge::spawn_with_env(&root, &socket_dir, &[("CQS_MCP_ENABLE_MUTATIONS", "1")]);
+    bridge.send(&json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}));
+    let _ = bridge.recv();
+
+    // tools/list → cqs_notes_add present with mutating annotations.
+    bridge.send(&json!({"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}));
+    let listed = bridge.recv();
+    let tools = listed
+        .get("result")
+        .and_then(|r| r.get("tools"))
+        .and_then(|t| t.as_array())
+        .expect("tools array");
+    let add = tools
+        .iter()
+        .find(|t| t.get("name").and_then(|n| n.as_str()) == Some("cqs_notes_add"))
+        .expect("cqs_notes_add must be listed when the flag is set");
+    let ann = add.get("annotations").expect("annotations");
+    assert_eq!(
+        ann.get("readOnlyHint").and_then(|v| v.as_bool()),
+        Some(false),
+        "notes_add is mutating, not read-only"
+    );
+    assert_eq!(
+        ann.get("destructiveHint").and_then(|v| v.as_bool()),
+        Some(false),
+        "notes_add is additive, not destructive"
+    );
+    // notes_remove must also be present and carry destructiveHint:true.
+    let remove = tools
+        .iter()
+        .find(|t| t.get("name").and_then(|n| n.as_str()) == Some("cqs_notes_remove"))
+        .expect("cqs_notes_remove must be listed when the flag is set");
+    assert_eq!(
+        remove
+            .get("annotations")
+            .and_then(|a| a.get("destructiveHint"))
+            .and_then(|v| v.as_bool()),
+        Some(true),
+        "notes_remove carries destructiveHint:true"
+    );
+
+    // tools/call cqs_notes_add → success CallToolResult (relayed `notes-add`).
+    bridge.send(&json!({
+        "jsonrpc":"2.0","id":3,"method":"tools/call",
+        "params": { "name": "cqs_notes_add", "arguments": { "text": "from the bridge", "sentiment": -0.5 } }
+    }));
+    let called = bridge.recv();
+    let result = called.get("result").expect("tools/call result");
+    assert_eq!(
+        result.get("isError").and_then(|v| v.as_bool()),
+        Some(false),
+        "a successful notes-add must not be an error: {result}"
+    );
+    let structured = result
+        .get("structuredContent")
+        .expect("structuredContent present");
+    assert_eq!(
+        structured.get("status").and_then(|v| v.as_str()),
+        Some("added")
+    );
+    assert_eq!(
+        structured.get("reindex_deferred").and_then(|v| v.as_bool()),
+        Some(true),
+        "daemon defers the reindex to the watch loop"
+    );
+}
+
+/// MCP Phase 2a: WITHOUT the flag, the bridge's `tools/list` must NOT advertise
+/// any notes mutator, and a `tools/call cqs_notes_add` is an unknown tool
+/// (-32601) — the bridge can't even route it. Boundary by absence + opt-in.
+#[test]
+fn gated_notes_tools_absent_without_flag() {
+    let (_dir, root, cqs_dir) = make_project();
+    let socket_dir = root.clone();
+    cqs::daemon_translate::set_socket_dir_override_for_test(Some(socket_dir.clone()));
+    let socket_path = cqs::daemon_translate::daemon_socket_path(&cqs_dir);
+    let _daemon = MockDaemon::start(socket_path);
+
+    // No CQS_MCP_ENABLE_MUTATIONS in the child env.
+    let mut bridge = Bridge::spawn(&root, &socket_dir);
+    bridge.send(&json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}));
+    let _ = bridge.recv();
+
+    bridge.send(&json!({"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}));
+    let listed = bridge.recv();
+    let names: Vec<String> = listed
+        .get("result")
+        .and_then(|r| r.get("tools"))
+        .and_then(|t| t.as_array())
+        .expect("tools array")
+        .iter()
+        .filter_map(|t| t.get("name").and_then(|n| n.as_str()).map(String::from))
+        .collect();
+    for tool in ["cqs_notes_add", "cqs_notes_update", "cqs_notes_remove"] {
+        assert!(
+            !names.contains(&tool.to_string()),
+            "{tool} must be absent from tools/list without the flag"
+        );
+    }
+
+    // Calling it is an unknown tool — the bridge can't route what it doesn't list.
+    bridge.send(&json!({
+        "jsonrpc":"2.0","id":3,"method":"tools/call",
+        "params": { "name": "cqs_notes_add", "arguments": { "text": "blocked" } }
+    }));
+    let r = bridge.recv();
+    assert_eq!(
+        r.get("error")
+            .and_then(|e| e.get("code"))
+            .and_then(|c| c.as_i64()),
+        Some(-32601),
+        "notes_add must be unknown (-32601) without the flag: {r}"
     );
 }
 


### PR DESCRIPTION
## MCP Phase 2a — gated notes-mutation channel + notes-write tools

First mutation tools on the MCP bridge: `cqs_notes_add` / `cqs_notes_update` / `cqs_notes_remove`, behind opt-in `CQS_MCP_ENABLE_MUTATIONS` (default off). The destructive set (gc / slot-remove / index --force / model swap / cache clear) stays withheld **by absence**.

**The load-bearing invariant — the daemon `Store` stays `Store<ReadOnly>`** (compile-time enforced). Notes mutations write the `notes.toml` *file* via shared cores under the existing exclusive lock (atomic temp+rename), never the Store; reindex is left to the watch loop (`reindex_deferred:true`). The writable-Store helpers are CLI-only and the daemon dispatch never calls them.

**Defense in depth on the flag** — enforced at BOTH layers: the bridge gates the advertised tool surface, and the daemon gates the actual dispatch (`require_mutations_enabled` runs first in every notes arm of `build_batch_cmd`, fails closed). A raw socket client bypassing `tools/list` still cannot mutate without the operator opt-in; the argv door is shut via `#[command(skip)]` on the `BatchCmd` variants.

**Single source of truth** — lifted the notes-write logic into `notes_{add,update,remove}_core`; CLI handlers delegate, so the CLI and MCP surfaces can't drift.

**Annotations:** `cqs_notes_add`/`update` non-destructive, `cqs_notes_remove` `destructiveHint:true`.

**Tests:** full `--tests` sweep 4826/0. Flag-gating (19 vs 22), notes-write round-trip via temp ctx AND child-process bridge + mock daemon, destructive-set-absent regardless of flag, annotation honesty, the `Store<ReadOnly>` invariant, MCP-inputSchema-readiness of the 3 cores. clippy/fmt/provenance clean.

**Security review:** opus adversarial — APPROVE, risk LOW; the read-only invariant is compile-time-held and the flag-gate fails closed against a raw socket client (the two make-or-break attacks).

Lane 2b (`cqs_index` fire-and-forget) is next. Scoped notes cores are a slice of the #2021 completion.
