### PR TITLE
fix(daemon): MCP relay cap + cqs_index slot honesty + inotify-independent notes reindex (v1.48.0 audit)

### DIFF
--- a/src/cli/batch/context.rs
+++ b/src/cli/batch/context.rs
@@ -299,6 +299,14 @@ pub(crate) struct BatchContext {
     /// `cqs watch --serve`, dispatching `reconcile` is a no-op rather than an
     /// error.
     pub(crate) reconcile_signal: cqs::watch_status::SharedReconcileSignal,
+    /// Shared one-shot pending-notes signal. The daemon notes-mutation handlers
+    /// flip this `true` after writing `docs/notes.toml`; the watch loop swaps it
+    /// back and drains the note reindex on its next cycle. Drives the notes
+    /// reindex off the writer's explicit signal instead of an inotify event that
+    /// is unreliable on the WSL `/mnt/c` deployment. Default outside
+    /// `cqs watch --serve` is a fresh `Arc<AtomicBool>` with no listener — a
+    /// notes write there is a plain file write with no daemon to reindex.
+    pub(crate) pending_notes_signal: cqs::watch_status::SharedNotesSignal,
     /// Event-driven freshness wake-up. The watch loop's
     /// `publish_watch_snapshot` calls `set_fresh` every cycle; the daemon's
     /// `wait_fresh` handler parks on `wait_until_fresh` until the state flips.
@@ -377,6 +385,7 @@ impl BatchContext {
             query_count: Arc::new(AtomicU64::new(0)),
             watch_snapshot: cqs::watch_status::shared_unknown(),
             reconcile_signal: cqs::watch_status::shared_reconcile_signal(),
+            pending_notes_signal: cqs::watch_status::shared_notes_signal(),
             fresh_notifier: cqs::watch_status::shared_fresh_notifier(),
         };
         // Baseline the data_version probe at construction (not lazily on the
@@ -1104,6 +1113,16 @@ impl BatchContext {
         self.reconcile_signal = shared;
     }
 
+    /// Install the shared pending-notes-signal handle. Called from the daemon
+    /// thread before lock-wrapping the `BatchContext`, so the notes-mutation
+    /// handlers flip a flag the watch loop is actually watching.
+    ///
+    /// Outside `cqs watch --serve`, this is never called and the field stays at
+    /// the no-op default (no listener picks it up).
+    pub fn adopt_pending_notes_signal(&mut self, shared: cqs::watch_status::SharedNotesSignal) {
+        self.pending_notes_signal = shared;
+    }
+
     /// Install the shared `FreshNotifier`. Called from the daemon thread
     /// alongside `adopt_watch_snapshot` so the `wait_fresh` handler parks on
     /// the same notifier the watch loop updates from `publish_watch_snapshot`.
@@ -1522,6 +1541,7 @@ impl BatchContext {
             outer_lock,
             watch_snapshot: Arc::clone(&self.watch_snapshot),
             reconcile_signal: Arc::clone(&self.reconcile_signal),
+            pending_notes_signal: Arc::clone(&self.pending_notes_signal),
             fresh_notifier: Arc::clone(&self.fresh_notifier),
         }
     }

