### PR TITLE
feat(mcp): cqs_index fire-and-forget tool (MCP Phase 2b)

### DIFF
--- a/src/cli/batch/commands.rs
+++ b/src/cli/batch/commands.rs
@@ -255,6 +255,21 @@ pub(crate) enum BatchCmd {
     NotesRemove {
         args: crate::cli::commands::notes::NotesRemoveArgs,
     },
+    /// Queue a reindex (MCP Phase 2b — `cqs_index` fire-and-forget).
+    ///
+    /// `#[command(skip)]` — NOT argv-reachable on the daemon socket. The only
+    /// constructor is `json_args::build_batch_cmd`, gated behind
+    /// `CQS_MCP_ENABLE_MUTATIONS`. The handler does NOT build the index: it
+    /// flips the shared `SharedReconcileSignal` (the same primitive `reconcile`
+    /// uses) and returns immediately; the watch loop performs the actual
+    /// reindex on its next tick. So it never acquires a writable `Store` — the
+    /// daemon's read-only Store typestate is preserved. The destructive
+    /// `index --force` variant is withheld by ABSENCE: the core `IndexArgs`
+    /// exposes no `force` field.
+    #[command(skip)]
+    Index {
+        args: crate::cli::commands::index::IndexArgs,
+    },
     /// One-shot implementation context (terminal — no pipeline chaining)
     Task {
         #[command(flatten)]
@@ -444,6 +459,7 @@ macro_rules! for_each_batch_cmd {
                 (NotesAdd,    dispatch_notes_add,    false)
                 (NotesUpdate, dispatch_notes_update, false)
                 (NotesRemove, dispatch_notes_remove, false)
+                (Index,      dispatch_index,        false)
                 (Task,       dispatch_task,         false)
                 (Review,     dispatch_review,       false)
                 (Ci,         dispatch_ci,           false)

--- a/src/cli/batch/handlers/misc.rs
+++ b/src/cli/batch/handlers/misc.rs
@@ -243,6 +243,54 @@ pub(in crate::cli::batch) fn dispatch_notes_remove(
     ))
 }
 
+/// Daemon handler for `cqs index` (MCP Phase 2b — fire-and-forget).
+///
+/// **Queues, never builds.** This handler does NOT run an index pipeline. It
+/// flips the shared `SharedReconcileSignal` via [`BatchView::request_reconcile`]
+/// — the SAME async primitive `dispatch_reconcile` uses — and returns
+/// immediately; the watch loop drains the signal on its next 100 ms tick and
+/// performs the actual reindex. So the socket handler returns promptly (no
+/// minutes-long block) and never acquires a writable `Store`: the daemon's
+/// `Store<ReadOnly>` typestate is preserved, exactly as for the notes-write
+/// path. The client polls completion via the already-exposed read tools
+/// `wait_fresh` / `status`.
+///
+/// The `slot` field of the core is advisory here: the daemon queues a reconcile
+/// of the slot it already serves (the active slot it was opened against), so a
+/// differing `slot` does not redirect the rebuild. The reconcile path takes no
+/// slot argument.
+///
+/// Reachable only when `build_batch_cmd` constructed `BatchCmd::Index`, which is
+/// gated behind `CQS_MCP_ENABLE_MUTATIONS` (the operator opt-in). The
+/// destructive `index --force` variant is withheld by absence (the core exposes
+/// no `force` field).
+pub(in crate::cli::batch) fn dispatch_index(
+    ctx: &BatchView,
+    args: &crate::cli::commands::index::IndexArgs,
+) -> Result<serde_json::Value> {
+    let _span = tracing::info_span!(
+        "batch_index",
+        slot = args.slot.as_deref().unwrap_or("(active)")
+    )
+    .entered();
+    let was_pending = ctx.request_reconcile();
+    tracing::info!(
+        slot = args.slot.as_deref().unwrap_or("(active)"),
+        was_pending,
+        "Reindex queued (fire-and-forget); watch loop performs the rebuild"
+    );
+    // Fire-and-forget: the rebuild is deferred to the watch loop, mirroring the
+    // notes-write `reindex_deferred` contract. `was_pending` lets a caller see
+    // that an earlier reconcile request was still un-drained (the watch loop
+    // coalesces them into one walk).
+    Ok(serde_json::json!({
+        "status": "queued",
+        "queued": true,
+        "reindex_deferred": true,
+        "was_pending": was_pending,
+    }))
+}
+
 /// Dispatches a task execution within a batch context, optionally with token budgeting.
 /// This function executes a task based on a natural language description, retrieving relevant code chunks and generating a JSON representation of the results. When a token budget is specified, it applies waterfall budgeting similar to the CLI; otherwise, it returns the standard task JSON representation.
 /// # Arguments

--- a/src/cli/batch/handlers/mod.rs
+++ b/src/cli/batch/handlers/mod.rs
@@ -30,10 +30,10 @@ pub(super) use info::{
     dispatch_similar, dispatch_stats,
 };
 pub(super) use misc::{
-    dispatch_diff, dispatch_drift, dispatch_gather, dispatch_gc, dispatch_help, dispatch_notes,
-    dispatch_notes_add, dispatch_notes_remove, dispatch_notes_update, dispatch_ping, dispatch_plan,
-    dispatch_reconcile, dispatch_refresh, dispatch_scout, dispatch_status, dispatch_task,
-    dispatch_wait_fresh, dispatch_where,
+    dispatch_diff, dispatch_drift, dispatch_gather, dispatch_gc, dispatch_help, dispatch_index,
+    dispatch_notes, dispatch_notes_add, dispatch_notes_remove, dispatch_notes_update,
+    dispatch_ping, dispatch_plan, dispatch_reconcile, dispatch_refresh, dispatch_scout,
+    dispatch_status, dispatch_task, dispatch_wait_fresh, dispatch_where,
 };
 pub(super) use search::dispatch_search;
 

--- a/src/cli/batch/json_args.rs
+++ b/src/cli/batch/json_args.rs
@@ -326,6 +326,20 @@ pub(super) fn build_batch_cmd(command: &str, arguments: &serde_json::Value) -> R
             let c: crate::cli::commands::notes::NotesRemoveArgs = parse_core(command, arguments)?;
             BatchCmd::NotesRemove { args: c }
         }
