### PR TITLE
feat(mcp): expose stats/health as zero-arg read tools + Phase-1 command-core classification (#2021)

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ cqs mcp
 ```
 
 **Tool surface**:
-- **Default (read-only)**: 19 `cqs_`-prefixed tools — `cqs_search`, `cqs_gather`, `cqs_scout`, `cqs_onboard`, `cqs_similar`, `cqs_callers`, `cqs_callees`, `cqs_deps`, `cqs_impact`, `cqs_test_map`, `cqs_trace`, `cqs_blame`, `cqs_diff`, `cqs_drift`, `cqs_dead`, `cqs_ci`, `cqs_review`, `cqs_plan`, `cqs_read`. (`cqs_context`/`cqs_explain` are deliberately withheld — their relay would carry unscanned doc/signature content.)
+- **Default (read-only)**: 21 `cqs_`-prefixed tools — `cqs_search`, `cqs_gather`, `cqs_scout`, `cqs_onboard`, `cqs_similar`, `cqs_callers`, `cqs_callees`, `cqs_deps`, `cqs_impact`, `cqs_test_map`, `cqs_trace`, `cqs_blame`, `cqs_diff`, `cqs_drift`, `cqs_dead`, `cqs_ci`, `cqs_review`, `cqs_plan`, `cqs_read`, `cqs_stats`, `cqs_health`. (`cqs_context`/`cqs_explain` are deliberately withheld — their relay would carry unscanned doc/signature content.)
 - **Opt-in mutations** (`CQS_MCP_ENABLE_MUTATIONS=1`): adds 4 mutating tools — `cqs_notes_add`, `cqs_notes_update`, `cqs_notes_remove`, `cqs_index`. Notes mutations write `docs/notes.toml` (the watch loop reindexes); `cqs_index` queues a non-blocking reconcile. Neither writes the daemon's in-memory Store directly.
 - **Permanently withheld**: the destructive set (`gc`, `slot remove`, `index --force`, `model swap`, `cache clear`) is never exposed, regardless of flag value.
 

--- a/src/cli/batch/json_args.rs
+++ b/src/cli/batch/json_args.rs
@@ -71,8 +71,8 @@ use crate::cli::commands::search::scout::ScoutArgs as ScoutCore;
 use crate::cli::commands::search::similar::SimilarArgs as SimilarCore;
 use crate::cli::commands::{
     CalleesArgs as CalleesCore, CallersCoreArgs, CiArgs as CiCore, DeadArgs as DeadCore,
-    DepsCoreArgs, ImpactCoreArgs, PlanArgs as PlanCore, ReviewArgs as ReviewCore, TestMapCoreArgs,
-    TraceCoreArgs,
+    DepsCoreArgs, HealthArgs as HealthCore, ImpactCoreArgs, PlanArgs as PlanCore,
+    ReviewArgs as ReviewCore, StatsArgs as StatsCore, TestMapCoreArgs, TraceCoreArgs,
 };
 
 /// Default `TextJsonArgs` for a JSON-args-built variant. The daemon always
@@ -178,6 +178,8 @@ pub(crate) const JSON_ARGS_CAPABLE_COMMANDS: &[&str] = &[
     "review",
     "plan",
     "read",
+    "stats",
+    "health",
     "notes-add",
     "notes-update",
     "notes-remove",
@@ -365,6 +367,29 @@ pub(super) fn build_batch_cmd(command: &str, arguments: &serde_json::Value) -> R
             let c: ReadArgs = parse_core(command, arguments)?;
             BatchCmd::Read {
                 args: c,
+                output: text_json(),
+            }
+        }
+        // ─── MCP Phase 1: zero-arg read tools ──────────────────────────────────
+        //
+        // `stats` / `health` are ctx-only `BatchCmd` variants — the handler takes
+        // no `args` payload and builds the core via `*Args::default()`. So the
+        // core deserialize here is a SHAPE pre-check only: it proves the
+        // `arguments` object is well-typed (and rejects a non-object / wrong-typed
+        // value as a clean error), then is dropped. The variant carries only
+        // `output`, mirroring the argv path (`stats` / `health` accept no flags
+        // on either surface). Zero input fields → zero serde-output risk: neither
+        // core derives `Serialize`, and the command outputs the separate
+        // `StatsOutput` / `HealthReport`.
+        "stats" => {
+            let _shape_check: StatsCore = parse_core(command, arguments)?;
+            BatchCmd::Stats {
+                output: text_json(),
+            }
+        }
+        "health" => {
+            let _shape_check: HealthCore = parse_core(command, arguments)?;
+            BatchCmd::Health {
                 output: text_json(),
             }
         }
@@ -802,6 +827,10 @@ mod tests {
             ),
             ("context", vec!["src/lib.rs"], json!({"path": "src/lib.rs"})),
             ("read", vec!["src/lib.rs"], json!({"path": "src/lib.rs"})),
+            // Zero-arg read tools: the JSON `{}` must produce the same envelope
+            // as the bare argv form (the handler ignores any input).
+            ("stats", vec![], json!({})),
+            ("health", vec![], json!({})),
         ];
         for (command, argv, arguments) in cases {
             let (v_argv, v_json) = run_both(&ctx, command, &argv, arguments);
@@ -1523,12 +1552,14 @@ mod tests {
 
         // 2. A representative spread of argv-only / unknown commands is NOT
         //    capable — the catch-all bites, and they are absent from the list.
+        //    (`stats` / `health` ARE capable now — Phase-1 zero-arg read tools —
+        //    so they are deliberately excluded from this not-capable spread.)
         for cmd in [
             "where",
             "explain",
             "notes",
-            "health",
             "task",
+            "ping",
             "nonexistent_cmd",
         ] {
             assert!(

--- a/src/cli/commands/index/stats.rs
+++ b/src/cli/commands/index/stats.rs
@@ -221,7 +221,18 @@ pub(crate) fn build_stats<Mode>(store: &cqs::Store<Mode>, cqs_dir: &Path) -> Res
 
 /// Input for [`stats_core`]. `cqs stats` takes no positional or flag input
 /// beyond the freshness toggle — both CLI and daemon want the same numbers.
+///
+/// Both the CLI (`cmd_stats`) and the daemon (`dispatch_stats`) build this via
+/// `StatsArgs::default()`; neither surface accepts user input for it. So the
+/// MCP `inputSchema` advertises ZERO properties (`include_staleness` is
+/// `#[schemars(skip)]`), matching the fact that the daemon honors no field —
+/// advertising the knob would be a schema-vs-wire lie (the `max_nodes`-style
+/// inert-field pattern). `#[serde(default)]` keeps a wire `{}` deserializing,
+/// and serde still tolerates an inert `include_staleness` key without erroring.
+/// INPUT-only (no `Serialize` derive); the output type is the separate
+/// `StatsOutput`, so the schema derive cannot alter the JSON output shape.
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+#[serde(default)]
 pub(crate) struct StatsArgs {
     /// When `true`, walk the filesystem and populate `stale_files` /
     /// `missing_files`. Both surfaces set this; it is an Arg (not hardcoded)
@@ -229,6 +240,7 @@ pub(crate) struct StatsArgs {
     /// walk. `created_at` and `hnsw_vectors` are populated unconditionally —
     /// they are cheap metadata reads, not a filesystem scan.
     #[serde(default = "default_true")]
+    #[schemars(skip)]
     pub include_staleness: bool,
 }
 

--- a/src/cli/commands/review/health.rs
+++ b/src/cli/commands/review/health.rs
@@ -16,7 +16,15 @@ use cqs::Parser;
 /// today; the struct exists so the core matches the established
 /// `*Args` + `*_core` shape and can grow Deserialize-able fields without a
 /// signature change (MCP-ready).
-#[derive(Debug, Default, serde::Deserialize)]
+///
+/// Derives `schemars::JsonSchema` so the MCP bridge can advertise its
+/// (currently empty) `inputSchema`. `#[serde(default)]` lets a wire caller send
+/// `{}` and inherit the production default. INPUT-only: there is no `Serialize`
+/// derive, and the command's output is the separate
+/// `cqs::health::HealthReport`, so adding these derives cannot alter the JSON
+/// output wire shape.
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
+#[serde(default)]
 pub(crate) struct HealthArgs {}
 
 /// Surface-agnostic core for `cqs health`. Returns the typed

--- a/src/cli/mcp/mod.rs
+++ b/src/cli/mcp/mod.rs
@@ -148,9 +148,10 @@ mod tests {
     ///
     /// With `CQS_MCP_ENABLE_MUTATIONS` unset, the exposed MCP tool set must
     /// equal the daemon's JSON-args-capable read command set MINUS the withheld
-    /// set — byte-identical to Phase 1 (19 read tools, zero mutation delta).
-    /// Fails if a JSON-args command is added/removed without updating the MCP
-    /// surface, or if a withheld command leaks into `tools/list`.
+    /// set — 21 read tools (the original 19 plus the zero-arg `stats`/`health`),
+    /// zero mutation delta. Fails if a JSON-args command is added/removed
+    /// without updating the MCP surface, or if a withheld command leaks into
+    /// `tools/list`.
     #[test]
     #[serial_test::serial(mcp_mutations_env)]
     fn tools_list_matches_json_args_registry() {
@@ -162,18 +163,18 @@ mod tests {
             "MCP tools/list (flag off) must equal the JSON-args read registry minus the \
              withheld set.\nexposed (mapped to commands): {exposed:?}\nexpected: {expected:?}"
         );
-        // Phase 1 = exactly 19 read tools.
+        // The flag-off read surface = exactly 21 read tools.
         assert_eq!(
             exposed.len(),
-            19,
-            "flag-off tools/list must expose 19 tools"
+            21,
+            "flag-off tools/list must expose 21 tools"
         );
     }
 
     /// Flag-gating guard: the mutation tools are present IFF
     /// `CQS_MCP_ENABLE_MUTATIONS=1`. With the flag on, the exposed set is the
     /// read set PLUS exactly the three notes mutators AND the fire-and-forget
-    /// `index` (23 total).
+    /// `index` (25 total).
     #[test]
     #[serial_test::serial(mcp_mutations_env)]
     fn mutation_tools_present_iff_flag_set() {
@@ -205,7 +206,7 @@ mod tests {
                 "flag-on tools/list must be the read set plus exactly the 3 notes mutators \
                  and the index queue tool"
             );
-            assert_eq!(on.len(), 23, "flag-on tools/list must expose 23 tools");
+            assert_eq!(on.len(), 25, "flag-on tools/list must expose 25 tools");
         }
     }
 

--- a/src/cli/mcp/tools.rs
+++ b/src/cli/mcp/tools.rs
@@ -106,12 +106,24 @@ pub struct ToolDef {
 /// Render the schema for a core `T` as a `serde_json::Value`. schemars 1.x
 /// `schema_for!` produces a 2020-12 schema; `serde(default)` cores yield no
 /// `required` array (every param optional on the wire).
+///
+/// A core with zero schema-visible fields (an empty struct, or one whose only
+/// field is `#[schemars(skip)]`) renders WITHOUT a `properties` key. Every tool
+/// row is required to carry a `properties` object (the well-formedness +
+/// overlay-honesty guards assert it), so a missing `properties` is normalized
+/// to an empty `{}` here — the one chokepoint all core schemas flow through, so
+/// any future zero-arg tool inherits the guarantee.
 fn schema<T: schemars::JsonSchema>() -> Value {
-    serde_json::to_value(schemars::schema_for!(T)).unwrap_or_else(|_| {
+    let mut s = serde_json::to_value(schemars::schema_for!(T)).unwrap_or_else(|_| {
         // schemars schema serialization is infallible in practice; fall back to
         // a minimal object so a hypothetical failure can't poison tools/list.
         serde_json::json!({"type": "object", "properties": {}})
-    })
+    });
+    if let Some(obj) = s.as_object_mut() {
+        obj.entry("properties")
+            .or_insert_with(|| Value::Object(Default::default()));
+    }
+    s
 }
 
 /// The worktree-overlay tri-state keys the daemon's `overlay_from_args` reads
@@ -178,8 +190,8 @@ use crate::cli::commands::search::scout::ScoutArgs as ScoutCore;
 use crate::cli::commands::search::similar::SimilarArgs as SimilarCore;
 use crate::cli::commands::{
     CalleesArgs as CalleesCore, CallersCoreArgs, CiArgs as CiCore, DeadArgs as DeadCore,
-    DepsCoreArgs, ImpactCoreArgs, PlanArgs as PlanCore, ReviewArgs as ReviewCore, TestMapCoreArgs,
-    TraceCoreArgs,
+    DepsCoreArgs, HealthArgs as HealthCore, ImpactCoreArgs, PlanArgs as PlanCore,
+    ReviewArgs as ReviewCore, StatsArgs as StatsCore, TestMapCoreArgs, TraceCoreArgs,
 };
 
 /// The composed tool table for `tools/list` — the Phase-1 read tools, plus the
@@ -365,6 +377,28 @@ fn read_tools() -> &'static [ToolDef] {
                 "Read a project file with cqs notes injected (or, with focus, just one function \
                  plus its type dependencies).",
             input_schema: schema::<ReadArgs>,
+            annotations: ToolAnnotations::READ,
+        },
+        // Zero-arg read tools (MCP Phase 1). Both take no input — their cores
+        // advertise an empty `properties` object — and both build their core via
+        // `*Args::default()` on every surface, so there is no knob to expose.
+        ToolDef {
+            name: "cqs_stats",
+            command: "stats",
+            description:
+                "Index statistics: chunk/file/note counts, call-graph and type-graph totals, \
+                 per-language and per-type breakdowns, model, schema version, and freshness \
+                 (stale/missing files). The one-call snapshot of what's indexed.",
+            input_schema: schema::<StatsCore>,
+            annotations: ToolAnnotations::READ,
+        },
+        ToolDef {
+            name: "cqs_health",
+            command: "health",
+            description:
+                "Codebase quality snapshot: dead-code count, staleness, hotspots (most-called \
+                 functions), and untested functions. The pre-work health check.",
+            input_schema: schema::<HealthCore>,
             annotations: ToolAnnotations::READ,
         },
     ]
@@ -688,6 +722,10 @@ fn validate_arguments(command: &str, arguments: &Value) -> Result<(), String> {
         "review" => check::<ReviewCore>(arguments),
         "plan" => check::<PlanCore>(arguments),
         "read" => check::<ReadArgs>(arguments),
+        // Zero-arg read tools (Phase 1). The core has no advertised properties,
+        // so the shape check just rejects a non-object / wrong-typed `arguments`.
+        "stats" => check::<StatsCore>(arguments),
+        "health" => check::<HealthCore>(arguments),
         // Phase-2a gated notes mutators. Only reachable when the mutation tools
         // are in the table (flag on), since `find_tool` gates on the same flag —
         // but the pre-check arm is unconditional so a flag-on call shape-checks.


### PR DESCRIPTION
Phase 1 of #2021 (complete the MCP command-core input structs) — the **safe, zero-risk subset** plus the **authoritative classification** that scopes Phase 2.

## Classification (the key deliverable)
41 daemon commands; 24 already have a JsonSchema core; **17 don't**. Full breakdown:

**No-arg (7):** `stats`/`health` → **exposed here** (read-only, agent-useful, input-only structs). `gc`/`refresh`/`ping`/`status`/`help` → withheld (mutating or daemon/CLI infra).

**Argv-bearing (10) → Phase 2:** `where`/`related`/`task`(overlay)/`stale`/`notes`(list) → expose as read tools (each needs a `Deserialize+JsonSchema` core + converter + parity test). `suggest` (only safe with `--apply` withheld-by-absence) + `impact-diff` (git-state-dependent) → scoping decision. `explain` (already withheld, RT-RELAY) + `reconcile`/`wait-fresh` → withheld infra.

No serde-output-aliasing risk found in any of the 17 (all clap `Args` or pure-`Deserialize`; none derive `Serialize` onto a live output path). Phase 2 re-verifies per command.

## Implemented: `stats` + `health` (the no-arg read-only subset)
- `StatsArgs`/`HealthArgs` gain `JsonSchema` + struct-level `#[serde(default)]`; **input-only** (outputs are the separate `StatsOutput`/`HealthReport`, so the derive can't change JSON output). `StatsArgs::include_staleness` is `#[schemars(skip)]` (inert wire field, the `max_nodes` precedent); `HealthArgs` is empty.
- `build_batch_cmd` arms (ctx-only → core deserialize is a shape pre-check, discarded); `tool_table` exposes `cqs_stats`/`cqs_health` (read annotations); `validate_arguments` arms.
- `schema<T>()` now normalizes a zero-field core to `properties: {}` at the one chokepoint all core schemas flow through (`entry().or_insert_with` — non-destructive, existing tools with fields untouched), so any future zero-arg tool inherits the guarantee.
- Parity guards: read tools 19→21 (flag off), 23→25 (flag on); README read-tool list updated, pinned by `readme_read_tool_list_matches_registry`.

## Tests
- MCP module 31 · json_args 29 (incl. `parity_json_args_equals_argv` stats/health + the exhaustiveness guard) · stats/health cores 7
- clippy `--all-targets --features cuda-index`, fmt, provenance: clean
- **Full `--tests` sweep** (cross-surface registry change): **0 failures** (bin 2600, lib 1256, + every integration crate)

Phase 2 (the argv-bearing cores + the `suggest`/`impact-diff` scoping calls) tracked under #2021.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
