### PR TITLE
fix(mcp): bridge polish — error-shape docs, derived parity guard, max_nodes schema honesty (#2030)

### DIFF
--- a/src/cli/batch/json_args.rs
+++ b/src/cli/batch/json_args.rs
@@ -137,6 +137,73 @@ fn overlay_from_args(arguments: &serde_json::Value) -> OverlayArgs {
     }
 }
 
+/// Substring marker in the catch-all rejection for a command with no Phase-0
+/// core. The probe predicate [`is_json_args_capable`] keys off this exact
+/// phrase, so the bail message and the predicate cannot drift — change one and
+/// the other follows.
+const NO_CORE_REJECTION: &str = "does not accept a JSON `arguments` object";
+
+/// The canonical set of JSON-args-capable command names — the SINGLE source of
+/// truth for "which commands [`build_batch_cmd`] accepts an `arguments` object
+/// for." Lists exactly the non-catch-all match arms below (the read commands
+/// plus the gated `notes-*` / `index` mutators). Co-located with the arms so a
+/// reviewer edits both together; the `json_args_capability_matches_arms`
+/// exhaustiveness test PROVES this list equals the arms by probing
+/// `build_batch_cmd`, so a new arm without an entry here (or vice versa) fails
+/// the build. The MCP registry-parity guard derives its expected tool set from
+/// this slice rather than re-listing it.
+///
+/// Test-only: its consumers are the exhaustiveness test here and the MCP guard
+/// in `cli::mcp` (both `#[cfg(test)]`). Production routing reads the match arms
+/// directly, never this list.
+#[cfg(test)]
+pub(crate) const JSON_ARGS_CAPABLE_COMMANDS: &[&str] = &[
+    "search",
+    "gather",
+    "scout",
+    "onboard",
+    "similar",
+    "callers",
+    "callees",
+    "deps",
+    "impact",
+    "test-map",
+    "trace",
+    "blame",
+    "context",
+    "diff",
+    "drift",
+    "dead",
+    "ci",
+    "review",
+    "plan",
+    "read",
+    "notes-add",
+    "notes-update",
+    "notes-remove",
+    "index",
+];
+
+/// Whether `command` is JSON-args-capable: [`build_batch_cmd`] accepts an
+/// `arguments` object for it (it has a Phase-0 core) rather than falling through
+/// to the catch-all "no Phase-0 core" rejection. Derived by probing
+/// `build_batch_cmd` with an empty object and inspecting whether the error (if
+/// any) is the catch-all — so the predicate reads the arms directly and cannot
+/// drift from them. A capable command with `{}` either builds (serde defaults)
+/// or fails for a different reason (a missing required field, the gated-mutation
+/// opt-in); only an argv-only / unknown command yields the catch-all marker.
+///
+/// Test-only: it exists to pin [`JSON_ARGS_CAPABLE_COMMANDS`] against the arms
+/// (the `json_args_capability_matches_arms` guard). Production never needs a
+/// capability predicate — `build_batch_cmd` already returns the right error.
+#[cfg(test)]
+pub(crate) fn is_json_args_capable(command: &str) -> bool {
+    match build_batch_cmd(command, &serde_json::Value::Object(Default::default())) {
+        Ok(_) => true,
+        Err(e) => !e.to_string().contains(NO_CORE_REJECTION),
+    }
+}
+
 /// Build the `BatchCmd` for a JSON-args request: deserialize `arguments` into
 /// the command's Phase-0 core, then construct the matching argv-side
 /// `BatchCmd` variant. The caller feeds the result into the SAME
@@ -341,7 +408,7 @@ pub(super) fn build_batch_cmd(command: &str, arguments: &serde_json::Value) -> R
             BatchCmd::Index { args: c }
         }
         other => bail!(
-            "command '{other}' does not accept a JSON `arguments` object \
+            "command '{other}' {NO_CORE_REJECTION} \
              (no Phase-0 core struct); use the argv `args` form"
         ),
     };
