### PR TITLE
fix(review): resolve git-diff dir from served project, drop test cwd race (#2035)

### DIFF
--- a/src/cli/batch/handlers/analysis.rs
+++ b/src/cli/batch/handlers/analysis.rs
@@ -194,8 +194,10 @@ pub(in crate::cli::batch) fn dispatch_review(
     cqs::worktree_overlay::clear_overlay_meta();
 
     // Thin adapter over the shared `review_overlay` — same schema + budgeting as
-    // the CLI JSON surface. Adapter owns diff I/O (git only, no stdin).
-    let diff_text = crate::cli::commands::run_git_diff(base)?;
+    // the CLI JSON surface. Adapter owns diff I/O (git only, no stdin). The diff
+    // runs in the served project (`ctx.root`), NOT the daemon's launch cwd, so a
+    // daemon serving a project from elsewhere reviews the right tree.
+    let diff_text = crate::cli::commands::run_git_diff(base, &ctx.root)?;
     // Resolve the worktree overlay (Part B PR3): merges the direct-callers
     // section. `None` ⇒ parent-truth (the default).
     let overlay = super::graph::resolve_graph_overlay(ctx, &args.overlay)?;
@@ -238,8 +240,9 @@ pub(in crate::cli::batch) fn dispatch_ci(
 
     // Thin adapter over the shared `ci_overlay` — same schema + budgeting as the
     // CLI JSON surface. Gate failure is reported in the JSON (no exit) because
-    // the batch session must continue. Adapter owns diff I/O (git only).
-    let diff_text = crate::cli::commands::run_git_diff(base)?;
+    // the batch session must continue. Adapter owns diff I/O (git only). The diff
+    // runs in the served project (`ctx.root`), NOT the daemon's launch cwd.
+    let diff_text = crate::cli::commands::run_git_diff(base, &ctx.root)?;
     // Resolve the worktree overlay: merges BOTH the embedded review's
     // direct-callers section and the dead_in_diff set. `None` ⇒ parent-truth.
     let overlay = super::graph::resolve_graph_overlay(ctx, &args.overlay)?;

--- a/src/cli/batch/handlers/graph.rs
+++ b/src/cli/batch/handlers/graph.rs
@@ -480,7 +480,8 @@ pub(in crate::cli::batch) fn dispatch_impact_diff(
     let base = args.base.as_deref();
     let _span = tracing::info_span!("batch_impact_diff", ?base).entered();
 
-    let diff_text = crate::cli::commands::run_git_diff(base)?;
+    // Diff runs in the served project (`ctx.root`), NOT the daemon's launch cwd.
+    let diff_text = crate::cli::commands::run_git_diff(base, &ctx.root)?;
     let hunks = cqs::parse_unified_diff(&diff_text);
 
     if hunks.is_empty() {
@@ -2336,7 +2337,22 @@ mod tests {
         edges: &[(&str, &str, u32, &str)],
     ) -> (TempDir, crate::cli::batch::BatchContext) {
         let dir = TempDir::new().expect("tempdir");
-        let cqs_dir = dir.path().join(".cqs");
+        let ctx = parent_store_in(dir.path(), chunks, edges);
+        (dir, ctx)
+    }
+
+    /// Seed a parent store under `base/.cqs` and return a read-only context
+    /// whose `root` is `base`. Used by `parent_store_with` (own temp dir) and
+    /// by the review/ci git-repo tests, which build the store INSIDE the temp
+    /// git repo so `ctx.root` == the repo — letting `run_git_diff` resolve the
+    /// served-project dir from `ctx.root` instead of the process cwd, so the
+    /// tests neither chdir nor share a cwd serializer.
+    fn parent_store_in(
+        base: &Path,
+        chunks: &[(&str, &str)],
+        edges: &[(&str, &str, u32, &str)],
+    ) -> crate::cli::batch::BatchContext {
+        let cqs_dir = base.join(".cqs");
         std::fs::create_dir_all(&cqs_dir).expect("mkdir .cqs");
         let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
         let mut emb = vec![0.0_f32; cqs::EMBEDDING_DIM];
@@ -2379,8 +2395,7 @@ mod tests {
                     .expect("upsert parent edge");
             }
         }
-        let ctx = create_test_context(&cqs_dir).expect("create_test_context");
-        (dir, ctx)
+        create_test_context(&cqs_dir).expect("create_test_context")
     }
 
     /// Extract caller names from a serialized `callers_overlay` output. The
@@ -3633,16 +3648,17 @@ mod tests {
     // ─── daemon-path marker honesty: review (end-to-end via dispatch_review) ─────
     //
     // `dispatch_review` acquires its diff from `run_git_diff`, which runs `git
-    // diff` in the PROCESS cwd. These tests build a temp git repo (committed
-    // baseline + an uncommitted edit to `src/lib.rs`), chdir into it under a lock
-    // (cwd is process-global), inject the overlay via `set_test_overlay_override`,
-    // and assert the marker is `"callers-only"` ONLY on a genuine direct-callers
-    // merge — ABSENT on an unrelated dirty file and on an empty diff. The absent
-    // cases are RED under a naive `overlay.is_some()` gate (the overlay is active
-    // and non-trivial in every case), so they pin the participation-gated marker.
-
-    /// Serializes the cwd-mutating `dispatch_review` tests (cwd is process-wide).
-    static REVIEW_CWD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    // diff` in the SERVED-PROJECT dir (`ctx.root`), not the process cwd. These
+    // tests build a temp git repo (committed baseline + an uncommitted edit to
+    // `src/lib.rs`), seed the store INSIDE the repo so `ctx.root` == the repo,
+    // inject the overlay via `set_test_overlay_override`, and assert the marker
+    // is `"callers-only"` ONLY on a genuine direct-callers merge — ABSENT on an
+    // unrelated dirty file and on an empty diff. The absent cases are RED under a
+    // naive `overlay.is_some()` gate (the overlay is active and non-trivial in
+    // every case), so they pin the participation-gated marker.
+    //
+    // No process-global chdir: the diff dir rides `ctx.root`, so these run safely
+    // in parallel with any cwd-reading test — there is no shared cwd to race.
 
     /// Build a temp git repo whose `src/lib.rs` has a committed baseline and an
     /// uncommitted one-line edit at line 1, so `git diff` (no base) yields a hunk
@@ -3688,9 +3704,11 @@ mod tests {
     /// "callers-only"` (NOT "full": tests + risk-scoring stay parent-truth).
     #[test]
     fn dispatch_review_genuine_merge_carries_callers_only_marker() {
-        let _cwd = REVIEW_CWD_LOCK.lock().unwrap();
         let repo = temp_git_repo_with_lib_edit();
-        let (_dir, ctx) = parent_store_with(
+        // Store lives INSIDE the repo → `ctx.root` == repo, so `run_git_diff`
+        // diffs the repo without any chdir.
+        let ctx = parent_store_in(
+            repo.path(),
             &[("src/edited.rs", "old_caller"), ("src/lib.rs", "target")],
             &[("old_caller", "src/edited.rs", 1, "target")],
         );
@@ -3700,12 +3718,9 @@ mod tests {
             &["src/edited.rs"],
         ));
         let _guard = crate::cli::batch::view::set_test_overlay_override(overlay);
-        let original = std::env::current_dir().expect("cwd");
-        std::env::set_current_dir(repo.path()).expect("chdir repo");
-        let result =
-            super::super::analysis::dispatch_review(&ctx.build_view(None), &review_wire_args());
-        std::env::set_current_dir(&original).expect("restore cwd");
-        let json = result.expect("dispatch_review");
+        let json =
+            super::super::analysis::dispatch_review(&ctx.build_view(None), &review_wire_args())
+                .expect("dispatch_review");
         assert_eq!(
             overlay_graph_marker(&json),
             Some("callers-only"),
@@ -3718,9 +3733,9 @@ mod tests {
     /// participation → marker ABSENT. RED under a naive `overlay.is_some()` gate.
     #[test]
     fn dispatch_review_unrelated_delta_no_marker() {
-        let _cwd = REVIEW_CWD_LOCK.lock().unwrap();
         let repo = temp_git_repo_with_lib_edit();
-        let (_dir, ctx) = parent_store_with(
+        let ctx = parent_store_in(
+            repo.path(),
             &[("src/stable.rs", "the_caller"), ("src/lib.rs", "target")],
             &[("the_caller", "src/stable.rs", 1, "target")],
         );
@@ -3731,12 +3746,9 @@ mod tests {
             &["src/unrelated.rs"],
         ));
         let _guard = crate::cli::batch::view::set_test_overlay_override(overlay);
-        let original = std::env::current_dir().expect("cwd");
-        std::env::set_current_dir(repo.path()).expect("chdir repo");
-        let result =
-            super::super::analysis::dispatch_review(&ctx.build_view(None), &review_wire_args());
-        std::env::set_current_dir(&original).expect("restore cwd");
-        let json = result.expect("dispatch_review");
+        let json =
+            super::super::analysis::dispatch_review(&ctx.build_view(None), &review_wire_args())
+                .expect("dispatch_review");
         assert_eq!(
             overlay_graph_marker(&json),
             None,
@@ -3750,10 +3762,10 @@ mod tests {
     /// `overlay.is_some()` gate.
     #[test]
     fn dispatch_review_empty_diff_no_marker() {
-        let _cwd = REVIEW_CWD_LOCK.lock().unwrap();
         let repo = temp_git_repo_with_lib_edit();
         // The store has NO chunk at src/lib.rs, so the diff maps no function.
-        let (_dir, ctx) = parent_store_with(
+        let ctx = parent_store_in(
+            repo.path(),
             &[("src/edited.rs", "old_caller"), ("src/other.rs", "target")],
             &[("old_caller", "src/edited.rs", 1, "target")],
         );
@@ -3763,12 +3775,9 @@ mod tests {
             &["src/edited.rs"],
         ));
         let _guard = crate::cli::batch::view::set_test_overlay_override(overlay);
-        let original = std::env::current_dir().expect("cwd");
-        std::env::set_current_dir(repo.path()).expect("chdir repo");
-        let result =
-            super::super::analysis::dispatch_review(&ctx.build_view(None), &review_wire_args());
-        std::env::set_current_dir(&original).expect("restore cwd");
-        let json = result.expect("dispatch_review");
+        let json =
+            super::super::analysis::dispatch_review(&ctx.build_view(None), &review_wire_args())
+                .expect("dispatch_review");
         assert_eq!(
             overlay_graph_marker(&json),
             None,
@@ -4036,14 +4045,16 @@ mod tests {
 
     // ─── daemon-path marker honesty: ci (end-to-end via dispatch_ci) ─────────────
     //
-    // `dispatch_ci` acquires its diff from `run_git_diff` in the PROCESS cwd. These
-    // tests reuse `temp_git_repo_with_lib_edit` (committed baseline + uncommitted
-    // edit to src/lib.rs), chdir under `REVIEW_CWD_LOCK` (cwd is process-global),
-    // inject the overlay via `set_test_overlay_override`, and assert the COMPOSITE
-    // marker is `"callers-only"` (NEVER "full") ONLY on a genuine merge — ABSENT on
-    // an unrelated dirty file and on an empty diff. The absent cases are RED under a
+    // `dispatch_ci` acquires its diff from `run_git_diff` in the SERVED-PROJECT dir
+    // (`ctx.root`), not the process cwd. These tests reuse
+    // `temp_git_repo_with_lib_edit` (committed baseline + uncommitted edit to
+    // src/lib.rs), seed the store INSIDE the repo so `ctx.root` == the repo, inject
+    // the overlay via `set_test_overlay_override`, and assert the COMPOSITE marker
+    // is `"callers-only"` (NEVER "full") ONLY on a genuine merge — ABSENT on an
+    // unrelated dirty file and on an empty diff. The absent cases are RED under a
     // naive `overlay.is_some()` gate (the overlay is active and non-trivial in every
-    // case), so they pin the participation-gated marker.
+    // case), so they pin the participation-gated marker. No process-global chdir,
+    // so these run safely in parallel with any cwd-reading test.
 
     /// Wire `args::CiArgs` with default (inactive) overlay flags — the overlay is
     /// injected via `set_test_overlay_override`, not the wire flags.
@@ -4063,9 +4074,9 @@ mod tests {
     /// component bounds the claim).
     #[test]
     fn dispatch_ci_genuine_merge_carries_callers_only_marker() {
-        let _cwd = REVIEW_CWD_LOCK.lock().unwrap();
         let repo = temp_git_repo_with_lib_edit();
-        let (_dir, ctx) = parent_store_with(
+        let ctx = parent_store_in(
+            repo.path(),
             &[("src/edited.rs", "old_caller"), ("src/lib.rs", "target")],
             &[("old_caller", "src/edited.rs", 1, "target")],
         );
@@ -4075,11 +4086,8 @@ mod tests {
             &["src/edited.rs"],
         ));
         let _guard = crate::cli::batch::view::set_test_overlay_override(overlay);
-        let original = std::env::current_dir().expect("cwd");
-        std::env::set_current_dir(repo.path()).expect("chdir repo");
-        let result = super::super::analysis::dispatch_ci(&ctx.build_view(None), &ci_wire_args());
-        std::env::set_current_dir(&original).expect("restore cwd");
-        let json = result.expect("dispatch_ci");
+        let json = super::super::analysis::dispatch_ci(&ctx.build_view(None), &ci_wire_args())
+            .expect("dispatch_ci");
         assert_eq!(
             overlay_graph_marker(&json),
             Some("callers-only"),
@@ -4093,9 +4101,9 @@ mod tests {
     /// `overlay.is_some()` gate.
     #[test]
     fn dispatch_ci_unrelated_delta_no_marker() {
-        let _cwd = REVIEW_CWD_LOCK.lock().unwrap();
         let repo = temp_git_repo_with_lib_edit();
-        let (_dir, ctx) = parent_store_with(
+        let ctx = parent_store_in(
+            repo.path(),
             &[("src/stable.rs", "the_caller"), ("src/lib.rs", "target")],
             &[("the_caller", "src/stable.rs", 1, "target")],
         );
@@ -4105,11 +4113,8 @@ mod tests {
             &["src/unrelated.rs"],
         ));
         let _guard = crate::cli::batch::view::set_test_overlay_override(overlay);
-        let original = std::env::current_dir().expect("cwd");
-        std::env::set_current_dir(repo.path()).expect("chdir repo");
-        let result = super::super::analysis::dispatch_ci(&ctx.build_view(None), &ci_wire_args());
-        std::env::set_current_dir(&original).expect("restore cwd");
-        let json = result.expect("dispatch_ci");
+        let json = super::super::analysis::dispatch_ci(&ctx.build_view(None), &ci_wire_args())
+            .expect("dispatch_ci");
         assert_eq!(
             overlay_graph_marker(&json),
             None,
@@ -4123,10 +4128,10 @@ mod tests {
     /// `overlay.is_some()` gate.
     #[test]
     fn dispatch_ci_empty_diff_no_marker() {
-        let _cwd = REVIEW_CWD_LOCK.lock().unwrap();
         let repo = temp_git_repo_with_lib_edit();
         // The store has NO chunk at src/lib.rs, so the diff maps no function.
-        let (_dir, ctx) = parent_store_with(
+        let ctx = parent_store_in(
+            repo.path(),
             &[("src/edited.rs", "old_caller"), ("src/other.rs", "target")],
             &[("old_caller", "src/edited.rs", 1, "target")],
         );
@@ -4136,11 +4141,8 @@ mod tests {
             &["src/edited.rs"],
         ));
         let _guard = crate::cli::batch::view::set_test_overlay_override(overlay);
-        let original = std::env::current_dir().expect("cwd");
-        std::env::set_current_dir(repo.path()).expect("chdir repo");
-        let result = super::super::analysis::dispatch_ci(&ctx.build_view(None), &ci_wire_args());
-        std::env::set_current_dir(&original).expect("restore cwd");
-        let json = result.expect("dispatch_ci");
+        let json = super::super::analysis::dispatch_ci(&ctx.build_view(None), &ci_wire_args())
+            .expect("dispatch_ci");
         assert_eq!(
             overlay_graph_marker(&json),
             None,

--- a/src/cli/commands/graph/impact_diff.rs
+++ b/src/cli/commands/graph/impact_diff.rs
@@ -21,7 +21,7 @@ pub(crate) fn cmd_impact_diff(
     let diff_text = if from_stdin {
         crate::cli::commands::read_stdin()?
     } else {
-        crate::cli::commands::run_git_diff(base)?
+        crate::cli::commands::run_git_diff(base, root)?
     };
 
     // 2. Parse hunks

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -595,11 +595,19 @@ pub(crate) fn read_stdin() -> anyhow::Result<String> {
     Ok(buf)
 }
 
-/// Run `git diff` and return the output. Validates `base` ref to prevent argument injection.
-pub(crate) fn run_git_diff(base: Option<&str>) -> anyhow::Result<String> {
+/// Run `git diff` in `cwd` and return the output. Validates `base` ref to
+/// prevent argument injection.
+///
+/// `cwd` is the resolved project root (`ctx.root`), not the running process's
+/// cwd. Threading it explicitly keeps the diff attributed to the served project
+/// regardless of where the binary (CLI invocation or long-lived daemon) was
+/// launched: a daemon launched from a different directory than the project it
+/// serves would otherwise diff the wrong tree.
+pub(crate) fn run_git_diff(base: Option<&str>, cwd: &std::path::Path) -> anyhow::Result<String> {
     let _span = tracing::info_span!("run_git_diff").entered();
 
     let mut cmd = std::process::Command::new("git");
+    cmd.current_dir(cwd);
     cmd.args(["--no-pager", "diff", "--no-color"]);
     if let Some(b) = base {
         // Strict ref validation matching git's own `check-ref-format` rules.
@@ -1137,10 +1145,12 @@ mod tests {
         assert_eq!(used, 30);
     }
 
-    // run_git_diff rejects base refs starting with '-' (flag injection)
+    // run_git_diff rejects base refs starting with '-' (flag injection).
+    // The ref validation fires before the git invocation, so the cwd is
+    // irrelevant to these rejection tests — pass the current dir.
     #[test]
     fn test_run_git_diff_rejects_dash_prefix() {
-        let result = run_git_diff(Some("--exec=whoami"));
+        let result = run_git_diff(Some("--exec=whoami"), std::path::Path::new("."));
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
@@ -1153,7 +1163,7 @@ mod tests {
     // run_git_diff rejects base refs containing null bytes
     #[test]
     fn test_run_git_diff_rejects_null_bytes() {
-        let result = run_git_diff(Some("main\0--exec=whoami"));
+        let result = run_git_diff(Some("main\0--exec=whoami"), std::path::Path::new("."));
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
@@ -1167,7 +1177,7 @@ mod tests {
     #[test]
     fn test_run_git_diff_rejects_newlines_and_tabs() {
         for bad in ["main\nrm -rf /", "main\rfoo", "main\tfoo"] {
-            let result = run_git_diff(Some(bad));
+            let result = run_git_diff(Some(bad), std::path::Path::new("."));
             assert!(result.is_err(), "ref `{bad:?}` must be rejected");
             let err = result.unwrap_err().to_string();
             assert!(
@@ -1181,7 +1191,7 @@ mod tests {
     #[test]
     fn test_run_git_diff_rejects_oversize_ref() {
         let big = "a".repeat(256);
-        let result = run_git_diff(Some(&big));
+        let result = run_git_diff(Some(&big), std::path::Path::new("."));
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
@@ -1193,7 +1203,7 @@ mod tests {
     // run_git_diff rejects empty ref
     #[test]
     fn test_run_git_diff_rejects_empty_ref() {
-        let result = run_git_diff(Some(""));
+        let result = run_git_diff(Some(""), std::path::Path::new("."));
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(

--- a/src/cli/commands/review/affected.rs
+++ b/src/cli/commands/review/affected.rs
@@ -92,7 +92,7 @@ pub(crate) fn cmd_affected(
     let diff_text = if from_stdin {
         crate::cli::commands::read_stdin()?
     } else {
-        crate::cli::commands::run_git_diff(base)?
+        crate::cli::commands::run_git_diff(base, root)?
     };
 
     if json {

--- a/src/cli/commands/review/ci.rs
+++ b/src/cli/commands/review/ci.rs
@@ -130,7 +130,7 @@ pub(crate) fn cmd_ci(
     let diff_text = if from_stdin {
         crate::cli::commands::read_stdin()?
     } else {
-        crate::cli::commands::run_git_diff(base)?
+        crate::cli::commands::run_git_diff(base, root)?
     };
 
     // The gate `passed` flag drives the process exit code below, so both

--- a/src/cli/commands/review/diff_review.rs
+++ b/src/cli/commands/review/diff_review.rs
@@ -157,7 +157,7 @@ pub(crate) fn cmd_review(
     let diff_text = if from_stdin {
         crate::cli::commands::read_stdin()?
     } else {
-        crate::cli::commands::run_git_diff(base)?
+        crate::cli::commands::run_git_diff(base, root)?
     };
 
     if json {


### PR DESCRIPTION
Fixes #2035 — the flaky `dispatch_review_unrelated_delta_no_marker` CWD race, plus a latent daemon bug of the same shape it exposed.

## The flake (the filed issue)
The review test mutated the **process-global cwd** under `REVIEW_CWD_LOCK`, which serializes review-cwd tests against each other but **not** against unrelated parallel tests that *read* the cwd → spurious failures. Serializing every cwd-reader (options a/c) is fragile (14 unbounded cwd-reading sites in `src/cli/`), so this takes **option (b): eliminate the process-global `chdir` entirely.**

## The latent daemon bug it exposed (folded in — same seam)
`run_git_diff` ran `git diff` in the **process cwd**, never set. On the daemon path that's the daemon's *launch* directory, not the served project (`ctx.root`) — so a daemon serving a project from a different cwd would diff the **wrong tree**. This is the exact shape as the kind-fallback telemetry cwd bug (#2026): process-cwd reliance decoupled from the served-project context. `BatchView::root` already carries the served-project dir, so the fix was contained.

## The fix
- `run_git_diff(base)` → `run_git_diff(base, cwd: &Path)` with `cmd.current_dir(cwd)`. All 7 production callers thread the already-resolved `ctx.root` / `root` (3 daemon dispatchers: `dispatch_review`/`dispatch_ci`/`dispatch_impact_diff` + 4 CLI-direct commands), so the diff is attributed to the served project on **both** surfaces.
- The 6 review/ci daemon marker tests seed the store *inside* the temp git repo (new `parent_store_in` helper) so `ctx.root` == the repo, passed explicitly. `REVIEW_CWD_LOCK` and every `set_current_dir`/`current_dir` removed. The original `dispatch_review_unrelated_delta_no_marker` scenario is preserved verbatim.

## Tests
- Targeted: 11 (dispatch_review ×3, dispatch_ci ×3, run_git_diff ×5).
- **Race-gone:** full bin suite **1256/0 at `--test-threads=16`** (the racing scenario); 5 repeated parallel dispatch-filter runs green.
- Daemon: `daemon_forward_test` 34; slow `cli_review_test` (real-git-repo end-to-end) + `cli_serve_test` pass.
- **Full `--tests` sweep** (daemon-behavior change): **953/0/36 ignored across 60 binaries.**
- clippy `--all-targets --features cuda-index -D warnings`, fmt, provenance lint: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