+        // ─── MCP Phase 2b: gated fire-and-forget reindex ───────────────────────
+        //
+        // `cqs_index` over the daemon. Same opt-in gate as the notes channel.
+        // The handler QUEUES (flips the reconcile signal) and returns
+        // immediately — it never builds the index and never acquires a writable
+        // `Store`, so the `Store<ReadOnly>` invariant holds. The scoped core
+        // exposes only the non-destructive subset (`slot`, …); `--force` is
+        // withheld by ABSENCE (the core has no `force` field), so a forced full
+        // rebuild is unreachable over the wire regardless of the flag.
+        "index" => {
+            require_mutations_enabled(command)?;
+            let c: crate::cli::commands::index::IndexArgs = parse_core(command, arguments)?;
+            BatchCmd::Index { args: c }
+        }
         other => bail!(
             "command '{other}' does not accept a JSON `arguments` object \
              (no Phase-0 core struct); use the argv `args` form"
@@ -1042,6 +1056,140 @@ mod tests {
             store.chunk_count().is_ok(),
             "the daemon's Store<ReadOnly> must stay usable across a notes write"
         );
+    }
+
+    // ─── MCP Phase 2b: gated fire-and-forget reindex (`index`) ─────────────────
+
+    /// With the flag OFF, `index` over the JSON-args path is rejected by
+    /// `build_batch_cmd` AND by the full dispatch — the daemon-side enforcement
+    /// that a raw socket client can't bypass the bridge's `tools/list` gating.
+    /// The reconcile signal is NOT flipped.
+    #[test]
+    #[serial_test::serial(mcp_mutations_env)]
+    fn index_rejected_when_flag_off() {
+        use std::sync::atomic::Ordering;
+        let _guard = MutEnvGuard::set(false);
+        let (_dir, ctx) = seed_ctx();
+        // build_batch_cmd refuses without the opt-in.
+        assert!(
+            build_batch_cmd("index", &json!({})).is_err(),
+            "`index` must be rejected when CQS_MCP_ENABLE_MUTATIONS is unset"
+        );
+        // Full dispatch returns an error envelope and does NOT queue.
+        assert!(
+            !ctx.reconcile_signal.load(Ordering::Acquire),
+            "reconcile signal must start un-pending"
+        );
+        let mut out = Vec::new();
+        dispatch_via_view_json(&ctx.build_view(None), "index", &json!({}), &mut out);
+        let v: serde_json::Value = serde_json::from_slice(&out).expect("JSON");
+        assert!(
+            v.get("error").is_some_and(|e| !e.is_null()),
+            "`index` flag-off must return an error envelope, got: {v}"
+        );
+        assert!(
+            !ctx.reconcile_signal.load(Ordering::Acquire),
+            "flag-off `index` must NOT flip the reconcile signal"
+        );
+    }
+
+    /// With the flag ON, `index` returns PROMPTLY with the queued/deferred
+    /// envelope (a fire-and-forget queue, NOT a blocking build), and flips the
+    /// shared reconcile signal so the watch loop performs the rebuild.
+    #[test]
+    #[serial_test::serial(mcp_mutations_env)]
+    fn index_queues_promptly_when_flag_on() {
+        use std::sync::atomic::Ordering;
+        let _guard = MutEnvGuard::set(true);
+        let (_dir, ctx) = seed_ctx();
+        assert!(
+            !ctx.reconcile_signal.load(Ordering::Acquire),
+            "reconcile signal must start un-pending"
+        );
+
+        let start = std::time::Instant::now();
+        let mut out = Vec::new();
+        dispatch_via_view_json(&ctx.build_view(None), "index", &json!({}), &mut out);
+        let elapsed_ms = start.elapsed().as_millis();
+        let v: serde_json::Value = serde_json::from_slice(&out).expect("JSON");
+
+        // Fire-and-forget: it must return well before any real index build could
+        // run. A blocking build would take seconds even on a tiny index; a queue
+        // is sub-millisecond. 500 ms is a generous ceiling for the dispatch.
+        assert!(
+            elapsed_ms < 500,
+            "`index` must return promptly (fire-and-forget), took {elapsed_ms}ms"
+        );
+
+        let data = &v["data"];
+        assert!(
+            v.get("data").is_some_and(|d| !d.is_null()),
+            "index must return a data envelope, got: {v}"
+        );
+        assert_eq!(data["status"], "queued");
+        assert_eq!(data["queued"], true, "the response must mark queued:true");
+        assert_eq!(
+            data["reindex_deferred"], true,
+            "the daemon defers the rebuild to the watch loop"
+        );
+        // The signal is now pending — the watch loop will drain it.
+        assert!(
+            ctx.reconcile_signal.load(Ordering::Acquire),
+            "flag-on `index` must flip the reconcile signal"
+        );
+    }
+
+    /// The daemon `index` path preserves `Store<ReadOnly>`: it never acquires a
+    /// writable store (it only flips the reconcile signal). Mirrors the notes
+    /// `Store<ReadOnly>` invariant test — type-level proof the handler had no
+    /// writable store to reach for, and the read-only store stays usable.
+    #[test]
+    #[serial_test::serial(mcp_mutations_env)]
+    fn index_keeps_store_read_only() {
+        let _guard = MutEnvGuard::set(true);
+        let (_dir, ctx) = seed_ctx();
+        let view = ctx.build_view(None);
+        // Type assertion: the view's store is read-only (compile-time proof the
+        // handler had no writable store to reach for).
+        let store: std::sync::Arc<cqs::store::Store<cqs::store::ReadOnly>> = view.store();
+        let mut out = Vec::new();
+        dispatch_via_view_json(&view, "index", &json!({}), &mut out);
+        let v: serde_json::Value = serde_json::from_slice(&out).expect("JSON");
+        assert_eq!(v["data"]["status"], "queued");
+        // The read-only store is still live after queueing (a read succeeds —
+        // the typestate was never traded for a writable handle).
+        assert!(
+            store.chunk_count().is_ok(),
+            "the daemon's Store<ReadOnly> must stay usable across an index queue"
+        );
+    }
+
+    /// `index --force` is unreachable over the wire: the scoped `IndexArgs` core
+    /// has no `force` field, so a `force:true` key in `arguments` is silently
+    /// ignored (deserialize succeeds, dropping the unknown key) — there is no
+    /// path that turns a fire-and-forget queue into a forced full rebuild. The
+    /// queue still happens (non-destructive), and no forced behavior is invoked.
+    #[test]
+    #[serial_test::serial(mcp_mutations_env)]
+    fn index_force_key_is_ignored_not_a_forced_rebuild() {
+        let _guard = MutEnvGuard::set(true);
+        // The core deserializes `{"force": true}` to the default (force is not a
+        // field) — proving `--force` cannot be smuggled in via the wire.
+        let cmd = build_batch_cmd("index", &json!({"force": true, "slot": "primary"}))
+            .expect("index with an unknown `force` key still builds (key ignored)");
+        match cmd {
+            BatchCmd::Index { args } => {
+                assert_eq!(
+                    args.slot.as_deref(),
+                    Some("primary"),
+                    "the known `slot` field round-trips"
+                );
+                // There is no `force` field to inspect — its absence from the
+                // struct is the withhold. The build succeeding with the queue
+                // semantics (not a forced rebuild) is the assertion.
+            }
+            _ => panic!("expected BatchCmd::Index"),
+        }
     }
 
     /// Malformed `arguments` (a type the core cannot accept) produces a clean

