### PR TITLE
fix(telemetry): attribute kind-fallbacks to top-level command + served project (#2026)

### DIFF
--- a/src/cli/batch/commands.rs
+++ b/src/cli/batch/commands.rs
@@ -537,6 +537,20 @@ macro_rules! gen_is_pipeable_impl {
                     BatchCmd::TestSleep { .. } => "test-sleep",
                 }
             }
+
+            /// Every name `command_name()` can return in a test build, in
+            /// table order plus the `#[cfg(test)]` `TestSleep` fixture (which
+            /// IS a real clap subcommand under test, so the bidirectional
+            /// exhaustiveness check must account for it). Built from the SAME
+            /// table as `command_name()`, so the test reads from the one
+            /// source of truth — no second hand-maintained list to drift.
+            #[cfg(test)]
+            pub(crate) const ALL_COMMAND_NAMES: &'static [&'static str] = &[
+                $($n,)*
+                $($n2,)*
+                $($n3,)*
+                "test-sleep",
+            ];
         }
     };
 }
@@ -1143,56 +1157,82 @@ mod tests {
         assert!(!dead.is_pipeable());
     }
 
+    /// The `#[command(skip)]` variants — argv-UNreachable on the daemon
+    /// socket (their only constructor is `json_args::build_batch_cmd`, gated
+    /// behind `CQS_MCP_ENABLE_MUTATIONS`), so clap's `find_subcommand` does
+    /// NOT know them. They never fire kind-fallbacks (they're notes-mutation /
+    /// reindex commands, not graph cores), so their `command_name()` is inert
+    /// for telemetry attribution. Listed here so the exhaustiveness test below
+    /// excludes them DELIBERATELY: adding a new `#[command(skip)]` variant
+    /// forces a conscious edit to this slice, and dropping `#[command(skip)]`
+    /// from one of these (making it a real subcommand) trips the
+    /// `skip_set_is_genuinely_not_clap_subcommands` arm.
+    #[cfg(test)]
+    const CLAP_SKIPPED_COMMAND_NAMES: &[&str] =
+        &["notes-add", "notes-update", "notes-remove", "index"];
+
     /// `command_name()` must return the canonical clap subcommand string for
-    /// each variant — the same name `telemetry::describe_command` records for
-    /// the CLI path, so kind-fallback telemetry buckets line up across the
-    /// CLI and daemon surfaces. Pins the renamed variants (`test-map`,
-    /// `impact-diff`, `notes-add`, `wait-fresh`) whose `command_name()` is NOT
-    /// the lowercased ident, and confirms every returned name resolves to a
-    /// real clap subcommand (a drift guard on the table's name column).
+    /// EVERY argv-reachable variant — the same name
+    /// `telemetry::describe_command` records on the CLI path, so kind-fallback
+    /// telemetry buckets line up across the CLI and daemon surfaces.
+    ///
+    /// Exhaustive and bidirectional (no hand-picked spot-check):
+    /// - Every name in `BatchCmd::ALL_COMMAND_NAMES` (built from the dispatch
+    ///   table, the single source of truth) that is NOT a documented
+    ///   `#[command(skip)]` variant must resolve to a real clap subcommand.
+    ///   A renamed `cli_name` that drifts from its clap name fails here.
+    /// - Conversely, every clap subcommand must appear in
+    ///   `ALL_COMMAND_NAMES`. A new argv-reachable variant whose `cli_name`
+    ///   doesn't match its clap subcommand name fails here.
+    /// - Every skip-listed name must genuinely NOT be a clap subcommand, so
+    ///   the exclusion stays honest: lose `#[command(skip)]` and this fails.
     #[test]