--- a/src/cli/batch/handlers/misc.rs
+++ b/src/cli/batch/handlers/misc.rs
@@ -198,11 +198,15 @@ pub(in crate::cli::batch) fn dispatch_notes(
 /// Daemon handler for `notes add` (MCP Phase 2a gated mutation channel).
 ///
 /// Writes `docs/notes.toml` via the shared [`notes_add_core`] — a plain file
-/// write under the file lock, NOT a `Store` write. The watch loop reindexes the
-/// file on its next tick. This is the load-bearing invariant: the daemon holds
-/// a `Store<ReadOnly>` (`ctx.store()` returns `Arc<Store<ReadOnly>>`), and this
-/// handler never acquires a writable store, so the typestate guarantee that the
-/// daemon cannot mutate the index DB is preserved.
+/// write under the file lock, NOT a `Store` write. The handler then flips the
+/// shared pending-notes signal ([`BatchView::request_notes_reindex`]) so the
+/// watch loop reindexes the notes table on its next tick — driven by the
+/// writer's explicit signal, not by an inotify event (unreliable for this path
+/// on the WSL `/mnt/c` deployment). This is the load-bearing invariant: the
+/// daemon holds a `Store<ReadOnly>` (`ctx.store()` returns
+/// `Arc<Store<ReadOnly>>`), and this handler never acquires a writable store, so
+/// the typestate guarantee that the daemon cannot mutate the index DB is
+/// preserved — the reindex happens in the watch loop, not here.
 ///
 /// Reachable only when `build_batch_cmd` constructed `BatchCmd::NotesAdd`, which
 /// is gated behind `CQS_MCP_ENABLE_MUTATIONS` (the operator opt-in).
@@ -212,6 +216,16 @@ pub(in crate::cli::batch) fn dispatch_notes_add(
 ) -> Result<serde_json::Value> {
     let _span = tracing::info_span!("batch_notes_add").entered();
     let core = crate::cli::commands::notes::notes_add_core(&ctx.root, args)?;
+    // Signal the watch loop to reindex the notes table — driving the reindex off
+    // this explicit signal rather than an inotify event the WSL `/mnt/c`
+    // deployment may never deliver.
+    let was_pending = ctx.request_notes_reindex();
+    tracing::info!(
+        status = core.status,
+        sentiment = core.sentiment,
+        was_pending,
+        "notes write committed; note reindex queued"
+    );
     Ok(crate::cli::commands::notes::notes_mutation_daemon_json(
         &core,
     ))
@@ -225,6 +239,13 @@ pub(in crate::cli::batch) fn dispatch_notes_update(
 ) -> Result<serde_json::Value> {
     let _span = tracing::info_span!("batch_notes_update").entered();
     let core = crate::cli::commands::notes::notes_update_core(&ctx.root, args)?;
+    let was_pending = ctx.request_notes_reindex();
+    tracing::info!(
+        status = core.status,
+        sentiment = core.sentiment,
+        was_pending,
+        "notes write committed; note reindex queued"
+    );
     Ok(crate::cli::commands::notes::notes_mutation_daemon_json(
         &core,
     ))
@@ -238,6 +259,13 @@ pub(in crate::cli::batch) fn dispatch_notes_remove(
 ) -> Result<serde_json::Value> {
     let _span = tracing::info_span!("batch_notes_remove").entered();
     let core = crate::cli::commands::notes::notes_remove_core(&ctx.root, args)?;
+    let was_pending = ctx.request_notes_reindex();
+    tracing::info!(
+        status = core.status,
+        sentiment = core.sentiment,
+        was_pending,
+        "notes write committed; note reindex queued"
+    );
     Ok(crate::cli::commands::notes::notes_mutation_daemon_json(
         &core,
     ))
@@ -255,10 +283,17 @@ pub(in crate::cli::batch) fn dispatch_notes_remove(
 /// path. The client polls completion via the already-exposed read tools
 /// `wait_fresh` / `status`.
 ///
-/// The `slot` field of the core is advisory here: the daemon queues a reconcile
-/// of the slot it already serves (the active slot it was opened against), so a
-/// differing `slot` does not redirect the rebuild. The reconcile path takes no
-/// slot argument.
+/// The `slot` field of the core targets a specific slot, but the reconcile path
+/// the daemon drives takes no slot argument — it reconciles whatever slot the
+/// daemon was opened against. So a `slot` that names a DIFFERENT slot than the
+/// served one cannot be honored without redirecting the daemon. Rather than
+/// silently reconcile the served slot while reporting `queued` (a wrong-slot
+/// reindex the caller cannot detect across the interop boundary), this handler
+/// REFUSES the mismatch with a client-facing error naming the served slot. A
+/// matching or omitted `slot` proceeds. When the served slot is not yet known
+/// (the watch loop hasn't published a snapshot — daemon ramp-up), the queue
+/// still fires but the response echoes `served_slot: null` so the caller can see
+/// the target was not verified.
 ///
 /// Reachable only when `build_batch_cmd` constructed `BatchCmd::Index`, which is
 /// gated behind `CQS_MCP_ENABLE_MUTATIONS` (the operator opt-in). The
@@ -273,21 +308,54 @@ pub(in crate::cli::batch) fn dispatch_index(
         slot = args.slot.as_deref().unwrap_or("(active)")
     )
     .entered();
+
+    let served_slot = ctx.served_slot();
+
+    // Refuse a request that names a slot the daemon does not serve. Failing
+    // loud beats a silent wrong-slot reindex: the reconcile path cannot target
+    // a non-served slot, so honoring the request is impossible — reporting
+    // success while reindexing a different slot would be an undetectable lie to
+    // an autonomous caller.
+    if let Some(requested) = args.slot.as_deref() {
+        if let Some(served) = served_slot.as_deref() {
+            if requested != served {
+                tracing::warn!(
+                    requested,
+                    served,
+                    "cqs_index slot mismatch — refusing to reindex a slot the daemon does not serve"
+                );
+                return Err(crate::cli::json_envelope::ClientFacingError::new(
+                    crate::cli::json_envelope::ErrorCode::InvalidInput,
+                    format!(
+                        "slot '{requested}' is not the slot this daemon serves ('{served}'); \
+                         the daemon reconciles only its served slot — restart `cqs watch --serve` \
+                         bound to '{requested}', or omit `slot` to reindex the served slot"
+                    ),
+                )
+                .into());
+            }
+        }
+    }
+
     let was_pending = ctx.request_reconcile();
     tracing::info!(
         slot = args.slot.as_deref().unwrap_or("(active)"),
+        served_slot = served_slot.as_deref().unwrap_or("(unknown)"),
         was_pending,
         "Reindex queued (fire-and-forget); watch loop performs the rebuild"
     );
     // Fire-and-forget: the rebuild is deferred to the watch loop, mirroring the
     // notes-write `reindex_deferred` contract. `was_pending` lets a caller see
     // that an earlier reconcile request was still un-drained (the watch loop
-    // coalesces them into one walk).
+    // coalesces them into one walk). `served_slot` echoes the slot the queued
+    // reconcile actually targets so the caller can confirm the substitution did
+    // not occur (it carries `null` only during the daemon's ramp-up window).
     Ok(serde_json::json!({
         "status": "queued",
         "queued": true,
         "reindex_deferred": true,
         "was_pending": was_pending,
+        "served_slot": served_slot,
     }))
 }
 

--- a/src/cli/batch/json_args.rs
+++ b/src/cli/batch/json_args.rs
@@ -1056,6 +1056,63 @@ mod tests {
         );
     }
 
+    /// DATA-SAFETY: a daemon notes mutation must flip the shared pending-notes
+    /// signal so the note reindex is driven by the writer — independent of an
+    /// inotify event, which is unreliable for `docs/notes.toml` on the WSL
+    /// `/mnt/c` deployment. Without this, a successfully-written note could be
+    /// NEVER indexed and the index would diverge from the file indefinitely.
+    ///
+    /// Each of add / update / remove must flip it: all three write the file.
+    #[test]
+    #[serial_test::serial(mcp_mutations_env)]
+    fn notes_mutation_flips_pending_notes_signal() {
+        use std::sync::atomic::Ordering;
+        let _guard = MutEnvGuard::set(true);
+
+        for (command, arguments) in [
+            (
+                "notes-add",
+                json!({"text": "needs index", "sentiment": 0.0}),
+            ),
+            // update/remove target the note add seeds, so add first inside each
+            // case via a fresh ctx to keep the cases independent.
+            ("notes-update", json!({"text": "seed", "new_text": "seed2"})),
+            ("notes-remove", json!({"text": "seed"})),
+        ] {
+            let (_dir, ctx) = seed_ctx();
+            // Seed a note for the update/remove cases (add case ignores it).
+            if command != "notes-add" {
+                let mut seed_out = Vec::new();
+                dispatch_via_view_json(
+                    &ctx.build_view(None),
+                    "notes-add",
+                    &json!({"text": "seed", "sentiment": 0.0}),
+                    &mut seed_out,
+                );
+                // The seed add already flips the signal; clear it so the case
+                // under test proves IT flips the signal, not the seed.
+                ctx.pending_notes_signal.store(false, Ordering::Release);
+            }
+            assert!(
+                !ctx.pending_notes_signal.load(Ordering::Acquire),
+                "{command}: pending-notes signal must start cleared"
+            );
+
+            let mut out = Vec::new();
+            dispatch_via_view_json(&ctx.build_view(None), command, &arguments, &mut out);
+            let v: serde_json::Value = serde_json::from_slice(&out).expect("JSON");
+            assert!(
+                v.get("data").is_some_and(|d| !d.is_null()),
+                "{command} must succeed, got: {v}"
+            );
+            assert!(
+                ctx.pending_notes_signal.load(Ordering::Acquire),
+                "{command} must flip the pending-notes signal so the watch loop reindexes \
+                 the note independent of inotify"
+            );
+        }
+    }
+
     /// Flag ON: a full add → update → remove round-trip over the JSON-args path,
     /// each mutation reflected in the temp file.
     #[test]
@@ -1228,6 +1285,81 @@ mod tests {
         assert!(
             store.chunk_count().is_ok(),
             "the daemon's Store<ReadOnly> must stay usable across an index queue"
+        );
+    }
+
+    /// A `slot` that names a DIFFERENT slot than the daemon serves must be
+    /// REFUSED — not silently accepted as a bare queued success against the
+    /// served slot. The reconcile path cannot target a non-served slot, so
+    /// honoring the request is impossible; reporting `queued` while reindexing a
+    /// different slot would be an undetectable lie across the interop boundary.
+    #[test]
+    #[serial_test::serial(mcp_mutations_env)]
+    fn index_mismatched_slot_is_refused_not_a_bare_queued_success() {
+        use std::sync::atomic::Ordering;
+        let _guard = MutEnvGuard::set(true);
+        let (_dir, ctx) = seed_ctx();
+        let view = ctx.build_view(None);
+
+        // Seed the shared watch snapshot with a served slot the daemon is bound
+        // to (the watch loop publishes this in production; here we plant it).
+        let mut snap = cqs::watch_status::WatchSnapshot::unknown();
+        snap.active_slot = Some("served".to_string());
+        view.test_overwrite_watch_snapshot(snap);
+
+        let mut out = Vec::new();
+        dispatch_via_view_json(&view, "index", &json!({"slot": "other"}), &mut out);
+        let v: serde_json::Value = serde_json::from_slice(&out).expect("JSON");
+
+        // Must be an ERROR envelope, not a queued success.
+        assert!(
+            v.get("error").is_some_and(|e| !e.is_null()),
+            "a mismatched-slot index must return an error envelope, got: {v}"
+        );
+        assert!(
+            v.get("data").is_none_or(|d| d.is_null()),
+            "a mismatched-slot index must NOT return a queued data payload, got: {v}"
+        );
+        // The error message must NAME the served slot so the caller can act.
+        let msg = v["error"]["message"].as_str().unwrap_or("");
+        assert!(
+            msg.contains("served"),
+            "the rejection must name the served slot, got: {msg}"
+        );
+        // And it must NOT have flipped the reconcile signal — no wrong-slot
+        // reindex was queued.
+        assert!(
+            !ctx.reconcile_signal.load(Ordering::Acquire),
+            "a refused mismatched-slot index must NOT queue a reconcile"
+        );
+    }
+
+    /// A `slot` that MATCHES the served slot proceeds to a normal queued
+    /// success and echoes `served_slot` so the caller can confirm the target.
+    #[test]
+    #[serial_test::serial(mcp_mutations_env)]
+    fn index_matching_slot_queues_and_echoes_served_slot() {
+        use std::sync::atomic::Ordering;
+        let _guard = MutEnvGuard::set(true);
+        let (_dir, ctx) = seed_ctx();
+        let view = ctx.build_view(None);
+
+        let mut snap = cqs::watch_status::WatchSnapshot::unknown();
+        snap.active_slot = Some("served".to_string());
+        view.test_overwrite_watch_snapshot(snap);
+
+        let mut out = Vec::new();
+        dispatch_via_view_json(&view, "index", &json!({"slot": "served"}), &mut out);
+        let v: serde_json::Value = serde_json::from_slice(&out).expect("JSON");
+
+        assert_eq!(v["data"]["status"], "queued");
+        assert_eq!(
+            v["data"]["served_slot"], "served",
+            "the success payload must echo the served slot, got: {v}"
+        );
+        assert!(
+            ctx.reconcile_signal.load(Ordering::Acquire),
+            "a matching-slot index must queue the reconcile"
         );
     }
 

--- a/src/cli/batch/view.rs
+++ b/src/cli/batch/view.rs
@@ -648,6 +648,12 @@ pub(crate) struct BatchView {
     /// daemon's behalf; the watch loop swaps it back to `false` and runs an
     /// immediate reconcile pass.
     pub(super) reconcile_signal: cqs::watch_status::SharedReconcileSignal,
+    /// Shared one-shot pending-notes signal. Cloned the same way as
+    /// `reconcile_signal`. The notes-mutation handlers flip this to `true` after
+    /// writing `docs/notes.toml`; the watch loop swaps it back and drains the
+    /// note reindex — independent of an inotify event that may never arrive on
+    /// the WSL `/mnt/c` deployment.
+    pub(super) pending_notes_signal: cqs::watch_status::SharedNotesSignal,
     /// Shared event-driven freshness notifier. Cloned the same way;
     /// `dispatch_wait_fresh` parks on this until the watch loop publishes a
     /// Fresh transition or the caller's deadline runs out.
@@ -1447,6 +1453,22 @@ impl BatchView {
             .unwrap_or_else(|p| (*p.into_inner()).clone())
     }
 
+    /// Name of the slot the daemon is currently serving, as published by the
+    /// watch loop into the shared snapshot. `None` before the loop has ticked
+    /// once (ramp-up window) or outside `cqs watch --serve` (one-shot batch,
+    /// where the loop never runs). Reads through the shared snapshot lock and
+    /// holds it only long enough to clone the small name out.
+    ///
+    /// The `cqs_index` daemon handler reads this to detect — and refuse — a
+    /// request to reindex a slot the daemon does not serve, instead of silently
+    /// reconciling the served slot while reporting success.
+    pub fn served_slot(&self) -> Option<String> {
+        self.watch_snapshot
+            .read()
+            .map(|guard| guard.active_slot.clone())
+            .unwrap_or_else(|p| p.into_inner().active_slot.clone())
+    }
+
     /// Flip the shared one-shot reconcile flag. Returns `true` if the flag was
     /// already pending (caller can dedupe in log lines), `false` if this call
     /// set it. Either way the watch loop runs the reconcile on its next 100 ms
@@ -1457,6 +1479,21 @@ impl BatchView {
     /// the bit is visible to the loop when it observes the flip.
     pub fn request_reconcile(&self) -> bool {
         self.reconcile_signal
+            .swap(true, std::sync::atomic::Ordering::Release)
+    }
+
+    /// Flip the shared one-shot pending-notes flag. Returns `true` if the flag
+    /// was already pending (caller can dedupe in log lines), `false` if this
+    /// call set it. Either way the watch loop drains the note reindex on its
+    /// next tick. Called by the notes-mutation handlers after the
+    /// `docs/notes.toml` write so the reindex does not depend on an inotify
+    /// event that is unreliable on the WSL `/mnt/c` deployment.
+    ///
+    /// `Release` ordering mirrors [`Self::request_reconcile`]: the watch loop's
+    /// matching `swap` uses `AcqRel`, so the file write the handler completed
+    /// before flipping the bit is visible to the loop when it observes the flip.
+    pub fn request_notes_reindex(&self) -> bool {
+        self.pending_notes_signal
             .swap(true, std::sync::atomic::Ordering::Release)
     }
 

--- a/src/cli/commands/index/index_args.rs
+++ b/src/cli/commands/index/index_args.rs
@@ -37,10 +37,12 @@
 #[derive(Debug, Clone, PartialEq, Default, serde::Deserialize, schemars::JsonSchema)]
 #[serde(default)]
 pub(crate) struct IndexArgs {
-    /// Target slot name (per-project `.cqs/slots/<name>/`). Advisory on the
-    /// fire-and-forget daemon path: the daemon queues a reconcile of the slot it
-    /// already serves (the active slot it was opened against), so a `slot` that
-    /// differs from the served slot does not redirect the rebuild. Present in the
-    /// schema for honesty and forward use; omit it to reindex the active slot.
+    /// Target slot name (per-project `.cqs/slots/<name>/`). On the
+    /// fire-and-forget daemon path the reconcile targets the slot the daemon was
+    /// opened against; the reconcile path cannot redirect to another slot. A
+    /// `slot` that matches the served slot (or is omitted) queues that slot's
+    /// reindex. A `slot` that names a DIFFERENT slot is REFUSED with an error
+    /// naming the served slot — the daemon will not silently reindex the wrong
+    /// slot while reporting success. Omit it to reindex the served slot.
     pub slot: Option<String>,
 }

--- a/src/cli/commands/io/notes.rs
+++ b/src/cli/commands/io/notes.rs
@@ -340,8 +340,11 @@ pub(crate) fn notes_remove_core(
 /// `sentiment` / `text_preview` / `file`), but `indexed:false` and
 /// `total_notes:0` because the daemon (MCP Phase 2a) does NOT reindex from the
 /// handler — it wrote the `notes.toml` *file* and leaves the reindex to the
-/// watch loop (the `Store<ReadOnly>` invariant). The `reindex_deferred` flag is
-/// the honest signal that the index lags the file until the next watch tick.
+/// watch loop (the `Store<ReadOnly>` invariant). The reindex is driven by the
+/// handler flipping the shared pending-notes signal the watch loop drains every
+/// tick — NOT by an inotify event, which is unreliable for this path on the WSL
+/// `/mnt/c` deployment. The `reindex_deferred` flag is the honest signal that
+/// the index lags the file until the next watch tick.
 pub(crate) fn notes_mutation_daemon_json(core: &NoteMutationCore) -> serde_json::Value {
     let result = NoteMutationOutput {
         status: core.status.into(),

--- a/src/cli/json_envelope.rs
+++ b/src/cli/json_envelope.rs
@@ -159,6 +159,36 @@ impl From<ErrorCode> for &'static str {
     }
 }
 
+/// A handler validation error whose message is SAFE to surface to a client
+/// verbatim. [`redact_error`] downcasts to this and emits its `message`
+/// unchanged with the carried [`ErrorCode`], instead of collapsing it to an
+/// opaque chain-id like every other unknown error class.
+///
+/// Use this only for messages that carry no path, query text, or DB internals —
+/// the redaction default exists precisely because most error text is unsafe.
+/// The motivating case is a slot-mismatch rejection (`cqs_index` asked to
+/// reindex a slot the daemon does not serve): the served-slot NAME must reach
+/// the caller for the rejection to be actionable, and a slot name is safe to
+/// disclose.
+#[derive(Debug, thiserror::Error)]
+#[error("{message}")]
+pub struct ClientFacingError {
+    /// The wire-format error code surfaced alongside the message.
+    pub code: ErrorCode,
+    /// The verbatim, redaction-exempt client-facing message.
+    pub message: String,
+}
+
+impl ClientFacingError {
+    /// Construct a client-facing validation error with the given code.
+    pub fn new(code: ErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
 /// Standard error code taxonomy as `&'static str` constants. Each constant
 /// delegates to [`ErrorCode::as_str`] so the wire-format strings live in
 /// exactly one place.
@@ -773,6 +803,15 @@ pub fn redact_error(err: &anyhow::Error) -> (ErrorCode, String) {
         );
     }
 
+    // Client-facing validation errors carry a message the handler already
+    // vetted as safe to disclose (e.g. a served-slot name). Surface it verbatim
+    // with the carried code rather than redacting it to a chain-id — the whole
+    // point of the type is that the message must reach the caller to be
+    // actionable.
+    if let Some(cf) = root.downcast_ref::<ClientFacingError>() {
+        return (cf.code, cf.message.clone());
+    }
+
     // IO errors: the Display form is safe (kind + os error message), but
     // the surrounding anyhow context may carry the path. Return the root
     // io::Error display only.
@@ -1221,6 +1260,50 @@ mod tests {
         let _wrapped = wrap_value(&payload);
         assert_eq!(payload["big"][0], 0);
         assert_eq!(payload["big"][99], 99);
+    }
+
+    // A ClientFacingError is surfaced VERBATIM (with its carried code), not
+    // redacted to a chain-id — the slot-mismatch rejection relies on the served
+    // slot name reaching the caller. Distinct from the unknown-root default,
+    // which redacts.
+    #[test]
+    fn redact_error_client_facing_surfaces_message_verbatim() {
+        let err: anyhow::Error = ClientFacingError::new(
+            ErrorCode::InvalidInput,
+            "slot 'other' is not the slot this daemon serves ('served')",
+        )
+        .into();
+        let (code, msg) = redact_error(&err);
+        assert_eq!(
+            code,
+            ErrorCode::InvalidInput,
+            "the carried code is preserved"
+        );
+        assert!(
+            msg.contains("served") && msg.contains("other"),
+            "the client-facing message must surface verbatim, got: {msg}"
+        );
+        assert!(
+            !msg.contains("err-"),
+            "a client-facing error must NOT be redacted to a chain-id, got: {msg}"
+        );
+    }
+
+    // A ClientFacingError surfaces verbatim even when wrapped in extra anyhow
+    // context — `redact_error` walks to the chain root to find it.
+    #[test]
+    fn redact_error_client_facing_surfaces_through_context() {
+        let err: anyhow::Error = anyhow::Error::from(ClientFacingError::new(
+            ErrorCode::NotFound,
+            "no such slot 'x'",
+        ))
+        .context("while queueing index");
+        let (code, msg) = redact_error(&err);
+        assert_eq!(code, ErrorCode::NotFound);
+        assert!(
+            msg.contains("no such slot 'x'"),
+            "the root client-facing message must surface, got: {msg}"
+        );
     }
 
     // redact_error returns a stable code+chain-id pair for unknown error

--- a/src/cli/limits.rs
+++ b/src/cli/limits.rs
@@ -204,13 +204,15 @@ pub(crate) fn read_max_file_size() -> u64 {
 
 // ============ daemon response cap ============
 
-/// Default 16 MiB cap on the daemon-to-CLI response buffer. Larger payloads
-/// force the CLI to fall back to direct (non-daemon) execution.
-pub(crate) const MAX_DAEMON_RESPONSE_BYTES: u64 = 16 * 1024 * 1024;
-
 /// Resolve the daemon response cap honoring `CQS_DAEMON_MAX_RESPONSE_BYTES`.
+///
+/// Delegates to the library-level [`cqs::limits::max_daemon_response_bytes`] so
+/// the CLI daemon-forward path and the MCP relay
+/// (`daemon_translate::daemon_json_args_request`) read ONE source of truth — the
+/// relay can never end up with a smaller cap than the CLI it fronts. Larger
+/// payloads force the CLI to fall back to direct (non-daemon) execution.
 pub(crate) fn max_daemon_response_bytes() -> u64 {
-    parse_env_u64("CQS_DAEMON_MAX_RESPONSE_BYTES", MAX_DAEMON_RESPONSE_BYTES)
+    cqs::limits::max_daemon_response_bytes()
 }
 
 // ============ daemon periodic GC cadence ============

--- a/src/cli/mcp/tools.rs
+++ b/src/cli/mcp/tools.rs
@@ -595,6 +595,15 @@ fn relay_and_classify(cqs_dir: &Path, command: &str, arguments: &Value) -> CallO
                 format!("cqs daemon returned a malformed response: {msg}"),
             );
         }
+        Err(DaemonRpcError::ResponseTooLarge(msg)) => {
+            // The result was valid but exceeded the relay read cap. Surface the
+            // limit verbatim so the agent can raise the cap or narrow the query
+            // instead of reading it as a malformed-response failure.
+            return CallOutcome::ProtocolError(
+                lifecycle::INTERNAL_ERROR,
+                format!("cqs daemon {msg}"),
+            );
+        }
     };
 
     // The success envelope is `{"status":"ok","output":<dispatch>}`. Peel the

--- a/src/cli/watch/daemon.rs
+++ b/src/cli/watch/daemon.rs
@@ -37,6 +37,13 @@ use super::{
 /// daemon's `dispatch_reconcile` handler flips a flag the watch loop is
 /// actually reading.
 ///
+/// `daemon_pending_notes_signal`: the notes-table sibling of the reconcile
+/// signal. Plugged in via
+/// [`crate::cli::batch::BatchContext::adopt_pending_notes_signal`] so the
+/// notes-mutation handlers flip a flag the watch loop drains into a note
+/// reindex — driving the reindex off the writer's signal rather than an
+/// inotify event that is unreliable on the WSL `/mnt/c` deployment.
+///
 /// `in_flight`: the shared per-connection counter. Owned by the outer
 /// `cmd_watch` scope (not local to this thread) so the watch loop can
 /// sample it into the `cqs status --watch` ops block. This
@@ -68,6 +75,7 @@ pub(super) fn spawn_daemon_thread(
     daemon_runtime: Arc<tokio::runtime::Runtime>,
     daemon_watch_snapshot: cqs::watch_status::SharedWatchSnapshot,
     daemon_reconcile_signal: cqs::watch_status::SharedReconcileSignal,
+    daemon_pending_notes_signal: cqs::watch_status::SharedNotesSignal,
     daemon_fresh_notifier: cqs::watch_status::SharedFreshNotifier,
     in_flight: Arc<AtomicUsize>,
 ) -> JoinHandle<()> {
@@ -117,6 +125,9 @@ pub(super) fn spawn_daemon_thread(
         // (called when a git hook posts to the socket) flips a flag the watch
         // loop checks.
         ctx.adopt_reconcile_signal(daemon_reconcile_signal);
+        // Same shape for the pending-notes signal: the notes-mutation handlers
+        // flip a flag the watch loop drains into a note reindex.
+        ctx.adopt_pending_notes_signal(daemon_pending_notes_signal);
         // Same shape for the freshness notifier: `dispatch_wait_fresh` parks
         // on the same notifier the watch loop signals from
         // `publish_watch_snapshot`.

--- a/src/cli/watch/mod.rs
+++ b/src/cli/watch/mod.rs
@@ -406,6 +406,35 @@ fn resolve_debounce(
 /// just recv timeouts — because a continuous stream of events arriving
 /// faster than the recv timeout never reaches the timeout arm at all;
 /// only the max-latency condition can fire there.
+/// Drain the daemon's one-shot pending-notes signal into the watch state.
+///
+/// Swaps the shared `AtomicBool` to `false`; if it WAS set (a notes-mutation
+/// handler flipped it after writing `docs/notes.toml`), maps it onto
+/// `state.pending_notes` and arms the debounce clocks exactly as the inotify
+/// branch does, so the next [`flush_due`] fires the note reindex. Returns
+/// `true` when a pending write was drained.
+///
+/// This is the data-safety bridge: it makes the note reindex fire off the
+/// writer's explicit signal rather than off an inotify event, which is
+/// unreliable for that path on the WSL `/mnt/c` deployment. Coalesces with an
+/// inotify event that did arrive (both set `pending_notes`; one reindex drains
+/// it).
+fn drain_pending_notes_signal(
+    signal: &std::sync::atomic::AtomicBool,
+    state: &mut WatchState,
+) -> bool {
+    if signal.swap(false, std::sync::atomic::Ordering::AcqRel) {
+        state.pending_notes = true;
+        state.last_event = std::time::Instant::now();
+        if state.first_pending_event.is_none() {
+            state.first_pending_event = Some(state.last_event);
+        }
+        true
+    } else {
+        false
+    }
+}
+
 fn flush_due(state: &WatchState, debounce: &DebounceConfig) -> bool {
     if state.pending_files.is_empty() && !state.pending_notes {
         return false;
@@ -846,6 +875,15 @@ pub fn cmd_watch(
     let reconcile_signal_handle: cqs::watch_status::SharedReconcileSignal =
         cqs::watch_status::shared_reconcile_signal();
 
+    // Cross-thread one-shot pending-notes signal, the notes-table sibling of
+    // `reconcile_signal_handle`. The daemon's notes-mutation handlers flip it to
+    // `true` after writing `docs/notes.toml`; this loop swaps it back to `false`
+    // and drains the note reindex. Drives the notes reindex off the writer's
+    // explicit signal rather than an inotify event the WSL `/mnt/c` deployment
+    // may never deliver.
+    let pending_notes_signal_handle: cqs::watch_status::SharedNotesSignal =
+        cqs::watch_status::shared_notes_signal();
+
     // Cross-thread event-driven freshness notifier. Watch loop's
     // `publish_watch_snapshot` calls `set_fresh` every cycle; the daemon's
     // `wait_fresh` handler parks on `wait_until_fresh`. Single round-trip,
@@ -912,6 +950,9 @@ pub fn cmd_watch(
             let daemon_watch_snapshot = Arc::clone(&watch_snapshot_handle);
             // Clone the reconcile-signal Arc too.
             let daemon_reconcile_signal = Arc::clone(&reconcile_signal_handle);
+            // Clone the pending-notes-signal Arc so the notes-mutation handlers
+            // flip a flag this loop drains.
+            let daemon_pending_notes_signal = Arc::clone(&pending_notes_signal_handle);
             // Clone the freshness notifier so the daemon's `wait_fresh`
             // handler shares the same notifier the watch loop publishes
             // through.
@@ -929,6 +970,7 @@ pub fn cmd_watch(
                 daemon_runtime,
                 daemon_watch_snapshot,
                 daemon_reconcile_signal,
+                daemon_pending_notes_signal,
                 daemon_fresh_notifier,
                 daemon_in_flight,
             );
@@ -1736,6 +1778,17 @@ pub fn cmd_watch(
                      Hint: Restart 'cqs watch' to resume monitoring."
                 );
             }
+        }
+
+        // Drain the daemon's pending-notes signal on every loop iteration —
+        // independent of which `recv_timeout` arm fired. A notes-mutation
+        // handler (`dispatch_notes_add` / `update` / `remove`) flips it after
+        // writing `docs/notes.toml`; the helper maps it onto `pending_notes` so
+        // the note reindex fires through the same flush path an inotify event
+        // would, WITHOUT depending on inotify (unreliable for that path on WSL
+        // `/mnt/c`).
+        if drain_pending_notes_signal(&pending_notes_signal_handle, &mut state) {
+            tracing::info!("Daemon notes-mutation signal drained — note reindex queued");
         }
 
         // Pre-drain decision. Evaluated on every loop iteration —

--- a/src/cli/watch/tests.rs
+++ b/src/cli/watch/tests.rs
@@ -2472,6 +2472,58 @@ fn flush_due_notes_only_pending_flushes() {
 }
 
 #[test]
+fn drain_pending_notes_signal_set_arms_pending_notes_and_flush() {
+    // DATA-SAFETY: a daemon notes-mutation handler flips the shared signal after
+    // writing docs/notes.toml. The loop's drain must map it onto pending_notes,
+    // arm the burst clock, and (after a quiet gap) make flush_due fire — driving
+    // the note reindex off the writer's signal, NOT off inotify (unreliable on
+    // WSL /mnt/c). Without this the written note would never be indexed.
+    use std::sync::atomic::AtomicBool;
+    let mut state = test_watch_state();
+    state.pending_notes = false;
+    state.first_pending_event = None;
+
+    let signal = AtomicBool::new(true);
+    let drained = drain_pending_notes_signal(&signal, &mut state);
+    assert!(drained, "a set signal must report a drained write");
+    assert!(
+        state.pending_notes,
+        "the drain must map the signal onto pending_notes"
+    );
+    assert!(
+        state.first_pending_event.is_some(),
+        "the drain must arm the burst clock so the max-latency cap can fire"
+    );
+    // The signal is one-shot: a second drain with no new write is a no-op.
+    assert!(
+        !drain_pending_notes_signal(&signal, &mut state),
+        "the signal must be cleared after one drain (one-shot)"
+    );
+
+    // After a quiet gap, the notes-only pending state flushes.
+    state.last_event = backdate(600);
+    assert!(
+        flush_due(&state, &dbc(500, 3000)),
+        "drained notes signal must reach a flush once the quiet gap elapses"
+    );
+}
+
+#[test]
+fn drain_pending_notes_signal_unset_is_a_noop() {
+    use std::sync::atomic::AtomicBool;
+    let mut state = test_watch_state();
+    state.pending_notes = false;
+    state.first_pending_event = None;
+    let signal = AtomicBool::new(false);
+    assert!(!drain_pending_notes_signal(&signal, &mut state));
+    assert!(
+        !state.pending_notes,
+        "an unset signal must not spuriously queue a note reindex"
+    );
+    assert!(state.first_pending_event.is_none());
+}
+
+#[test]
 fn collect_events_arms_burst_clock_once_per_burst() {
     // `first_pending_event` is sticky: the first accepted event arms
     // it, later events in the same burst leave it untouched (only

--- a/src/daemon_translate.rs
+++ b/src/daemon_translate.rs
@@ -692,6 +692,14 @@ pub enum DaemonRpcError {
     /// handler-level error. The `message` is the daemon's own description.
     #[error("daemon error: {0}")]
     DaemonError(String),
+    /// The daemon's response filled the bridge read cap before a newline
+    /// arrived. The payload is valid but larger than the relay buffer, so it
+    /// would parse as garbage if forwarded — distinct from [`Self::BadResponse`]
+    /// so the caller can advise raising `CQS_DAEMON_MAX_RESPONSE_BYTES` (or
+    /// narrowing the query) rather than chasing a version-skew parse failure.
+    /// The `message` names the resolved cap and the override env var.
+    #[error("daemon response too large: {0}")]
+    ResponseTooLarge(String),
 }
 
 #[cfg(unix)]
@@ -824,9 +832,16 @@ fn daemon_request<T: serde::de::DeserializeOwned>(
 /// (`{"data":...}`), and to carry the envelope `_meta` through. Peeling would
 /// collapse both into a bare payload and discard `_meta`.
 ///
-/// Uses a 1 MiB response cap and the shared [`resolve_daemon_timeout_ms`]
-/// timeout because tool responses (search, gather, task) are far larger than
-/// the small ping/status RPCs the typed helper serves.
+/// Sizes its read cap from [`crate::limits::max_daemon_response_bytes`]
+/// — the same env-overridable resolver the CLI daemon-forward path uses — so
+/// the bridge is never narrower than the CLI it fronts: a valid `gather`/
+/// `search`/`scout` payload the daemon would deliver to the CLI is delivered
+/// to MCP too. Hitting the cap yields a distinct
+/// [`DaemonRpcError::ResponseTooLarge`] naming the limit and the
+/// `CQS_DAEMON_MAX_RESPONSE_BYTES` override, not an opaque parse failure.
+/// Uses the shared [`resolve_daemon_timeout_ms`] timeout because tool
+/// responses (search, gather, task) are far larger than the small ping/status
+/// RPCs the typed helper serves.
 ///
 /// Returns a typed [`DaemonRpcError`] on a transport/parse failure — the
 /// bridge maps `SocketMissing`/`Transport`/`DaemonError`/`BadResponse` to the
@@ -849,6 +864,11 @@ pub fn daemon_json_args_request(
     .entered();
 
     if !sock_path.exists() {
+        tracing::warn!(
+            stage = "socket_missing",
+            command,
+            "daemon json-args request failed: socket does not exist"
+        );
         return Err(DaemonRpcError::SocketMissing(format!(
             "no daemon running (socket {} does not exist)",
             sock_path.display()
@@ -886,15 +906,38 @@ pub fn daemon_json_args_request(
         DaemonRpcError::Transport(format!("flush failed: {e}"))
     })?;
 
-    // 1 MiB read cap — tool responses (search/gather/task) are materially
-    // larger than the few-KB ping/status payloads, but still bounded against a
-    // buggy daemon. Mirrors the MCP request-line cap.
-    let mut reader = std::io::BufReader::new(&stream).take(1024 * 1024);
+    // Response read cap, sized from the shared env-overridable resolver the CLI
+    // daemon-forward path uses (default 16 MiB). The request-line cap and this
+    // response cap are independent limits: the former bounds the inbound
+    // arguments frame, this bounds the outbound payload the bridge buffers.
+    // Sizing from the shared resolver keeps the bridge no narrower than the CLI
+    // it fronts — a valid gather/search/scout payload that reaches the CLI
+    // reaches MCP too.
+    let max_response = crate::limits::max_daemon_response_bytes();
+    let mut reader = std::io::BufReader::new(&stream).take(max_response);
     let mut response_line = String::new();
-    reader.read_line(&mut response_line).map_err(|e| {
+    let bytes_read = reader.read_line(&mut response_line).map_err(|e| {
         tracing::warn!(stage = "read", error = %e, command, "daemon json-args request failed");
         DaemonRpcError::Transport(format!("read response failed: {e}"))
     })?;
+
+    // A full buffer with no terminating newline means the payload was truncated
+    // at the cap. Forwarding it would parse as garbage; surface a distinct error
+    // naming the limit and the override knob so a large-but-valid result is not
+    // mistaken for a malformed daemon response.
+    if bytes_read as u64 == max_response {
+        let cap_mib = max_response / 1024 / 1024;
+        tracing::warn!(
+            stage = "read",
+            bytes = bytes_read,
+            cap_mib,
+            command,
+            "daemon json-args response exceeded read cap"
+        );
+        return Err(DaemonRpcError::ResponseTooLarge(format!(
+            "response exceeded {cap_mib} MiB — raise CQS_DAEMON_MAX_RESPONSE_BYTES or narrow the query"
+        )));
+    }
 
     let envelope: serde_json::Value = serde_json::from_str(response_line.trim()).map_err(|e| {
         tracing::warn!(stage = "parse", error = %e, command, "daemon json-args request failed");
@@ -1352,6 +1395,13 @@ pub fn wait_for_fresh(cqs_dir: &std::path::Path, wait_secs: u64) -> FreshnessWai
         Err(DaemonRpcError::DaemonError(msg)) => {
             tracing::warn!(error = %msg, "wait_for_fresh: daemon-side error");
             FreshnessWait::Transport(msg)
+        }
+        Err(DaemonRpcError::ResponseTooLarge(msg)) => {
+            // The small status/reconcile payloads this path reads cannot
+            // realistically fill the cap; treat an over-cap response as an
+            // unusable daemon answer.
+            tracing::warn!(error = %msg, "wait_for_fresh: daemon response exceeded read cap");
+            FreshnessWait::BadResponse(msg)
         }
     }
 }
@@ -2557,6 +2607,111 @@ mod tests {
             }
             other => panic!("expected BadResponse naming the non-string message, got: {other:?}",),
         }
+    }
+
+    /// The MCP relay's response read is sized from
+    /// `CQS_DAEMON_MAX_RESPONSE_BYTES` (default 16 MiB) — NOT a hardcoded 1 MiB.
+    /// When a valid-but-large response fills the cap before a newline arrives,
+    /// the relay returns a DISTINCT `ResponseTooLarge` naming the limit and the
+    /// override env var, instead of an opaque `BadResponse` parse failure that
+    /// would make MCP strictly narrower than the CLI it fronts.
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial(daemon_response_cap_env)]
+    fn json_args_response_over_cap_is_distinct_too_large_error() {
+        use std::io::{BufRead, BufReader, Write};
+        use std::os::unix::net::UnixListener;
+
+        let dir = tempfile::tempdir().unwrap();
+        let cqs_dir = dir.path().join(".cqs");
+        std::fs::create_dir_all(&cqs_dir).unwrap();
+
+        // Tiny cap so a small mock payload exceeds it. The override resolver
+        // rejects 0 and garbage, so a positive small value is honored.
+        std::env::set_var("CQS_DAEMON_MAX_RESPONSE_BYTES", "64");
+
+        set_socket_dir_override_for_test(Some(dir.path().to_path_buf()));
+        let sock_path = daemon_socket_path(&cqs_dir);
+        let listener = UnixListener::bind(&sock_path).unwrap();
+
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut req = String::new();
+            BufReader::new(&stream).read_line(&mut req).unwrap();
+            // Write WELL over the 64-byte cap with NO terminating newline before
+            // the cap, so `read_line` fills the buffer and stops at the cap.
+            let big = "x".repeat(4096);
+            write!(stream, "{{\"status\":\"ok\",\"output\":\"{big}\"}}").unwrap();
+            stream.flush().unwrap();
+            // Hold the connection open briefly so the reader hits the cap rather
+            // than EOF.
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        });
+
+        let result = daemon_json_args_request(&cqs_dir, "search", &serde_json::json!({}));
+        handle.join().unwrap();
+        let _ = std::fs::remove_file(&sock_path);
+        set_socket_dir_override_for_test(None);
+        std::env::remove_var("CQS_DAEMON_MAX_RESPONSE_BYTES");
+
+        match result {
+            Err(DaemonRpcError::ResponseTooLarge(msg)) => {
+                assert!(
+                    msg.contains("CQS_DAEMON_MAX_RESPONSE_BYTES"),
+                    "the too-large error must name the override env var, got: {msg}"
+                );
+                assert!(
+                    msg.contains("MiB"),
+                    "the too-large error must name the limit, got: {msg}"
+                );
+            }
+            other => panic!("expected ResponseTooLarge on an over-cap response, got: {other:?}"),
+        }
+    }
+
+    /// A normal, under-cap response is NOT misclassified as too-large: the
+    /// distinct error fires only when the buffer actually fills.
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial(daemon_response_cap_env)]
+    fn json_args_response_under_cap_is_not_too_large() {
+        use std::io::{BufRead, BufReader, Write};
+        use std::os::unix::net::UnixListener;
+
+        let dir = tempfile::tempdir().unwrap();
+        let cqs_dir = dir.path().join(".cqs");
+        std::fs::create_dir_all(&cqs_dir).unwrap();
+
+        // Default cap (no override) is 16 MiB — a small payload is well under.
+        std::env::remove_var("CQS_DAEMON_MAX_RESPONSE_BYTES");
+
+        set_socket_dir_override_for_test(Some(dir.path().to_path_buf()));
+        let sock_path = daemon_socket_path(&cqs_dir);
+        let listener = UnixListener::bind(&sock_path).unwrap();
+
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut req = String::new();
+            BufReader::new(&stream).read_line(&mut req).unwrap();
+            writeln!(stream, r#"{{"status":"ok","output":{{"data":[]}}}}"#).unwrap();
+            stream.flush().unwrap();
+        });
+
+        let result = daemon_json_args_request(&cqs_dir, "search", &serde_json::json!({}));
+        handle.join().unwrap();
+        let _ = std::fs::remove_file(&sock_path);
+        set_socket_dir_override_for_test(None);
+
+        // A normal small response succeeds (returns the full envelope), and in
+        // no case is it classified as ResponseTooLarge.
+        assert!(
+            !matches!(result, Err(DaemonRpcError::ResponseTooLarge(_))),
+            "an under-cap response must never be classified too-large, got: {result:?}"
+        );
+        assert!(
+            result.is_ok(),
+            "a well-formed under-cap response must parse"
+        );
     }
 
     // ── socket parent-dir hardening ───────────────────────────────────

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -578,6 +578,24 @@ pub fn parse_env_u64(key: &str, default: u64) -> u64 {
     }
 }
 
+// ============ daemon response cap ============
+
+/// Default 16 MiB cap on a single daemon-to-client response buffer. Bounds the
+/// `read_line` allocation against a rogue/buggy daemon while staying large
+/// enough for real `gather` / `search` / `task` JSON outputs on big corpora.
+///
+/// Lives in the library `limits` module (not `cli::limits`) because BOTH the
+/// binary CLI daemon-forward path AND the library-side MCP relay
+/// (`daemon_translate::daemon_json_args_request`) size their read cap from it —
+/// a single source of truth so the relay can never be narrower than the CLI it
+/// fronts. `cli::limits::max_daemon_response_bytes` delegates here.
+pub const MAX_DAEMON_RESPONSE_BYTES: u64 = 16 * 1024 * 1024;
+
+/// Resolve the daemon response cap honoring `CQS_DAEMON_MAX_RESPONSE_BYTES`.
+pub fn max_daemon_response_bytes() -> u64 {
+    parse_env_u64("CQS_DAEMON_MAX_RESPONSE_BYTES", MAX_DAEMON_RESPONSE_BYTES)
+}
+
 // ============ cqs serve idle eviction ============
 
 /// Default idle-shutdown threshold for `cqs serve` in minutes. After this

--- a/src/watch_status.rs
+++ b/src/watch_status.rs
@@ -301,6 +301,34 @@ pub fn shared_reconcile_signal() -> SharedReconcileSignal {
     Arc::new(AtomicBool::new(false))
 }
 
+/// One-shot "a note write landed in `docs/notes.toml` — reindex notes" signal,
+/// the notes-table sibling of [`SharedReconcileSignal`].
+///
+/// The daemon notes-mutation handlers (`dispatch_notes_add` / `update` /
+/// `remove`) write the file under the lock, then flip this to `true`. The watch
+/// loop swaps it back to `false` on its next tick and drains the note reindex —
+/// the same flush path an inotify event on the notes file triggers.
+///
+/// Exists because inotify on `docs/notes.toml` is unreliable on the WSL
+/// `/mnt/c` (Windows NTFS / 9P) deployment: a successfully-written note could
+/// otherwise be NEVER indexed, leaving the index diverged from the file
+/// indefinitely. Driving the reindex off this explicit writer signal — rather
+/// than off a filesystem event that may never arrive — closes that gap.
+///
+/// Atomic, not RwLock-guarded, for the same reason as the reconcile signal: a
+/// single one-shot bit, drained by exactly one consumer (the watch loop's
+/// `swap(false, AcqRel)`), where coalescing two writes into one reindex walk is
+/// correct because the notes reindex is idempotent.
+pub type SharedNotesSignal = Arc<AtomicBool>;
+
+/// Build the canonical pending-notes-signal handle, initialised to `false`
+/// (no note write pending). The watch loop and the daemon thread each keep an
+/// `Arc` clone; flipping it to `true` from any thread races safely with the
+/// loop's `swap`.
+pub fn shared_notes_signal() -> SharedNotesSignal {
+    Arc::new(AtomicBool::new(false))
+}
+
 /// Event-driven freshness notifier: a single server-side park-and-wake
 /// rather than a client-side poll loop.
 ///


### PR DESCRIPTION
v1.48.0 audit — daemon/MCP boundary infra (3× P2). Closes three defects on the new interop boundary, the third a real index-divergence correctness bug on the primary WSL `/mnt/c` deployment.

## Item 1 — relay response cap (P2)
The MCP-relay read of the daemon response was hardcoded to 1 MiB — 16× below the daemon's own 16 MiB output cap, ignored `CQS_DAEMON_MAX_RESPONSE_BYTES`, and silently truncated large-but-valid `gather`/`search`/`scout` results into a misleading "malformed response" parse error (MCP strictly narrower than the CLI it fronts). Now sizes the read from `cqs::limits::max_daemon_response_bytes()` (the same env-overridable resolver the daemon dispatch uses), captures `bytes_read`, and on cap-hit returns a distinct `DaemonRpcError::ResponseTooLarge` naming the limit + env var instead of an opaque failure. The cap constant + resolver moved `cli::limits` → `cqs::limits` (lib) so `daemon_translate.rs` (a lib-crate file) and the CLI read ONE source of truth; the CLI resolver now delegates. Fixed the stale comment (request-line cap and response cap are independent). Rider: `tracing::warn!` on the `SocketMissing` arm.

## Item 2 — cqs_index slot honesty (P2)
`dispatch_index` read `args.slot` only for the span, then reconciled whatever slot the daemon was bound to — so an MCP client sending `{"slot":"other"}` got `{status:queued}` while a *different* slot reindexed (a silent wrong-slot lie to an autonomous agent). Added `BatchView::served_slot()`; `dispatch_index` now refuses a mismatched slot with a client-facing error naming the served slot (fail loud), and echoes `served_slot` on the success path. A new `ClientFacingError` type (downcast in `redact_error`) lets the served-slot name survive error redaction — slot names are safe to disclose. Fixed the lying `IndexArgs.slot` schema doc. Rider: notes-mutation handlers emit a body-free `info!` (status/sentiment, never note text).

## Item 3 — inotify-independent notes reindex (P2, data-safety)
The daemon/MCP notes-mutation path returned `reindex_deferred:true` trusting the watch loop's **inotify** watcher to pick up the `docs/notes.toml` write — but inotify is unreliable for that path on WSL `/mnt/c`, so a successfully-written note could be silently never indexed, the index diverging from the file indefinitely after the daemon reported success. Added `SharedNotesSignal` (the notes-table sibling of `SharedReconcileSignal`): the notes-mutation handlers flip it after the file write; the watch loop drains it **every tick** into `state.pending_notes`, arming the same flush path inotify would — driving the reindex off the writer's explicit signal, independent of inotify. Also makes the `cqs_index` escape hatch reliable.

## Tests
- New: relay over/under-cap (2), slot mismatch refused / match echoes served_slot (2), notes-signal flip add/update/remove (1), watch drain helper (2), `ClientFacingError` redaction-exemption (2)
- **Full `--tests` sweep** (global-state change): 4852 passed, 0 failed, 67 ignored
- clippy `--all-targets --features cuda-index -D warnings`: clean · fmt: applied · provenance lint: clean

Note: includes a one-arm edit to `mcp/tools.rs` `relay_and_classify` (mapping the new `ResponseTooLarge` variant) so the branch compiles; reconciled with the sibling MCP-surface PR at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