--- a/src/cli/batch/view.rs
+++ b/src/cli/batch/view.rs
@@ -191,7 +191,7 @@ pub(crate) fn dispatch_via_view_json(
     }
 
     // NUL byte rejection — same contract as the argv path, but over the JSON
-    // string values rather than argv tokens (serde decodes ` ` into a
+    // string values rather than argv tokens (serde decodes `\0` into a
     // String, so a structural walk is the equivalent check).
     if json_value_contains_nul(arguments) {
         view.error_count.fetch_add(1, Ordering::Relaxed);

--- a/src/cli/commands/index/index_args.rs
+++ b/src/cli/commands/index/index_args.rs
@@ -1,0 +1,46 @@
+//! The Phase-0 JsonSchema core for `cqs index` (MCP Phase 2b, fire-and-forget).
+//!
+//! A scoped slice of the clap-side [`crate::cli::args::IndexArgs`] that exposes
+//! ONLY the non-destructive subset to an MCP client. It derives
+//! `serde::Deserialize` + `schemars::JsonSchema`, so it doubles as the
+//! `cqs_index` `inputSchema` source and the daemon deserialize target — the
+//! same struct-is-the-contract discipline the read cores and the Phase-2a notes
+//! cores follow.
+//!
+//! ## What this core deliberately OMITS (boundary by absence)
+//!
+//! The destructive / model-swapping fields of the clap `IndexArgs` are NOT
+//! present here, so they cannot be set over the wire even when the mutation flag
+//! is on:
+//! - `force` — the destructive full-rebuild variant. Withheld per the design
+//!   (`index --force` is the destructive twin of a fire-and-forget add); a
+//!   forced full rebuild from a steered MCP client is exactly the blast-radius
+//!   the §2 boundary withholds.
+//! - the `--improve-docs` / `--apply` / `--improve-all` / `llm-summaries`
+//!   family — these rewrite source files / spend API budget, out of charter for
+//!   a queued reindex.
+//!
+//! ## The fire-and-forget semantics
+//!
+//! The daemon dispatch for this core does NOT run an index build. It QUEUES a
+//! reconcile (flips the shared `SharedReconcileSignal`, the same primitive
+//! `reconcile` uses) and returns immediately; the watch loop performs the
+//! actual reindex on its next tick. So this core never reaches a writable
+//! `Store` — the daemon's `Store<ReadOnly>` invariant holds. The client polls
+//! completion via the already-exposed read tools `cqs_wait_fresh` / `cqs_status`.
+
+/// Scoped, non-destructive input for the `cqs_index` MCP tool (Phase 2b).
+///
+/// `#[serde(default)]` on the struct so an MCP caller can send `{}` (queue a
+/// reindex of the active slot) or supply just `slot`. Every field is optional on
+/// the wire — a queued reindex needs no required input.
+#[derive(Debug, Clone, PartialEq, Default, serde::Deserialize, schemars::JsonSchema)]
+#[serde(default)]
+pub(crate) struct IndexArgs {
+    /// Target slot name (per-project `.cqs/slots/<name>/`). Advisory on the
+    /// fire-and-forget daemon path: the daemon queues a reconcile of the slot it
+    /// already serves (the active slot it was opened against), so a `slot` that
+    /// differs from the served slot does not redirect the rebuild. Present in the
+    /// schema for honesty and forward use; omit it to reindex the active slot.
+    pub slot: Option<String>,
+}

--- a/src/cli/commands/index/mod.rs
+++ b/src/cli/commands/index/mod.rs
@@ -2,6 +2,7 @@
 
 mod build;
 mod gc;
+mod index_args;
 mod stale;
 mod stats;
 mod umap;
@@ -11,5 +12,9 @@ pub(crate) use build::{
     snapshot_fingerprint,
 };
 pub(crate) use gc::cmd_gc;
+// The Phase-0 JsonSchema core for the `cqs_index` MCP tool (Phase 2b). Distinct
+// from the clap-side `crate::cli::args::IndexArgs` — this is the non-destructive
+// wire slice the bridge advertises and the daemon deserializes.
+pub(crate) use index_args::IndexArgs;
 pub(crate) use stale::{cmd_stale, stale_core, StaleArgs};
 pub(crate) use stats::{cmd_stats, stats_core, StatsArgs};

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -11,7 +11,7 @@
 
 pub(crate) mod eval;
 mod graph;
-mod index;
+pub(crate) mod index;
 mod infra;
 mod io;
 pub(crate) mod resolve;

--- a/src/cli/mcp/mod.rs
+++ b/src/cli/mcp/mod.rs
@@ -164,9 +164,10 @@ mod tests {
         );
     }
 