@@ -1295,6 +1362,77 @@ mod tests {
                 assert_eq!(args.limit_arg.limit, 4);
             }
             _ => panic!("expected Plan"),
+        }
+    }
+
+    /// Exhaustiveness guard for the §2 derivation: the canonical
+    /// `JSON_ARGS_CAPABLE_COMMANDS` list must equal the set of commands
+    /// `build_batch_cmd` actually accepts (the non-catch-all arms), proven by
+    /// probing the builder rather than re-reading the arms by eye. A new arm
+    /// added without a list entry (or a list entry with no arm) fails here, so
+    /// the MCP registry-parity guard — which derives from this list — cannot
+    /// silently miss a newly-capable command.
+    #[test]
+    #[serial_test::serial(mcp_mutations_env)]
+    fn json_args_capability_matches_arms() {
+        // The flag-gated mutators are capable arms; enable the opt-in so the
+        // probe sees them as capable (with the flag off they bail on the gate,
+        // not the catch-all — still "capable", but we exercise the on path too).
+        let _g = MutEnvGuard::set(true);
+
+        // 1. Every listed command is genuinely capable (no catch-all rejection).
+        for &cmd in JSON_ARGS_CAPABLE_COMMANDS {
+            assert!(
+                is_json_args_capable(cmd),
+                "`{cmd}` is in JSON_ARGS_CAPABLE_COMMANDS but build_batch_cmd rejects it as \
+                 having no Phase-0 core — the list and the match arms diverged"
+            );
+        }
+
+        // 2. A representative spread of argv-only / unknown commands is NOT
+        //    capable — the catch-all bites, and they are absent from the list.
+        for cmd in [
+            "where",
+            "explain",
+            "notes",
+            "health",
+            "task",
+            "nonexistent_cmd",
+        ] {
+            assert!(
+                !is_json_args_capable(cmd),
+                "`{cmd}` is argv-only/unknown but build_batch_cmd treats it as JSON-args-capable"
+            );
+            assert!(
+                !JSON_ARGS_CAPABLE_COMMANDS.contains(&cmd),
+                "`{cmd}` is not JSON-args-capable yet appears in JSON_ARGS_CAPABLE_COMMANDS"
+            );
+        }
+
+        // 3. The list has no duplicates (a copy-paste straggler would inflate
+        //    the derived MCP tool count).
+        let unique: std::collections::BTreeSet<&&str> = JSON_ARGS_CAPABLE_COMMANDS.iter().collect();
+        assert_eq!(
+            unique.len(),
+            JSON_ARGS_CAPABLE_COMMANDS.len(),
+            "JSON_ARGS_CAPABLE_COMMANDS contains a duplicate"
+        );
+    }
+
+    /// The flag-OFF probe still classifies a gated mutator as capable: the gate
+    /// bail is NOT the catch-all "no Phase-0 core" rejection, so `notes-add`
+    /// remains JSON-args-capable regardless of the opt-in. This pins that the
+    /// capability predicate keys on the core's existence, not the flag.
+    #[test]
+    #[serial_test::serial(mcp_mutations_env)]
+    fn gated_mutator_is_capable_even_with_flag_off() {
+        let _g = MutEnvGuard::set(false);
+        for cmd in ["notes-add", "notes-update", "notes-remove", "index"] {
+            assert!(
+                is_json_args_capable(cmd),
+                "`{cmd}` must be JSON-args-capable even with the mutation flag off \
+                 (the gate bail is not the no-core catch-all)"
+            );
         }
     }
 

--- a/src/cli/batch/mod.rs
+++ b/src/cli/batch/mod.rs
@@ -47,6 +47,14 @@ pub(crate) use commands::{dispatch, BatchInput};
 #[cfg(test)]
 pub(crate) use commands::BatchCmd;
 pub(crate) use pipeline::{execute_pipeline, has_pipe_token};