-    fn command_name_matches_clap_subcommand() {
+    fn command_name_matches_clap_subcommand_exhaustively() {
         use clap::CommandFactory;
+        use std::collections::HashSet;
+
         let batch = BatchInput::command();
+        let skip: HashSet<&str> = CLAP_SKIPPED_COMMAND_NAMES.iter().copied().collect();
 
-        // The renamed variants: ident-lowercasing would NOT produce these.
-        let test_map = BatchCmd::TestMap {
-            args: crate::cli::args::TestMapArgs {
-                name: "f".into(),
-                depth: 5,
-                cross_project: false,
-                limit_arg: crate::cli::args::LimitArg { limit: 5 },
-            },
-            output: TextJsonArgs { json: false },
-        };
-        assert_eq!(test_map.command_name(), "test-map");
-
-        let wait_fresh = BatchCmd::WaitFresh {
-            args: crate::cli::args::WaitFreshArgs { wait_secs: 1 },
-        };
-        assert_eq!(wait_fresh.command_name(), "wait-fresh");
-
-        // Every name a variant reports must be a real clap subcommand —
-        // otherwise the telemetry bucket would never match a logged command.
-        for name in [
-            test_map.command_name(),
-            wait_fresh.command_name(),
-            BatchCmd::Callers {
-                args: crate::cli::args::CallersArgs {
-                    name: "f".into(),
-                    cross_project: false,
-                    limit_arg: crate::cli::args::LimitArg { limit: 5 },
-                    edge_kind: None,
-                    overlay: Default::default(),
-                },
-                output: TextJsonArgs { json: false },
+        // Forward: every table name (minus skips) is a real clap subcommand.
+        let table_names: HashSet<&str> = BatchCmd::ALL_COMMAND_NAMES.iter().copied().collect();
+        for &name in BatchCmd::ALL_COMMAND_NAMES {
+            if skip.contains(name) {
+                continue;
             }
-            .command_name(),
-            BatchCmd::Refresh.command_name(),
-        ] {
             assert!(
                 batch.find_subcommand(name).is_some(),
-                "command_name() returned `{name}`, which is not a clap subcommand"
+                "BatchCmd::command_name() yields `{name}`, which is not a clap \
+                 subcommand — a `cli_name` drifted from its clap name, or the \
+                 variant should be in CLAP_SKIPPED_COMMAND_NAMES"
+            );
+        }
+
+        // Reverse: every clap subcommand is covered by a table name.
+        for sub in batch.get_subcommands() {
+            let name = sub.get_name();
+            assert!(
+                table_names.contains(name),
+                "clap subcommand `{name}` has no matching BatchCmd::command_name() \
+                 entry — a new argv-reachable variant whose cli_name doesn't match \
+                 its clap subcommand name"
+            );
+        }
+
+        // The skip-list documents a REAL exclusion: each skipped name must
+        // genuinely be absent from clap, so dropping `#[command(skip)]` from
+        // one of these variants is a conscious, test-visible change.
+        for &name in CLAP_SKIPPED_COMMAND_NAMES {
+            assert!(
+                batch.find_subcommand(name).is_none(),
+                "`{name}` is in CLAP_SKIPPED_COMMAND_NAMES but IS a clap subcommand \
+                 — it lost its `#[command(skip)]`; remove it from the skip-list"
+            );
+            // …and it must still be a real table row (the inert telemetry name
+            // exists even though clap can't reach the variant from argv).
+            assert!(
+                table_names.contains(name),
+                "skip-listed `{name}` is missing from the dispatch table"
             );
         }
     }

--- a/src/cli/batch/commands.rs
+++ b/src/cli/batch/commands.rs
@@ -432,58 +432,62 @@ macro_rules! for_each_batch_cmd {
     ($emit:ident) => {
         $emit! {
             args_variants: {
-                // Pipeable — primary input is a function name.
-                (Blame,      dispatch_blame,        true)
-                (Callers,    dispatch_callers,      true)
-                (Callees,    dispatch_callees,      true)
-                (Deps,       dispatch_deps,         true)
-                (Explain,    dispatch_explain,      true)
-                (Similar,    dispatch_similar,      true)
-                (Impact,     dispatch_impact,       true)
-                (TestMap,    dispatch_test_map,     true)
-                (Related,    dispatch_related,      true)
-                (Scout,      dispatch_scout,        true)
+                // Pipeable — primary input is a function name. Each row is
+                // `(Variant, handler_fn, cli_name, pipeable)`; `cli_name` is
+                // the canonical surface command (matches `clap`'s subcommand
+                // name and `telemetry::describe_command`'s output), used to
+                // attribute kind-fallback telemetry to the top-level command.
+                (Blame,      dispatch_blame,        "blame",       true)
+                (Callers,    dispatch_callers,      "callers",     true)
+                (Callees,    dispatch_callees,      "callees",     true)
+                (Deps,       dispatch_deps,         "deps",        true)
+                (Explain,    dispatch_explain,      "explain",     true)
+                (Similar,    dispatch_similar,      "similar",     true)
+                (Impact,     dispatch_impact,       "impact",      true)
+                (TestMap,    dispatch_test_map,     "test-map",    true)
+                (Related,    dispatch_related,      "related",     true)
+                (Scout,      dispatch_scout,        "scout",       true)
 
                 // Not pipeable — queries, paths, git refs.
-                (Search,     dispatch_search,       false)
-                (Gather,     dispatch_gather,       false)
-                (Trace,      dispatch_trace,        false)
-                (Dead,       dispatch_dead,         false)
-                (Context,    dispatch_context,      false)
-                (Onboard,    dispatch_onboard,      false)
-                (Where,      dispatch_where,        false)
-                (Read,       dispatch_read,         false)
-                (Stale,      dispatch_stale,        false)
-                (Drift,      dispatch_drift,        false)
-                (Notes,      dispatch_notes,        false)
-                (NotesAdd,    dispatch_notes_add,    false)
-                (NotesUpdate, dispatch_notes_update, false)
-                (NotesRemove, dispatch_notes_remove, false)
-                (Index,      dispatch_index,        false)
-                (Task,       dispatch_task,         false)
-                (Review,     dispatch_review,       false)
-                (Ci,         dispatch_ci,           false)
-                (Diff,       dispatch_diff,         false)
-                (ImpactDiff, dispatch_impact_diff,  false)
-                (Plan,       dispatch_plan,         false)
-                (Suggest,    dispatch_suggest,      false)
-                (Reconcile,  dispatch_reconcile,    false)
+                (Search,     dispatch_search,       "search",      false)
+                (Gather,     dispatch_gather,       "gather",      false)
+                (Trace,      dispatch_trace,        "trace",       false)
+                (Dead,       dispatch_dead,         "dead",        false)
+                (Context,    dispatch_context,      "context",     false)
+                (Onboard,    dispatch_onboard,      "onboard",     false)
+                (Where,      dispatch_where,        "where",       false)
+                (Read,       dispatch_read,         "read",        false)
+                (Stale,      dispatch_stale,        "stale",       false)
+                (Drift,      dispatch_drift,        "drift",       false)
+                (Notes,      dispatch_notes,        "notes",       false)
+                (NotesAdd,    dispatch_notes_add,    "notes-add",    false)
+                (NotesUpdate, dispatch_notes_update, "notes-update", false)
+                (NotesRemove, dispatch_notes_remove, "notes-remove", false)
+                (Index,      dispatch_index,        "index",       false)
+                (Task,       dispatch_task,         "task",        false)
+                (Review,     dispatch_review,       "review",      false)
+                (Ci,         dispatch_ci,           "ci",          false)
+                (Diff,       dispatch_diff,         "diff",        false)
+                (ImpactDiff, dispatch_impact_diff,  "impact-diff", false)
+                (Plan,       dispatch_plan,         "plan",        false)
+                (Suggest,    dispatch_suggest,      "suggest",     false)
+                (Reconcile,  dispatch_reconcile,    "reconcile",   false)
                 // wait_secs-only — no positional function name to receive
                 // a pipe.
-                (WaitFresh,  dispatch_wait_fresh,   false)
+                (WaitFresh,  dispatch_wait_fresh,   "wait-fresh",  false)
             }
             ctx_only_variants: {
                 // Struct variants with only `output: TextJsonArgs` (no
                 // primary `args` payload). Dispatched as `handler(ctx)`.
-                (Stats,   dispatch_stats,   false)
-                (Health,  dispatch_health,  false)
-                (Gc,      dispatch_gc,      false)
+                (Stats,   dispatch_stats,   "stats",  false)
+                (Health,  dispatch_health,  "health", false)
+                (Gc,      dispatch_gc,      "gc",     false)
             }
             unit_variants: {
-                (Refresh,  dispatch_refresh,  false)
-                (Ping,     dispatch_ping,     false)
-                (Status,   dispatch_status,   false)
-                (Help,     dispatch_help,     false)
+                (Refresh,  dispatch_refresh,  "refresh", false)
+                (Ping,     dispatch_ping,     "ping",    false)
+                (Status,   dispatch_status,   "status",  false)
+                (Help,     dispatch_help,     "help",    false)
             }
         }
     };
@@ -496,9 +500,9 @@ macro_rules! for_each_batch_cmd {
 /// `test_is_pipeable_exhaustive` below double-pins this.
 macro_rules! gen_is_pipeable_impl {
     (
-        args_variants:     { $(($v:ident, $h:ident, $p:expr))* }
-        ctx_only_variants: { $(($v2:ident, $h2:ident, $p2:expr))* }
-        unit_variants:     { $(($v3:ident, $h3:ident, $p3:expr))* }
+        args_variants:     { $(($v:ident, $h:ident, $n:literal, $p:expr))* }
+        ctx_only_variants: { $(($v2:ident, $h2:ident, $n2:literal, $p2:expr))* }
+        unit_variants:     { $(($v3:ident, $h3:ident, $n3:literal, $p3:expr))* }
     ) => {
         impl BatchCmd {
             /// Whether this command accepts a piped function name as its first positional arg.
@@ -508,11 +512,29 @@ macro_rules! gen_is_pipeable_impl {
                 // not this one — `let _` arms keep them in scope without
                 // tripping the unused-ident lint.
                 match self {
-                    $(BatchCmd::$v { .. } => { let _ = stringify!($h); $p },)*
-                    $(BatchCmd::$v2 { .. } => { let _ = stringify!($h2); $p2 },)*
-                    $(BatchCmd::$v3 => { let _ = stringify!($h3); $p3 },)*
+                    $(BatchCmd::$v { .. } => { let _ = stringify!($h); let _ = $n; $p },)*
+                    $(BatchCmd::$v2 { .. } => { let _ = stringify!($h2); let _ = $n2; $p2 },)*
+                    $(BatchCmd::$v3 => { let _ = stringify!($h3); let _ = $n3; $p3 },)*
                     #[cfg(test)]
                     BatchCmd::TestSleep { .. } => false,
+                }
+            }
+
+            /// Canonical surface command name for this variant — the same
+            /// string `clap` parses and `telemetry::describe_command` records
+            /// for the CLI path. Used at the dispatch chokepoint to attribute
+            /// a kind-fallback fired by an internal graph core to the
+            /// top-level command the agent actually invoked.
+            ///
+            /// `TestSleep` is a test-only fixture with no surface command; it
+            /// maps to `"test-sleep"` for completeness.
+            pub(crate) fn command_name(&self) -> &'static str {
+                match self {
+                    $(BatchCmd::$v { .. } => { let _ = stringify!($h); let _ = $p; $n },)*
+                    $(BatchCmd::$v2 { .. } => { let _ = stringify!($h2); let _ = $p2; $n2 },)*
+                    $(BatchCmd::$v3 => { let _ = stringify!($h3); let _ = $p3; $n3 },)*
+                    #[cfg(test)]
+                    BatchCmd::TestSleep { .. } => "test-sleep",
                 }
             }
         }
@@ -526,9 +548,9 @@ for_each_batch_cmd!(gen_is_pipeable_impl);
 /// has a handler.
 macro_rules! gen_dispatch_impl {
     (
-        args_variants:     { $(($v:ident, $h:ident, $p:expr))* }
-        ctx_only_variants: { $(($v2:ident, $h2:ident, $p2:expr))* }
-        unit_variants:     { $(($v3:ident, $h3:ident, $p3:expr))* }
+        args_variants:     { $(($v:ident, $h:ident, $n:literal, $p:expr))* }
+        ctx_only_variants: { $(($v2:ident, $h2:ident, $n2:literal, $p2:expr))* }
+        unit_variants:     { $(($v3:ident, $h3:ident, $n3:literal, $p3:expr))* }
     ) => {
         /// Execute a batch command and return a JSON value. The
         /// BatchCmd → handler mapping lives in `for_each_batch_cmd!`
@@ -537,25 +559,41 @@ macro_rules! gen_dispatch_impl {
         ///
         /// Takes a [`BatchView`] (snapshot of BatchContext caches built
         /// under a brief critical section).
+        ///
+        /// This is the single daemon/batch/stdin/pipeline/JSON-args dispatch
+        /// chokepoint (every surface funnels through here), so it installs the
+        /// kind-fallback origin — the top-level command name plus the served
+        /// project dir — for the duration of the handler. A graph core that
+        /// fires a fallback deeper in the same synchronous call reads it back
+        /// and attributes the fallback to this command and this project rather
+        /// than to its own sub-op name or the daemon's process cwd.
         pub(crate) fn dispatch(ctx: &BatchView, cmd: BatchCmd) -> Result<serde_json::Value> {
             let _span = tracing::debug_span!("batch_dispatch").entered();
             // Single table-driven query-log call.
             log_query_for(&cmd);
+            let _fallback_origin = crate::cli::telemetry::enter_fallback_origin(
+                cmd.command_name(),
+                &ctx.cqs_dir,
+            );
             // `output` field on each variant is intentionally dropped —
             // batch always emits JSON. Pattern-match `..` so the
             // destructure stays exhaustive even if future fields are
-            // added to a variant.
+            // added to a variant. `$n` (cli_name) is consumed by
+            // `command_name()` above, referenced here to keep the column live.
             match cmd {
                 $(BatchCmd::$v { args, .. } => {
                     let _ = $p; // keep the pipeability column referenced
+                    let _ = $n;
                     handlers::$h(ctx, &args)
                 },)*
                 $(BatchCmd::$v2 { .. } => {
                     let _ = $p2;
+                    let _ = $n2;
                     handlers::$h2(ctx)
                 },)*
                 $(BatchCmd::$v3 => {
                     let _ = $p3;
+                    let _ = $n3;
                     handlers::$h3(ctx)
                 },)*
                 #[cfg(test)]
@@ -1103,6 +1141,60 @@ mod tests {
             output: TextJsonArgs { json: false },
         };
         assert!(!dead.is_pipeable());
+    }
+
+    /// `command_name()` must return the canonical clap subcommand string for
+    /// each variant — the same name `telemetry::describe_command` records for
+    /// the CLI path, so kind-fallback telemetry buckets line up across the
+    /// CLI and daemon surfaces. Pins the renamed variants (`test-map`,
+    /// `impact-diff`, `notes-add`, `wait-fresh`) whose `command_name()` is NOT
+    /// the lowercased ident, and confirms every returned name resolves to a
+    /// real clap subcommand (a drift guard on the table's name column).
+    #[test]
+    fn command_name_matches_clap_subcommand() {
+        use clap::CommandFactory;
+        let batch = BatchInput::command();
+
+        // The renamed variants: ident-lowercasing would NOT produce these.
+        let test_map = BatchCmd::TestMap {
+            args: crate::cli::args::TestMapArgs {
+                name: "f".into(),
+                depth: 5,
+                cross_project: false,
+                limit_arg: crate::cli::args::LimitArg { limit: 5 },
+            },
+            output: TextJsonArgs { json: false },
+        };
+        assert_eq!(test_map.command_name(), "test-map");
+
+        let wait_fresh = BatchCmd::WaitFresh {
+            args: crate::cli::args::WaitFreshArgs { wait_secs: 1 },
+        };
+        assert_eq!(wait_fresh.command_name(), "wait-fresh");
+
+        // Every name a variant reports must be a real clap subcommand —
+        // otherwise the telemetry bucket would never match a logged command.
+        for name in [
+            test_map.command_name(),
+            wait_fresh.command_name(),
+            BatchCmd::Callers {
+                args: crate::cli::args::CallersArgs {
+                    name: "f".into(),
+                    cross_project: false,
+                    limit_arg: crate::cli::args::LimitArg { limit: 5 },
+                    edge_kind: None,
+                    overlay: Default::default(),
+                },
+                output: TextJsonArgs { json: false },
+            }
+            .command_name(),
+            BatchCmd::Refresh.command_name(),
+        ] {
+            assert!(
+                batch.find_subcommand(name).is_some(),
+                "command_name() returned `{name}`, which is not a clap subcommand"
+            );
+        }
     }
 
     /// Exhaustiveness link between the two enums the daemon-forward path

--- a/src/cli/commands/graph/mod.rs
+++ b/src/cli/commands/graph/mod.rs
@@ -101,34 +101,66 @@ pub(crate) fn detect_fallback(
 /// command fired it:
 ///
 /// - `tracing::info!` — the structured event an operator greps for, the
-///   routing-prioritization signal the audit asked for (command, name,
-///   kind, definition count).
+///   routing-prioritization signal the audit asked for (top-level command,
+///   firing sub-op, name, kind, definition count).
 /// - `telemetry::log_kind_fallback` — the durable counter `cqs telemetry`
 ///   aggregates into a per-command fallback rate (the Phase-2 routing
 ///   decision: do agents still bounce between commands). The telemetry
 ///   write self-gates on the `CQS_TELEMETRY` activation rules, so this is
 ///   a no-op when telemetry is off.
 ///
-/// The project `.cqs` dir is resolved here (rather than threaded through
-/// the surface-agnostic core signatures) because a fallback is a rare,
-/// off-the-hot-path event — the resolution cost is negligible against the
-/// SQL the command already ran, and keeping it out of the core signatures
-/// preserves their wire shape.
+/// `fallback_from` is the graph core's own sub-operation label (`callers` /
+/// `impact` / …). The *attribution* — which command to count against and
+/// which project's telemetry to write — comes from the
+/// [`telemetry::FallbackOrigin`] the dispatch boundary installed on this
+/// thread, NOT from `fallback_from` or the process cwd:
+///
+/// - The command counted (`cmd`) is the top-level command the agent
+///   invoked, so an aggregating command (`scout` / `gather` / …) that fans
+///   out to several graph cores attributes every fallback to itself — the
+///   count stays comparable to `commands[cmd]` instead of inflating the
+///   internal sub-ops the user never invoked directly. `fallback_from` is
+///   logged as a separate field so the sub-op detail survives.
+/// - The served-project `.cqs` dir comes from the origin (carried from
+///   `BatchContext` on the daemon path), not from `find_project_root()` on
+///   the process cwd — the daemon serves one project regardless of the cwd
+///   it was launched from, so a cwd-derived dir would mis-attribute the
+///   write. The core signatures stay surface-agnostic (the origin rides a
+///   thread-local, not a parameter), preserving their wire shape.
+///
+/// Fallback when no origin is installed (a direct-test call, or a future
+/// surface that forgot the guard): count against `fallback_from` and
+/// resolve the project from cwd — the historical behavior, so the recorder
+/// is never silently a no-op.
 pub(crate) fn record_kind_fallback(
     name: &str,
     kind: &'static str,
     fallback_from: &'static str,
     definitions: usize,
 ) {
-    tracing::info!(
-        command = fallback_from,
-        name,
-        kind,
-        definitions,
-        "kind-mismatch fallback fired"
-    );
-    let cqs_dir = cqs::resolve_index_dir(&crate::cli::config::find_project_root());
-    crate::cli::telemetry::log_kind_fallback(&cqs_dir, fallback_from, kind, name, definitions);
+    use crate::cli::telemetry;
+    telemetry::with_fallback_origin(|origin| {
+        let command = origin.map(|o| o.command.as_str()).unwrap_or(fallback_from);
+        tracing::info!(
+            command,
+            fallback_from,
+            name,
+            kind,
+            definitions,
+            "kind-mismatch fallback fired"
+        );
+        // Prefer the served-project dir from the origin; only re-derive from
+        // cwd when no dispatch boundary installed one.
+        let owned_dir;
+        let cqs_dir: &std::path::Path = match origin {
+            Some(o) => &o.cqs_dir,
+            None => {
+                owned_dir = cqs::resolve_index_dir(&crate::cli::config::find_project_root());
+                &owned_dir
+            }
+        };
+        telemetry::log_kind_fallback(cqs_dir, command, fallback_from, kind, name, definitions);
+    });
 }
 
 /// Map a [`KindResolution`] to the [`FallbackKind`] that drives a graph
@@ -448,6 +480,91 @@ mod tests {
         assert!(
             flags.iter().any(|f| f == "embedded-url"),
             "expected embedded-url flag, got: {flags:?}"
+        );
+    }
+
+    /// Read every `kind_fallback` event row from a project's telemetry log.
+    fn read_fallback_events(cqs_dir: &std::path::Path) -> Vec<serde_json::Value> {
+        let body = std::fs::read_to_string(cqs_dir.join("telemetry.jsonl")).unwrap_or_default();
+        body.lines()
+            .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+            .filter(|v| v["event"] == "kind_fallback")
+            .collect()
+    }
+
+    /// Bug A: a fan-out command's internal-core fallback attributes to the
+    /// TOP-LEVEL command, not the firing sub-op. When `scout` (which fans out
+    /// to several graph cores) triggers a `callers`-core fallback, the
+    /// telemetry must bucket it under `scout` so the count stays comparable to
+    /// `commands[scout]` — a rate that can no longer exceed 100% for a
+    /// single-core invocation. `fallback_from` preserves the `callers` sub-op.
+    #[test]
+    fn fallback_attributes_to_top_level_command_not_sub_op() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cqs_dir = tmp.path();
+        std::fs::write(cqs_dir.join("telemetry.jsonl"), "").unwrap();
+        std::env::set_var("CQS_TELEMETRY", "1");
+
+        {
+            // Simulate the dispatch boundary: the agent invoked `scout`.
+            let _origin = crate::cli::telemetry::enter_fallback_origin("scout", cqs_dir);
+            // A graph core fires its fallback tagged with its own sub-op.
+            super::record_kind_fallback("MAX", "const", "callers", 1);
+        }
+
+        std::env::remove_var("CQS_TELEMETRY");
+
+        let events = read_fallback_events(cqs_dir);
+        assert_eq!(events.len(), 1, "exactly one fallback recorded");
+        assert_eq!(
+            events[0]["cmd"], "scout",
+            "fallback must bucket under the top-level command the agent invoked"
+        );
+        assert_eq!(
+            events[0]["fallback_from"], "callers",
+            "the firing sub-op is preserved as fallback_from"
+        );
+    }
+
+    /// Bug B: the recorder writes to the SERVED project (the origin's `.cqs`
+    /// dir), not the process cwd. The origin points at `served/.cqs` while the
+    /// process cwd is elsewhere; the fallback must land in `served`, leaving a
+    /// cwd-derived project untouched.
+    #[test]
+    fn fallback_writes_to_served_project_not_cwd() {
+        let served = tempfile::tempdir().unwrap();
+        let served_cqs = served.path().join(".cqs");
+        std::fs::create_dir_all(&served_cqs).unwrap();
+        std::fs::write(served_cqs.join("telemetry.jsonl"), "").unwrap();
+
+        // A second project that a cwd-derived resolution might wrongly target.
+        let other = tempfile::tempdir().unwrap();
+        let other_cqs = other.path().join(".cqs");
+        std::fs::create_dir_all(&other_cqs).unwrap();
+        std::fs::write(other_cqs.join("telemetry.jsonl"), "").unwrap();
+
+        std::env::set_var("CQS_TELEMETRY", "1");
+        {
+            // Origin names the served project explicitly.
+            let _origin = crate::cli::telemetry::enter_fallback_origin("impact", &served_cqs);
+            super::record_kind_fallback("Config", "type", "impact", 2);
+        }
+        std::env::remove_var("CQS_TELEMETRY");
+
+        // The served project got the event…
+        let served_events = read_fallback_events(&served_cqs);
+        assert_eq!(
+            served_events.len(),
+            1,
+            "fallback must land in the served project's telemetry"
+        );
+        assert_eq!(served_events[0]["cmd"], "impact");
+
+        // …and the other project's log is still empty.
+        let other_events = read_fallback_events(&other_cqs);
+        assert!(
+            other_events.is_empty(),
+            "no fallback may land in a project the origin did not name"
         );
     }
 }

--- a/src/cli/commands/infra/telemetry_cmd.rs
+++ b/src/cli/commands/infra/telemetry_cmd.rs
@@ -36,15 +36,23 @@ pub(crate) struct TelemetryOutput {
     pub sessions: Option<usize>,
     pub commands: HashMap<String, usize>,
     pub categories: HashMap<String, usize>,
-    /// Per-command kind-mismatch fallback counts. Keyed by the firing graph
-    /// command (`callers`, `impact`, `deps`, `test-map`, `trace`, …); the
-    /// value is how many times that command redirected to a kind-labeled
-    /// fallback instead of running its normal flow. The Phase-2 routing
-    /// signal: a high `kind_fallbacks` rate relative to a command's total
-    /// invocations means agents are still bouncing between commands (asking
-    /// `callers` about a const, `impact` about a type) rather than routing
-    /// the first time. Skip-when-empty so the historical wire shape is
-    /// unchanged for telemetry logs with no fallback events.
+    /// Per-command kind-mismatch fallback counts. Keyed by the top-level
+    /// command the agent invoked (`callers`, `scout`, `impact`, `gather`, …)
+    /// — the same bucket `commands` uses — so the count is directly
+    /// comparable to that command's invocation total. The value is how many
+    /// times an invocation of that command (directly, or via the graph cores
+    /// it fans out to internally) redirected to a kind-labeled fallback. The
+    /// Phase-2 routing signal: a high `kind_fallbacks` rate relative to a
+    /// command's invocations means agents are still bouncing between commands
+    /// (asking `callers` about a const, `impact` about a type) rather than
+    /// routing the first time.
+    ///
+    /// The firing sub-operation (which internal graph core fired the
+    /// fallback) is recorded per-event as `fallback_from`, not folded into
+    /// this key — so an aggregating command's fan-out no longer inflates the
+    /// sub-op buckets the user never invoked directly. Skip-when-empty so the
+    /// historical wire shape is unchanged for telemetry logs with no fallback
+    /// events.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub kind_fallbacks: HashMap<String, usize>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -103,6 +111,12 @@ struct RawEntry {
     /// entry flavor.
     #[serde(default)]
     kind: Option<String>,
+    /// The internal graph core that fired a `kind_fallback` (`callers` /
+    /// `impact` / `trace` / …). Distinct from `cmd`, which is the top-level
+    /// command the agent invoked. Unset on every other entry flavor (and on
+    /// pre-fix `kind_fallback` rows, where the sub-op was stored in `cmd`).
+    #[serde(default)]
+    fallback_from: Option<String>,
 }
 
 #[derive(Debug)]
@@ -116,13 +130,17 @@ enum Entry {
         ts: u64,
         _reason: Option<String>,
     },
-    /// A graph command redirected to a kind-mismatch fallback. Counted
-    /// separately from `Command` (the invoke event for the same command
-    /// already lands via `log_command` at dispatch entry), so a fallback
-    /// neither double-counts the command nor inflates the event total.
+    /// A command redirected to a kind-mismatch fallback. `cmd` is the
+    /// top-level command the agent invoked (the bucket key, comparable to
+    /// `Command`); `_fallback_from` is the internal graph core that fired it.
+    /// Counted separately from `Command` (the invoke event for the same
+    /// command already lands via `log_command` at dispatch entry), so a
+    /// fallback neither double-counts the command nor inflates the event
+    /// total.
     KindFallback {
         cmd: String,
         _kind: Option<String>,
+        _fallback_from: Option<String>,
         ts: u64,
     },
 }
@@ -146,6 +164,7 @@ fn parse_entries(path: &Path) -> Result<Vec<Entry>> {
                         entries.push(Entry::KindFallback {
                             cmd,
                             _kind: raw.kind,
+                            _fallback_from: raw.fallback_from,
                             ts: raw.ts,
                         });
                     }
@@ -612,9 +631,15 @@ fn print_telemetry_text(output: &TelemetryOutput) {
     }
     println!();
 
-    // Kind-mismatch fallbacks (Phase-2 routing signal). Shown as a rate
-    // against each command's total invocations so a high bounce-rate is
-    // visible at a glance.
+    // Kind-mismatch fallbacks (Phase-2 routing signal). `kind_fallbacks` is
+    // keyed by the top-level command, the same bucket as `commands`, so the
+    // rate is per user-invocation and comparable. Render the rate only when
+    // the count fits inside the invocation total (`fb_count <= cmd_total`);
+    // a single invocation that fans out to several graph cores can fire more
+    // than one fallback, so a per-invocation `% of invocations` would still
+    // read >100% there — show a bare count in that case rather than a
+    // misleading percentage. Pre-fix logs (where the key was the sub-op, not
+    // the top-level command) land in the same bare-count branch.
     if !output.kind_fallbacks.is_empty() {
         println!();
         println!("{}:", "Kind Fallbacks".cyan());
@@ -622,11 +647,19 @@ fn print_telemetry_text(output: &TelemetryOutput) {
         fb_sorted.sort_by(|a, b| b.1.cmp(a.1));
         for (cmd, &fb_count) in &fb_sorted {
             let cmd_total = output.commands.get(*cmd).copied().unwrap_or(0);
-            if cmd_total > 0 {
+            if cmd_total > 0 && fb_count <= cmd_total {
                 let pct = (fb_count as f64 / cmd_total as f64) * 100.0;
                 println!(
                     "  {:<14} {:>4} / {:<4}  ({:.0}% of invocations)",
                     cmd, fb_count, cmd_total, pct,
+                );
+            } else if cmd_total > 0 {
+                // More fallbacks than invocations of this command (multi-core
+                // fan-out within single invocations) — a percentage would
+                // mislead, so report both raw counts.
+                println!(
+                    "  {:<14} {:>4} / {:<4}  (fallbacks / invocations)",
+                    cmd, fb_count, cmd_total,
                 );
             } else {
                 println!("  {:<14} {:>4}", cmd, fb_count);
@@ -988,6 +1021,76 @@ mod tests {
         );
         // Structural category counts only the real invocations.
         assert_eq!(out.categories.get("Structural").copied(), Some(3));
+    }
+
+    /// Bug A at the aggregation layer: a fan-out command's fallbacks bucket
+    /// under the TOP-LEVEL command (`cmd`), not the firing sub-op
+    /// (`fallback_from`). A single `scout` invocation that fans out to several
+    /// graph cores records several `kind_fallback` events all tagged
+    /// `cmd: scout` — they roll up under `scout`, the sub-op names never
+    /// become buckets, and the count stays comparable to `commands[scout]`.
+    #[test]
+    fn telemetry_core_buckets_fanout_fallbacks_under_top_level_command() {
+        let dir = tempfile::tempdir().unwrap();
+        write_test_telemetry(
+            dir.path(),
+            &[
+                // Two scout invocations.
+                r#"{"cmd":"scout","query":"a","ts":1001}"#,
+                r#"{"cmd":"scout","query":"b","ts":1002}"#,
+                // The second fans out to three graph cores, each firing a
+                // fallback. All tagged with the top-level command `scout`;
+                // `fallback_from` carries the distinct sub-op.
+                r#"{"event":"kind_fallback","cmd":"scout","fallback_from":"callers","kind":"const","name":"X","definitions":1,"ts":1002}"#,
+                r#"{"event":"kind_fallback","cmd":"scout","fallback_from":"impact","kind":"const","name":"X","definitions":1,"ts":1002}"#,
+                r#"{"event":"kind_fallback","cmd":"scout","fallback_from":"test-map","kind":"const","name":"X","definitions":1,"ts":1002}"#,
+            ],
+        );
+
+        let out = telemetry_core(dir.path(), &TelemetryArgs::default()).unwrap();
+        assert_eq!(out.events, 2, "two scout invocations, fallbacks annotate");
+        assert_eq!(out.commands.get("scout").copied(), Some(2));
+        // All three fallbacks roll up under the top-level command.
+        assert_eq!(
+            out.kind_fallbacks.get("scout").copied(),
+            Some(3),
+            "fan-out fallbacks bucket under the top-level command"
+        );
+        // The sub-op names are NOT buckets — they never become comparable to
+        // a `commands[callers]` the user never invoked.
+        assert_eq!(
+            out.kind_fallbacks.get("callers").copied(),
+            None,
+            "sub-op names must not become kind_fallbacks buckets"
+        );
+        assert_eq!(out.kind_fallbacks.get("impact").copied(), None);
+    }
+
+    /// A single-core command can never produce a `kind_fallbacks` count above
+    /// its invocation total — the rate the renderer prints stays `<= 100%`.
+    /// Pins the Bug-A invariant at the data layer: one `callers` invocation
+    /// that fell back records exactly one fallback bucketed under `callers`.
+    #[test]
+    fn telemetry_single_core_fallback_rate_within_bounds() {
+        let dir = tempfile::tempdir().unwrap();
+        write_test_telemetry(
+            dir.path(),
+            &[
+                r#"{"cmd":"callers","query":"X","ts":2001}"#,
+                r#"{"event":"kind_fallback","cmd":"callers","fallback_from":"callers","kind":"const","name":"X","definitions":1,"ts":2001}"#,
+            ],
+        );
+
+        let out = telemetry_core(dir.path(), &TelemetryArgs::default()).unwrap();
+        let invocations = out.commands.get("callers").copied().unwrap_or(0);
+        let fallbacks = out.kind_fallbacks.get("callers").copied().unwrap_or(0);
+        assert_eq!(invocations, 1);
+        assert_eq!(fallbacks, 1);
+        assert!(
+            fallbacks <= invocations,
+            "single-core fallback count must not exceed its invocation total \
+             (no >100% rate): {fallbacks} > {invocations}"
+        );
     }
 
     /// A `kind_fallback` event serializes into the `kind_fallbacks` map and

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -261,6 +261,16 @@ fn run_with_dispatch(
     // short-circuits to `OutputFormat::Json` regardless of `--format`. The
     // exact wiring lives per-shim in `commands/dispatch_shims.rs`.
     use crate::cli::definitions::{dispatch_group_a, dispatch_group_b};
+
+    // Install the kind-fallback origin for the inline (CLI-direct, non-daemon)
+    // dispatch. A graph core that fires a fallback deeper in this synchronous
+    // call attributes it to `telem_cmd` (the top-level command the user
+    // invoked — the same name `log_command` recorded above) and to this
+    // project's `.cqs` dir, instead of to the core's own sub-op name. The
+    // daemon-forward branch returned before reaching here, so it never
+    // double-installs (the daemon sets its own origin at `commands::dispatch`).
+    let _fallback_origin = telemetry::enter_fallback_origin(telem_cmd, project_cqs_dir);
+
     if let std::ops::ControlFlow::Break(result) = dispatch_group_a(&cli, project_cqs_dir) {
         return result;
     }

--- a/src/cli/telemetry.rs
+++ b/src/cli/telemetry.rs
@@ -17,9 +17,10 @@
 //!
 //! Local file only. No network calls. Auto-archives at 10 MB.
 
+use std::cell::RefCell;
 use std::fs::{self, OpenOptions};
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Maximum telemetry file size before auto-archiving (10 MB).
 const MAX_TELEMETRY_BYTES: u64 = 10 * 1024 * 1024;
@@ -322,6 +323,70 @@ pub fn log_routed(
     append_telemetry(cqs_dir, &entry, timestamp);
 }
 
+/// The top-level command + served-project dir a kind-fallback should be
+/// attributed to, captured at the dispatch boundary and read back when a
+/// graph core fires a fallback deeper in the call stack.
+///
+/// Two fields, two bugs closed:
+/// - `command` is the user-facing command the agent actually invoked
+///   (`scout` / `gather` / `impact` / `callers` / …), known at dispatch and
+///   the same name `log_command` records. Tagging the fallback with it makes
+///   `kind_fallbacks[cmd]` comparable to `commands[cmd]` — the rate is now
+///   per user-invocation. The graph core's own sub-operation label rides
+///   alongside as `fallback_from`, so the sub-op detail survives without
+///   becoming the (incomparable) bucket key.
+/// - `cqs_dir` is the request's served project, carried from `BatchContext`
+///   on the daemon path. The recorder used to re-derive it from the running
+///   process cwd, which mis-attributes every fallback to the wrong project
+///   when the daemon's cwd is not the served project.
+pub(crate) struct FallbackOrigin {
+    pub command: String,
+    pub cqs_dir: PathBuf,
+}
+
+thread_local! {
+    /// Per-thread current fallback origin. `None` outside a dispatch (or on a
+    /// path that never set it — see the recorder's cwd fallback). Graph cores
+    /// run synchronously on the dispatch thread, so the value a guard installs
+    /// at the boundary is the one a fallback deeper in the same call reads.
+    static FALLBACK_ORIGIN: RefCell<Option<FallbackOrigin>> = const { RefCell::new(None) };
+}
+
+/// RAII guard that installs a [`FallbackOrigin`] for the duration of a
+/// dispatch and restores the previous value on drop. Restore-on-drop (rather
+/// than clear-on-drop) keeps nesting correct — a command that internally
+/// dispatches a sub-command pops back to the outer origin instead of losing
+/// it. Set this at the single dispatch chokepoint on each surface.
+pub(crate) struct FallbackOriginGuard {
+    prev: Option<FallbackOrigin>,
+}
+
+impl Drop for FallbackOriginGuard {
+    fn drop(&mut self) {
+        let prev = self.prev.take();
+        FALLBACK_ORIGIN.with(|cell| {
+            *cell.borrow_mut() = prev;
+        });
+    }
+}
+
+/// Install the top-level command + served-project dir for the current
+/// dispatch. Hold the returned guard across the command's execution; the
+/// graph cores read it when they fire a fallback.
+pub(crate) fn enter_fallback_origin(command: &str, cqs_dir: &Path) -> FallbackOriginGuard {
+    let origin = FallbackOrigin {
+        command: command.to_string(),
+        cqs_dir: cqs_dir.to_path_buf(),
+    };
+    let prev = FALLBACK_ORIGIN.with(|cell| cell.borrow_mut().replace(origin));
+    FallbackOriginGuard { prev }
+}
+
+/// Run `f` with the current thread's fallback origin (if any) borrowed.
+pub(crate) fn with_fallback_origin<R>(f: impl FnOnce(Option<&FallbackOrigin>) -> R) -> R {
+    FALLBACK_ORIGIN.with(|cell| f(cell.borrow().as_ref()))
+}
+
 /// Log a kind-fallback fire to the telemetry file.
 ///
 /// A graph command (`callers`, `impact`, `deps`, `test-map`, `trace`, …)
@@ -332,18 +397,25 @@ pub fn log_routed(
 /// into a per-command fallback rate so the standing question — do agents
 /// still bounce between commands — has data behind it.
 ///
-/// Schema: `{event: "kind_fallback", cmd, kind, name, definitions, ts}`.
-/// `cmd` is the firing command (the fallback's `fallback_from`); `kind` is
-/// the routing label (`const` / `type` / `module` / `ambiguous`); `name`
-/// is redacted by default (it can carry symbol names worth keeping out of
-/// the plaintext journal — same `CQS_TELEMETRY_REDACT_QUERY` opt-out as
-/// search queries). Both surfaces (CLI direct and daemon dispatch) route
-/// through the same command cores, so a single call site here covers both.
+/// Schema: `{event: "kind_fallback", cmd, fallback_from, kind, name,
+/// definitions, ts}`. `cmd` is the top-level user-facing command the agent
+/// invoked (the [`FallbackOrigin`] captured at dispatch) so the count buckets
+/// the same way `log_command` does; `fallback_from` is the graph core's own
+/// sub-operation label (`callers` / `impact` / …) preserved for detail. An
+/// aggregating command (`scout` / `gather` / …) that fans out to several
+/// graph cores attributes every fallback it triggers to itself, not to the
+/// internal sub-ops the agent never invoked directly. `kind` is the routing
+/// label (`const` / `type` / `module` / `ambiguous`); `name` is redacted by
+/// default (it can carry symbol names worth keeping out of the plaintext
+/// journal — same `CQS_TELEMETRY_REDACT_QUERY` opt-out as search queries).
+/// Both surfaces (CLI direct and daemon dispatch) route through the same
+/// command cores, so a single call site here covers both.
 ///
 /// Activation rules and write semantics mirror [`log_command`].
 pub fn log_kind_fallback(
     cqs_dir: &Path,
     command: &str,
+    fallback_from: &str,
     kind: &str,
     name: &str,
     definitions: usize,
@@ -358,6 +430,7 @@ pub fn log_kind_fallback(
         "ts": timestamp,
         "event": "kind_fallback",
         "cmd": command,
+        "fallback_from": fallback_from,
         "kind": kind,
         "name": name_field,
         "definitions": definitions,
@@ -585,14 +658,21 @@ mod tests {
         // Default redaction on: the name must be hashed, not plaintext.
         std::env::remove_var("CQS_TELEMETRY_REDACT_QUERY");
 
-        log_kind_fallback(cqs_dir, "callers", "const", "MAX_RETRIES", 1);
+        // Top-level command (`scout`) distinct from the firing sub-op
+        // (`callers`): the event records both so the count buckets by the
+        // user-facing command while preserving the sub-op detail.
+        log_kind_fallback(cqs_dir, "scout", "callers", "const", "MAX_RETRIES", 1);
 
         std::env::remove_var("CQS_TELEMETRY");
 
         let body = std::fs::read_to_string(cqs_dir.join("telemetry.jsonl")).unwrap();
         let r: serde_json::Value = serde_json::from_str(body.trim()).unwrap();
         assert_eq!(r["event"], "kind_fallback");
-        assert_eq!(r["cmd"], "callers");
+        assert_eq!(r["cmd"], "scout", "cmd is the top-level command");
+        assert_eq!(
+            r["fallback_from"], "callers",
+            "fallback_from preserves the firing sub-op"
+        );
         assert_eq!(r["kind"], "const");
         assert_eq!(r["definitions"], 1);
         // Redacted: the raw symbol name must not appear; the field is an
@@ -600,6 +680,39 @@ mod tests {
         let name = r["name"].as_str().unwrap();
         assert_ne!(name, "MAX_RETRIES", "name must be redacted by default");
         assert_eq!(name.len(), 8, "redacted name is an 8-char hash prefix");
+    }
+
+    #[test]
+    fn fallback_origin_guard_sets_and_restores() {
+        // Outside any guard, no origin is installed.
+        with_fallback_origin(|o| assert!(o.is_none()));
+
+        {
+            let _g = enter_fallback_origin("scout", Path::new("/tmp/proj/.cqs"));
+            with_fallback_origin(|o| {
+                let o = o.expect("origin installed");
+                assert_eq!(o.command, "scout");
+                assert_eq!(o.cqs_dir, Path::new("/tmp/proj/.cqs"));
+            });
+
+            // Nesting: a sub-command's guard shadows, then restores the outer.
+            {
+                let _g2 = enter_fallback_origin("callers", Path::new("/tmp/other/.cqs"));
+                with_fallback_origin(|o| {
+                    assert_eq!(o.expect("inner origin").command, "callers");
+                });
+            }
+            with_fallback_origin(|o| {
+                assert_eq!(
+                    o.expect("outer origin restored").command,
+                    "scout",
+                    "inner guard drop must restore the outer origin, not clear it"
+                );
+            });
+        }
+
+        // After the outer guard drops, the origin is cleared again.
+        with_fallback_origin(|o| assert!(o.is_none()));
     }
 
     #[test]

--- a/src/cli/telemetry.rs
+++ b/src/cli/telemetry.rs
@@ -715,6 +715,57 @@ mod tests {
         with_fallback_origin(|o| assert!(o.is_none()));
     }
 
+    /// Cross-request restore on a POOLED thread — the invariant the daemon
+    /// relies on. A daemon worker thread is reused across requests; if a
+    /// guard's drop failed to restore the thread-local, request B would read
+    /// request A's leaked origin and mis-attribute its fallback. This pins the
+    /// no-leak property by serving two requests on the SAME thread (the same
+    /// `FALLBACK_ORIGIN` cell), asserting B never observes A's origin.
+    ///
+    /// Both "requests" run inline on the test thread — that is exactly a
+    /// pooled worker serving two sequential dispatches, which a per-test
+    /// thread (cargo's default) does NOT exercise on its own.
+    #[test]
+    fn fallback_origin_no_cross_request_leak_on_pooled_thread() {
+        // Baseline before any request: clean.
+        with_fallback_origin(|o| assert!(o.is_none(), "thread must start clean"));
+
+        // ── Request A: sets its origin, runs, guard drops at scope end. ──
+        {
+            let _a = enter_fallback_origin("callers", Path::new("/tmp/projA/.cqs"));
+            with_fallback_origin(|o| {
+                let o = o.expect("request A origin installed");
+                assert_eq!(o.command, "callers");
+                assert_eq!(o.cqs_dir, Path::new("/tmp/projA/.cqs"));
+            });
+        }
+
+        // Between requests on the reused thread: A's origin must be GONE.
+        with_fallback_origin(|o| {
+            assert!(
+                o.is_none(),
+                "request A's origin leaked to the next request on the pooled thread"
+            );
+        });
+
+        // ── Request B: a DIFFERENT command/project on the same thread. ──
+        {
+            let _b = enter_fallback_origin("impact", Path::new("/tmp/projB/.cqs"));
+            with_fallback_origin(|o| {
+                let o = o.expect("request B origin installed");
+                // B sees ITS OWN origin, never A's stale one.
+                assert_eq!(
+                    o.command, "impact",
+                    "request B must see its own origin, not A's"
+                );
+                assert_eq!(o.cqs_dir, Path::new("/tmp/projB/.cqs"));
+            });
+        }
+
+        // Thread returns to the pool clean for the next request.
+        with_fallback_origin(|o| assert!(o.is_none(), "thread must return clean"));
+    }
+
     #[test]
     fn telemetry_rotates_at_10mb_with_reused_handle() {
         // The size gate now uses `file.metadata()` (fstat on the open append


### PR DESCRIPTION
Fixes #2026 — two correctness bugs in the `kind_fallbacks` telemetry.

## Bug A — the rate divided incomparable denominators (>100%)
`commands[cmd]` counts user invocations; `kind_fallbacks[cmd]` counted core-level fallbacks tagged by sub-op, so the renderer printed nonsense like "442% of invocations". Fixed with **option (b) — record both**: the originating top-level command becomes the bucket key (comparable to `commands[cmd]`), and the firing sub-op is preserved as a distinct `fallback_from` event field. The renderer no longer prints >100% (bare counts when fan-out exceeds invocations) and the docstrings are corrected.

## Bug B — recorder re-derived the project from process cwd
`record_kind_fallback` resolved the target via `find_project_root()` on the running process cwd, correct today only because the systemd unit sets `WorkingDirectory` = the served project. Now the served-project dir travels on the same origin (from `BatchContext`/`BatchView.cqs_dir` on the daemon path), so fallbacks attribute to the *served* project, decoupled from daemon cwd. The lane found this mismatch (client-cwd `log_command` vs daemon-cwd fallback) was the *primary* source of the observed >100%.

## Mechanism
Both fixes ride a thread-local `FallbackOrigin` set by an RAII guard at each surface's single dispatch chokepoint (`commands::dispatch` for the daemon, `run_with_dispatch` for CLI-direct). The graph cores run synchronously on the dispatch thread, so their surface-agnostic signatures stay unchanged (honoring the existing docstring invariant). Added a table-driven `BatchCmd::command_name()` (+ a clap-drift guard test).

## Tests
- New: top-level-attribution, served-project-not-cwd, origin-guard set/restore, fan-out bucketing, single-core-rate-within-bounds, command-name-matches-clap.
- Full bin suite 1255/0; **full `--tests` sweep** (aggregation-shape change) 813/0; CLI + 6-command batch end-to-end smokes confirm per-command attribution + served-project write; user-facing `fallback_from` payload unchanged.
- clippy `--all-targets --features cuda-index -D warnings`, fmt, provenance lint: clean.

Pre-fix telemetry rows (no `fallback_from`) default the field to `None` and render as bare counts — no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