-    /// Flag-gating guard: the notes-mutation tools are present IFF
+    /// Flag-gating guard: the mutation tools are present IFF
     /// `CQS_MCP_ENABLE_MUTATIONS=1`. With the flag on, the exposed set is the
-    /// read set PLUS exactly the three notes mutators (22 total).
+    /// read set PLUS exactly the three notes mutators AND the fire-and-forget
+    /// `index` (23 total).
     #[test]
     #[serial_test::serial(mcp_mutations_env)]
     fn mutation_tools_present_iff_flag_set() {
@@ -174,43 +175,52 @@ mod tests {
         {
             let _guard = MutationsEnvGuard::set(false);
             let off = exposed_commands();
-            for cmd in ["notes-add", "notes-update", "notes-remove"] {
+            for cmd in ["notes-add", "notes-update", "notes-remove", "index"] {
                 assert!(
                     !off.contains(cmd),
                     "flag-off tools/list must NOT contain `{cmd}`"
                 );
             }
         }
-        // Flag on → read set + the three notes mutators.
+        // Flag on → read set + the three notes mutators + the index queue tool.
         {
             let _guard = MutationsEnvGuard::set(true);
             let on = exposed_commands();
-            for cmd in ["notes-add", "notes-update", "notes-remove"] {
+            for cmd in ["notes-add", "notes-update", "notes-remove", "index"] {
                 assert!(on.contains(cmd), "flag-on tools/list must contain `{cmd}`");
             }
             let mut want = expected_read_commands();
             want.insert("notes-add".to_string());
             want.insert("notes-update".to_string());
             want.insert("notes-remove".to_string());
+            want.insert("index".to_string());
             assert_eq!(
                 on, want,
-                "flag-on tools/list must be the read set plus exactly the 3 notes mutators"
+                "flag-on tools/list must be the read set plus exactly the 3 notes mutators \
+                 and the index queue tool"
             );
-            assert_eq!(on.len(), 22, "flag-on tools/list must expose 22 tools");
+            assert_eq!(on.len(), 23, "flag-on tools/list must expose 23 tools");
         }
     }
 
     /// Destructive-set-absent guard: `gc` / `slot remove` / `index --force` /
     /// `model swap` / `cache clear` must NEVER appear in `tools/list`,
     /// REGARDLESS of the mutation flag — boundary by absence (§1.3, §2.2). No
-    /// flag re-enables the destructive set in Phase 2a.
+    /// flag re-enables the destructive set in Phase 2b.
+    ///
+    /// Note: `cqs_index` (the non-destructive fire-and-forget queue) IS exposed
+    /// when the flag is on — it is NOT in this list. The withheld variant is the
+    /// FORCED full rebuild, which has no tool name at all (the scoped `IndexArgs`
+    /// core exposes no `force` field), so there is nothing to assert-absent for
+    /// it beyond the absence of any `--force` reachability (covered by the
+    /// `index --force` unreachability test).
     #[test]
     #[serial_test::serial(mcp_mutations_env)]
     fn destructive_set_absent_regardless_of_flag() {
         let destructive_tools = [
             "cqs_gc",
             "cqs_slot_remove",
-            "cqs_index",
+            "cqs_index_force",
             "cqs_model_swap",
             "cqs_cache_clear",
             "cqs_audit_mode",
@@ -225,6 +235,50 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// `index --force` is unreachable as a tool regardless of the flag: the only
+    /// `index` tool exposed is the non-destructive queue (`cqs_index`), and its
+    /// scoped `IndexArgs` core has NO `force` field — so a `force` key in
+    /// `arguments` is simply ignored (the core does not deserialize it), and
+    /// there is no separate forced-rebuild tool. This pins the §1.3 withhold.
+    #[test]
+    #[serial_test::serial(mcp_mutations_env)]
+    fn index_force_is_unreachable_as_a_tool() {
+        let _guard = MutationsEnvGuard::set(true);
+        let names: Vec<&'static str> = tools::tool_table().iter().map(|t| t.name).collect();
+        // Exactly one `index` tool — the queue — and no forced variant.
+        let index_tools: Vec<&&'static str> =
+            names.iter().filter(|n| n.contains("index")).collect();
+        assert_eq!(
+            index_tools.len(),
+            1,
+            "exactly one index tool must be exposed (the non-destructive queue), got: {index_tools:?}"
+        );
+        assert!(
+            names.contains(&"cqs_index"),
+            "the exposed index tool must be the non-destructive `cqs_index` queue"
+        );
+        // The exposed `cqs_index` schema must NOT advertise a `force` property —
+        // the destructive flag is withheld by absence from the scoped core.
+        let listed = tools::list();
+        let arr = listed
+            .get("tools")
+            .and_then(|t| t.as_array())
+            .expect("tools array");
+        let index_schema = arr
+            .iter()
+            .find(|t| t.get("name").and_then(|n| n.as_str()) == Some("cqs_index"))
+            .and_then(|t| t.get("inputSchema"))
+            .and_then(|s| s.get("properties"))
+            .and_then(|p| p.as_object())
+            .expect("cqs_index inputSchema properties");
+        assert!(
+            !index_schema.contains_key("force"),
+            "cqs_index schema must not expose a `force` property (destructive variant withheld), \
+             got properties: {:?}",
+            index_schema.keys().collect::<Vec<_>>()
+        );
     }
 
     /// Every exposed tool carries the `cqs_` prefix (D1), an `inputSchema` that
@@ -305,6 +359,19 @@ mod tests {
             Some(true),
             "notes_remove is the lone destructiveHint:true in the exposed set"
         );
+
+        // The Phase-2b queue tool: a mutator that is idempotent (repeated calls
+        // coalesce into one watch-loop walk) and non-destructive (rebuilds from
+        // the source tree).
+        let index = find("cqs_index");
+        assert_eq!(hint(&index, "readOnlyHint"), Some(false));
+        assert_eq!(hint(&index, "idempotentHint"), Some(true));
+        assert_eq!(
+            hint(&index, "destructiveHint"),
+            Some(false),
+            "cqs_index is a non-destructive queued reindex"
+        );
+        assert_eq!(hint(&index, "openWorldHint"), Some(false));
     }
 
     /// `context`/`explain` must be ABSENT from the exposed surface (D4b),

--- a/src/cli/mcp/tools.rs
+++ b/src/cli/mcp/tools.rs
@@ -314,17 +314,24 @@ fn read_tools() -> &'static [ToolDef] {
     ]
 }
 
-/// The Phase-2a gated notes-mutation tools (§3). Appended to `tool_table` ONLY
-/// when `CQS_MCP_ENABLE_MUTATIONS=1`. Each carries per-command annotations:
+/// The gated mutation tools (§3) — the Phase-2a notes channel plus the Phase-2b
+/// fire-and-forget `cqs_index`. Appended to `tool_table` ONLY when
+/// `CQS_MCP_ENABLE_MUTATIONS=1`. Each carries per-command annotations:
 /// `add` is additive (non-destructive, non-idempotent), `update` is idempotent
-/// but mutating, `remove` is the lone `destructiveHint:true` in the set. The
-/// `command` column maps to the `json_args::build_batch_cmd` notes arms
-/// (`notes-add`/`notes-update`/`notes-remove`) — also gated daemon-side.
+/// but mutating, `remove` is the lone `destructiveHint:true` in the set, and
+/// `index` is a queued reindex (idempotent, non-destructive — rebuilds from the
+/// source tree). The `command` column maps to the `json_args::build_batch_cmd`
+/// arms (`notes-add`/`notes-update`/`notes-remove`/`index`) — also gated
+/// daemon-side.
 ///
 /// The DESTRUCTIVE set (`gc`/`slot remove`/`index --force`/`model swap`/
 /// `cache clear`) is NOT here and has no flag that re-enables it: boundary by
-/// absence, the same mechanism that withholds `context`.
+/// absence, the same mechanism that withholds `context`. Note that `cqs_index`
+/// IS exposed but `index --force` is NOT — the scoped `IndexArgs` core has no
+/// `force` field, so the destructive full-rebuild variant is unreachable over
+/// the wire.
 fn mutation_tools() -> &'static [ToolDef] {
+    use crate::cli::commands::index::IndexArgs as IndexCore;
     use crate::cli::commands::notes::{NotesAddArgs, NotesRemoveArgs, NotesUpdateArgs};
     &[
         ToolDef {
@@ -369,6 +376,26 @@ fn mutation_tools() -> &'static [ToolDef] {
                 idempotent: true,
                 // The note text is gone — the lone destructive flag in the set.
                 destructive: true,
+                open_world: false,
+            },
+        },
+        ToolDef {
+            name: "cqs_index",
+            command: "index",
+            description:
+                "Queue a reindex of the active slot (fire-and-forget): returns immediately with \
+                 {queued:true, reindex_deferred:true}; the watch loop performs the rebuild on its \
+                 next tick — it does NOT block on the build. Poll completion with cqs_wait_fresh \
+                 (or cqs_status). Non-destructive: rebuilds from the source tree (the full-rebuild \
+                 `--force` variant is withheld).",
+            input_schema: schema::<IndexCore>,
+            annotations: ToolAnnotations {
+                read_only: false,
+                // A queued reindex converges to the same fresh index — repeated
+                // calls coalesce into one watch-loop walk.
+                idempotent: true,
+                // Rebuilds from source-of-truth; no data loss.
+                destructive: false,
                 open_world: false,
             },
         },
@@ -522,6 +549,9 @@ fn validate_arguments(command: &str, arguments: &Value) -> Result<(), String> {
         "notes-add" => check::<crate::cli::commands::notes::NotesAddArgs>(arguments),
         "notes-update" => check::<crate::cli::commands::notes::NotesUpdateArgs>(arguments),
         "notes-remove" => check::<crate::cli::commands::notes::NotesRemoveArgs>(arguments),
+        // Phase-2b gated fire-and-forget reindex. The scoped core (no `force`)
+        // is the shape pre-check; the daemon re-deserializes authoritatively.
+        "index" => check::<crate::cli::commands::index::IndexArgs>(arguments),
         // Unreachable: every table command is covered above. A new tool with no
         // arm fails the pre-check loudly rather than silently skipping it.
         other => Err(format!("no argument schema for command {other}")),


### PR DESCRIPTION
## MCP Phase 2b — `cqs_index` fire-and-forget (+ view.rs NUL fix)

Completes the user-blessed Phase 2 scope (notes-writes from 2a + index here), on top of the 2a mutation channel and gating.

**Fire-and-forget, never a Store write.** `dispatch_index` calls `request_reconcile()` (the same `SharedReconcileSignal` primitive as `dispatch_reconcile`) and returns immediately with `{status:"queued", queued:true, reindex_deferred:true}`; the watch loop performs the actual rebuild. The daemon's `Store<ReadOnly>` typestate invariant (from 2a) is preserved — no writable Store in the handler (asserted by `index_keeps_store_read_only`).

**`--force` withheld by absence.** New scoped `IndexArgs` JsonSchema core exposes only optional `slot` — there is no `force` field, so `index --force` / model-swap / improve-docs are unreachable over the wire regardless of the flag (pinned by `index_force_is_unreachable_as_a_tool`: exactly one index tool, schema has no `force` property). `slot` is honestly documented as advisory on the single-slot daemon path.

**Same gate as 2a** — `CQS_MCP_ENABLE_MUTATIONS` at both layers (`require_mutations_enabled` runs first in the `"index"` arm; fail-closed, tested). Annotation `idempotentHint:true`, `destructiveHint:false`. Flag-on `tools/list` = 23 (19 read + 3 notes + index); client polls completion via the existing `cqs_wait_fresh`/`cqs_status` read tools.

**Folded fix:** `src/cli/batch/view.rs:194` had a raw NUL byte in a comment (made `file` report "data" + plain grep treat it as binary) — replaced with `\0`. Verified the file is now NUL-free.

**Tests:** full `--tests` sweep 4815/0; index queues promptly (<500ms, signal flip) / rejected flag-off / Store-read-only invariant / force-key-ignored. clippy/fmt/provenance clean.

(Pre-existing flake noted separately: a CWD-race in `dispatch_review_unrelated_delta_no_marker` — not from this diff.)