+// The canonical JSON-args-capable command set, surfaced for the MCP
+// registry-parity guard (`cli::mcp::mod`) so it derives the expected tool set
+// from `build_batch_cmd`'s single source of truth rather than re-listing the
+// commands. Test-only — the guard that consumes it is `#[cfg(test)]`. The
+// `is_json_args_capable` probe predicate that pins this list against the match
+// arms stays local to `json_args` (used by its own exhaustiveness test).
+#[cfg(test)]
+pub(crate) use json_args::JSON_ARGS_CAPABLE_COMMANDS;
 
 use std::cell::{Cell, RefCell};
 use std::collections::HashSet;

--- a/src/cli/commands/graph/test_map.rs
+++ b/src/cli/commands/graph/test_map.rs
@@ -39,7 +39,14 @@ pub(crate) struct TestMapArgs {
     /// once at the adapter boundary from `CQS_TEST_MAP_MAX_NODES` (default
     /// 10,000) via [`test_map_max_nodes`]; the core never reads the env.
     /// `#[serde(default)]` so a wire caller that omits it gets the default.
+    ///
+    /// `#[schemars(skip)]`: the JSON-args adapter does not round-trip this field
+    /// (the handler env-resolves the ceiling), so the advertised MCP
+    /// `inputSchema` must NOT offer it — advertising a knob the daemon silently
+    /// ignores misleads the caller. Deserialize still accepts it (a wire client
+    /// that sends it is tolerated, just inert), only the schema hides it.
     #[serde(default = "test_map_max_nodes")]
+    #[schemars(skip)]
     pub max_nodes: usize,
 }
 

--- a/src/cli/commands/graph/trace.rs
+++ b/src/cli/commands/graph/trace.rs
@@ -40,7 +40,14 @@ pub(crate) struct TraceArgs {
     /// the adapter boundary from `CQS_TRACE_MAX_NODES` (default 10,000) via
     /// [`trace_max_nodes`]; the core never reads the env itself. `#[serde(default)]`
     /// so an MCP/wire caller that omits it falls back to the default ceiling.
+    ///
+    /// `#[schemars(skip)]`: the JSON-args adapter does not round-trip this field
+    /// (the handler env-resolves the ceiling), so the advertised MCP
+    /// `inputSchema` must NOT offer it — advertising a knob the daemon silently
+    /// ignores misleads the caller. Deserialize still accepts it (a wire client
+    /// that sends it is tolerated, just inert), only the schema hides it.
     #[serde(default = "trace_max_nodes")]
+    #[schemars(skip)]
     pub max_nodes: usize,
 }
 

--- a/src/cli/mcp/mod.rs
+++ b/src/cli/mcp/mod.rs
@@ -89,23 +89,27 @@ mod tests {
     }
 
     /// The command names that map to the exposed MCP read tools — the daemon's
-    /// JSON-args-capable read set MINUS the withheld doc/signature-relay set.
-    /// Returns the bare daemon command names (the registry comparison key).
+    /// JSON-args-capable read set MINUS the gated-mutation arms MINUS the
+    /// withheld doc/signature-relay set. Returns the bare daemon command names
+    /// (the registry comparison key).
+    ///
+    /// DERIVED, not hand-mirrored: the capable set comes from
+    /// `build_batch_cmd`'s single source of truth
+    /// ([`crate::cli::batch::JSON_ARGS_CAPABLE_COMMANDS`]), so a Lane-1 command
+    /// added there auto-enrolls in this guard rather than silently skipping it.
+    /// The const is itself pinned against the match arms by an exhaustiveness
+    /// test in `json_args.rs`, closing the incomplete-sweep gap.
     fn expected_read_commands() -> std::collections::BTreeSet<String> {
-        // The canonical JSON-args-capable read command set, mirrored from
-        // `build_batch_cmd`'s match arms (the notes-mutation arms are accounted
-        // for separately by the flag-gated rows). If Lane 1 adds a read command
-        // there, this list must grow with it (and the tool table in `tools.rs`).
-        let json_args_capable: std::collections::BTreeSet<&str> = [
-            "search", "gather", "scout", "onboard", "similar", "callers", "callees", "deps",
-            "impact", "test-map", "trace", "blame", "context", "diff", "drift", "dead", "ci",
-            "review", "plan", "read",
-        ]
-        .into_iter()
-        .collect();
+        // The gated mutators (`notes-*`, `index`) are JSON-args-capable but are
+        // NOT read tools — they ride the flag-gated rows and are accounted for
+        // separately. Subtract them here so this set is the READ surface only.
+        let gated_mutators: std::collections::BTreeSet<&str> =
+            ["notes-add", "notes-update", "notes-remove", "index"]
+                .into_iter()
+                .collect();
         // The withheld set: the P1 doc/signature relay surfaces (`context`,
         // `explain`) PLUS the destructive mutators that are withheld by absence
-        // in Phase 2a — naming them here makes the guard ENFORCE §1.3 (a future
+        // — naming them here makes the guard ENFORCE the withhold (a future
         // hand that adds `cqs_gc` to the table fails this test).
         let withheld: std::collections::BTreeSet<&str> = [
             "context",
@@ -118,8 +122,10 @@ mod tests {
         ]
         .into_iter()
         .collect();
-        json_args_capable
-            .difference(&withheld)
+        crate::cli::batch::JSON_ARGS_CAPABLE_COMMANDS
+            .iter()
+            .copied()
+            .filter(|c| !gated_mutators.contains(c) && !withheld.contains(c))
             .map(|s| s.to_string())
             .collect()
     }

--- a/src/cli/mcp/tools.rs
+++ b/src/cli/mcp/tools.rs
@@ -22,8 +22,9 @@
 //! authoritative deserialize happens daemon-side), then relayed as the Lane 1
 //! JSON-args frame. The daemon's two-layer envelope is classified:
 //! - Socket-layer transport/parse failure → a JSON-RPC protocol error.
-//! - A handler error riding under `status:"ok"`
-//!   (`output = {data:null, error:{...}}`, mirrored from `classify_slim_envelope`)
+//! - A handler error riding under `status:"ok"` (the slim error envelope:
+//!   `output = {error:{...}}` — error-present, NO `data` key, optional `_meta`,
+//!   the shape `classify_slim_envelope` matches as `Error`)
 //!   → `CallToolResult{isError:true}` with the redacted message — NOT a
 //!   protocol error (Blocker #1).
 //! - A success (`output = {data:..., (opt)_meta:...}`) → `CallToolResult` with
@@ -850,6 +851,35 @@ mod tests {
         assert_eq!(mcp_name_to_command("cqs_test_map"), "test-map");
         assert_eq!(mcp_name_to_command("cqs_search"), "search");
         assert_eq!(mcp_name_to_command("cqs_callers"), "callers");
+    }
+
+    /// Schema honesty: the `cqs_trace` / `cqs_test_map` `inputSchema` must NOT
+    /// advertise `max_nodes`. The field is env-resolved in the handler and does
+    /// NOT round-trip on the JSON-args adapter, so advertising it would offer a
+    /// knob the daemon silently ignores. `#[schemars(skip)]` drops it from the
+    /// schema while serde still tolerates it on the wire (inert).
+    #[test]
+    fn trace_and_test_map_schema_omits_max_nodes() {
+        for tool in ["cqs_trace", "cqs_test_map"] {
+            let def = find_tool(tool).unwrap_or_else(|| panic!("`{tool}` must be in the table"));
+            let schema = (def.input_schema)();
+            let props = schema
+                .get("properties")
+                .and_then(|p| p.as_object())
+                .unwrap_or_else(|| panic!("`{tool}` schema must carry properties"));
+            assert!(
+                !props.contains_key("max_nodes"),
+                "`{tool}` inputSchema must NOT advertise the inert `max_nodes` field; \
+                 got properties: {:?}",
+                props.keys().collect::<Vec<_>>()
+            );
+            // A real, advertised field is still present — proves we didn't
+            // accidentally empty the schema.
+            assert!(
+                props.contains_key("max_depth"),
+                "`{tool}` inputSchema must still advertise `max_depth`"
+            );
+        }
     }
 
     /// An unknown tool name is a -32601 protocol error, not a panic.

--- a/src/daemon_translate.rs
+++ b/src/daemon_translate.rs
@@ -819,10 +819,10 @@ fn daemon_request<T: serde::de::DeserializeOwned>(
 ///
 /// Unlike [`daemon_request`], this does NOT peel the dispatch layer via
 /// [`unwrap_dispatch_payload`]: the bridge must inspect the un-peeled `output`
-/// to distinguish a handler error riding under `status:"ok"`
-/// (`{"data":null,"error":{...}}`) from a success (`{"data":...}`), and to
-/// carry the envelope `_meta` through. Peeling would collapse both into a
-/// bare payload and discard `_meta`.
+/// to distinguish a handler error riding under `status:"ok"` (the slim error
+/// envelope `{"error":{...}}` — error-present, no `data` key) from a success
+/// (`{"data":...}`), and to carry the envelope `_meta` through. Peeling would
+/// collapse both into a bare payload and discard `_meta`.
 ///
 /// Uses a 1 MiB response cap and the shared [`resolve_daemon_timeout_ms`]
 /// timeout because tool responses (search, gather, task) are far larger than


### PR DESCRIPTION
Resolves #2030 — MCP bridge polish, three items from the post-Phase-2 review.

## 1. Handler-error-shape docstrings (trivial)
`wrap_error` (`src/cli/json_envelope.rs`) emits the slim shape `{"error":{…}}` with **no `data` key**, and `classify_slim_envelope` matches on data-present vs error-present. Two docstrings described a phantom `{data:null, error:{…}}` — corrected in `src/cli/mcp/tools.rs` (module doc + the `tools/call` handler-error bullet) and `src/daemon_translate.rs` (`daemon_json_args_request` doc). The already-correct docs (`classify_output`, the test docstring, the full-v1-envelope `unwrap_dispatch_payload` lines) were left untouched.

## 2. Derive the parity guard (the real win)
The hand-mirrored `json_args_capable` list in `src/cli/mcp/mod.rs`'s guard is gone — an incomplete-sweep risk (a new JSON-args arm could be added without enrolling it). `src/cli/batch/json_args.rs` now owns the single source of truth, co-located with `build_batch_cmd`'s arms:
- `JSON_ARGS_CAPABLE_COMMANDS` — canonical list (`#[cfg(test)]`).
- `is_json_args_capable()` — probe predicate keyed on a shared `NO_CORE_REJECTION` marker the catch-all bail also uses, so message and predicate can't drift.
- `json_args_capability_matches_arms` test — probes `build_batch_cmd` to **prove** the list equals the accepted arms.

`mod.rs`'s `expected_read_commands()` now derives from `JSON_ARGS_CAPABLE_COMMANDS` minus gated mutators and the withheld set. A new arm without a list entry (or vice versa) fails the exhaustiveness test; the MCP guard auto-enrolls the command.

## 3. `max_nodes` schema honesty
`#[schemars(skip)]` on the `max_nodes` field of `TestMapArgs` and `TraceArgs` (their own structs, not shared). The advertised `inputSchema` no longer offers a field the handler ignores, while serde `#[serde(default)]` deserialize still tolerates it (inert). New test `trace_and_test_map_schema_omits_max_nodes` asserts the schemas omit `max_nodes` and still carry `max_depth`.

## Test evidence (all `--features cuda-index`, private target dir)
- json_args: 26 passed (incl. 2 new) · mcp: 25 passed (incl. new schema test; registry guard still len==19)
- graph (trace+test_map): 147 passed · daemon_translate: 47 passed · cli_mcp_bridge_test: 6 passed
- `cargo clippy --all-targets --features cuda-index`: clean · `cargo fmt`: applied · provenance lint: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
