### PR TITLE
feat(mcp): expose where/related/stale as read tools (MCP cores Phase 2) (#2021)

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ cqs mcp
 ```
 
 **Tool surface**:
-- **Default (read-only)**: 21 `cqs_`-prefixed tools — `cqs_search`, `cqs_gather`, `cqs_scout`, `cqs_onboard`, `cqs_similar`, `cqs_callers`, `cqs_callees`, `cqs_deps`, `cqs_impact`, `cqs_test_map`, `cqs_trace`, `cqs_blame`, `cqs_diff`, `cqs_drift`, `cqs_dead`, `cqs_ci`, `cqs_review`, `cqs_plan`, `cqs_read`, `cqs_stats`, `cqs_health`. (`cqs_context`/`cqs_explain` are deliberately withheld — their relay would carry unscanned doc/signature content.)
+- **Default (read-only)**: 24 `cqs_`-prefixed tools — `cqs_search`, `cqs_gather`, `cqs_scout`, `cqs_onboard`, `cqs_similar`, `cqs_callers`, `cqs_callees`, `cqs_deps`, `cqs_impact`, `cqs_test_map`, `cqs_trace`, `cqs_blame`, `cqs_diff`, `cqs_drift`, `cqs_dead`, `cqs_ci`, `cqs_review`, `cqs_plan`, `cqs_read`, `cqs_where`, `cqs_related`, `cqs_stale`, `cqs_stats`, `cqs_health`. (`cqs_context`/`cqs_explain` are deliberately withheld — their relay would carry unscanned doc/signature content.)
 - **Opt-in mutations** (`CQS_MCP_ENABLE_MUTATIONS=1`): adds 4 mutating tools — `cqs_notes_add`, `cqs_notes_update`, `cqs_notes_remove`, `cqs_index`. Notes mutations write `docs/notes.toml` (the watch loop reindexes); `cqs_index` queues a non-blocking reconcile. Neither writes the daemon's in-memory Store directly.
 - **Permanently withheld**: the destructive set (`gc`, `slot remove`, `index --force`, `model swap`, `cache clear`) is never exposed, regardless of flag value.
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -647,7 +647,17 @@ pub(crate) struct ReadArgs {
 }
 
 /// Arguments shared between CLI `stale` and batch `stale`.
-#[derive(Args, Debug, Clone)]
+///
+/// Also the surface-agnostic core that the daemon JSON-args path (`cqs_stale`)
+/// deserializes directly — `count_only` is the lone request knob, read off the
+/// wire and projected by `dispatch_stale` (the compute core
+/// `commands::index::StaleArgs` stays parameterless). Input-only: it derives
+/// `Deserialize` + `JsonSchema`, never `Serialize`. The command's JSON OUTPUT
+/// is the separate `StaleOutput`, so these derives cannot change the output
+/// wire shape. `#[serde(default)]` lets a wire caller omit `count_only` and
+/// inherit the clap default (`false`).
+#[derive(Args, Debug, Clone, Default, serde::Deserialize, schemars::JsonSchema)]
+#[serde(default)]
 pub(crate) struct StaleArgs {
     /// Show counts only, skip file list
     #[arg(long)]

--- a/src/cli/batch/json_args.rs
+++ b/src/cli/batch/json_args.rs
@@ -47,8 +47,8 @@ use serde::de::DeserializeOwned;
 
 use crate::cli::args::{
     BlameArgs, CallersArgs, CiArgs, ContextArgs, DeadArgs, DepsArgs, DiffArgs, DriftArgs,
-    GatherArgs, ImpactArgs, LimitArg, OnboardArgs, OverlayArgs, PlanArgs, ReadArgs, ReviewArgs,
-    ScoutArgs, SearchArgs, SimilarArgs, TestMapArgs, TraceArgs,
+    GatherArgs, ImpactArgs, LimitArg, OnboardArgs, OverlayArgs, PlanArgs, ReadArgs, RelatedArgs,
+    ReviewArgs, ScoutArgs, SearchArgs, SimilarArgs, StaleArgs, TestMapArgs, TraceArgs, WhereArgs,
 };
 use crate::cli::definitions::{GateThreshold, OutputArgs, OutputFormat, TextJsonArgs};
 
@@ -67,8 +67,10 @@ use crate::cli::commands::drift::DriftArgs as DriftCore;
 use crate::cli::commands::search::gather::GatherArgs as GatherCore;
 use crate::cli::commands::search::onboard::OnboardArgs as OnboardCore;
 use crate::cli::commands::search::query::QueryArgs;
+use crate::cli::commands::search::related::RelatedArgs as RelatedCore;
 use crate::cli::commands::search::scout::ScoutArgs as ScoutCore;
 use crate::cli::commands::search::similar::SimilarArgs as SimilarCore;
+use crate::cli::commands::search::where_cmd::WhereArgs as WhereCore;
 use crate::cli::commands::{
     CalleesArgs as CalleesCore, CallersCoreArgs, CiArgs as CiCore, DeadArgs as DeadCore,
     DepsCoreArgs, HealthArgs as HealthCore, ImpactCoreArgs, PlanArgs as PlanCore,
@@ -178,6 +180,9 @@ pub(crate) const JSON_ARGS_CAPABLE_COMMANDS: &[&str] = &[
     "review",
     "plan",
     "read",
+    "where",
+    "related",
+    "stale",
     "stats",
     "health",
     "notes-add",
@@ -366,6 +371,37 @@ pub(super) fn build_batch_cmd(command: &str, arguments: &serde_json::Value) -> R
             // deserialize target and the variant field are the same struct.
             let c: ReadArgs = parse_core(command, arguments)?;
             BatchCmd::Read {
+                args: c,
+                output: text_json(),
+            }
+        }
+        // ─── MCP Phase 2: simple read tools ────────────────────────────────────
+        //
+        // `where` / `related` / `stale` carry a flat core (no overlay tri-state,
+        // no gating). Each output is a separate `Serialize` struct
+        // (`WhereOutput` / `RelatedOutput` / `StaleOutput`), so the input core is
+        // input-only — the JSON OUTPUT is byte-unchanged by these arms.
+        "where" => {
+            let c: WhereCore = parse_core(command, arguments)?;
+            BatchCmd::Where {
+                args: where_args_from_core(c),
+                output: text_json(),
+            }
+        }
+        "related" => {
+            let c: RelatedCore = parse_core(command, arguments)?;
+            BatchCmd::Related {
+                args: related_args_from_core(c),
+                output: text_json(),
+            }
+        }
+        // `stale`'s wire knob is the render flag `count_only`, which lives on the
+        // clap-side `args::StaleArgs` (the compute core is parameterless). That
+        // struct IS the deserialize target here, mirroring `read`'s `ReadArgs` —
+        // so the variant field and the schema source are the same type.
+        "stale" => {
+            let c: StaleArgs = parse_core(command, arguments)?;
+            BatchCmd::Stale {
                 args: c,
                 output: text_json(),
             }
@@ -698,6 +734,20 @@ fn plan_args_from_core(c: PlanCore) -> PlanArgs {
     }
 }
 
+fn where_args_from_core(c: WhereCore) -> WhereArgs {
+    WhereArgs {
+        description: c.description,
+        limit_arg: LimitArg { limit: c.limit },
+    }
+}
+
+fn related_args_from_core(c: RelatedCore) -> RelatedArgs {
+    RelatedArgs {
+        name: c.name,
+        limit_arg: LimitArg { limit: c.limit },
+    }
+}
+
 // ─── Tests ─────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -827,6 +877,11 @@ mod tests {
             ),
             ("context", vec!["src/lib.rs"], json!({"path": "src/lib.rs"})),
             ("read", vec!["src/lib.rs"], json!({"path": "src/lib.rs"})),
+            // Phase-2 read tools: `related` (co-occurrence, embedder-free) and
+            // `stale` (mtime diff). `where` needs an embedder, so its parity is
+            // pinned separately (`parity_where_json_args_equals_argv`).
+            ("related", vec!["caller_fn"], json!({"name": "caller_fn"})),
+            ("stale", vec![], json!({})),
             // Zero-arg read tools: the JSON `{}` must produce the same envelope
             // as the bare argv form (the handler ignores any input).
             ("stats", vec![], json!({})),
@@ -869,6 +924,14 @@ mod tests {
                 vec!["--include-pub", "--min-confidence", "high"],
                 json!({"include_pub": true, "min_confidence": "high"}),
             ),
+            (
+                "related",
+                vec!["caller_fn", "--limit", "2"],
+                json!({"name": "caller_fn", "limit": 2}),
+            ),
+            // `stale --count-only` projects to the 3-field count subset on both
+            // surfaces — guards that `count_only` rides the wire core.
+            ("stale", vec!["--count-only"], json!({"count_only": true})),
         ];
         for (command, argv, arguments) in cases {
             let (v_argv, v_json) = run_both(&ctx, command, &argv, arguments);
@@ -877,6 +940,26 @@ mod tests {
                 "JSON-args output must equal argv output for `{command}` with explicit fields\nargv:  {v_argv}\njson:  {v_json}"
             );
         }
+    }
+
+    /// `where` parity: it needs an embedder (`suggest_placement`), which the
+    /// embedder-free seed corpus lacks, so both paths return the SAME error
+    /// envelope — the assertion is value-equality of the two envelopes, proving
+    /// the JSON-args path routes through the same `dispatch_where` the argv path
+    /// uses (whether it errors or succeeds, the two surfaces agree).
+    #[test]
+    fn parity_where_json_args_equals_argv() {
+        let (_dir, ctx) = seed_ctx();
+        let (v_argv, v_json) = run_both(
+            &ctx,
+            "where",
+            &["add a new parser"],
+            json!({"description": "add a new parser"}),
+        );
+        assert_eq!(
+            v_argv, v_json,
+            "JSON-args output must equal argv output for `where`\nargv:  {v_argv}\njson:  {v_json}"
+        );
     }
 
     /// A missing optional field deserializes via `#[serde(default)]` — an empty
@@ -964,9 +1047,9 @@ mod tests {
     /// error on the JSON-args path rather than dispatching or panicking.
     #[test]
     fn argv_only_command_rejected_on_json_path() {
-        // `where` / `explain` are argv-only. (`notes-*` mutations now have a
-        // gated core — covered by the MCP Phase-2a tests below.)
-        let err = build_batch_cmd("where", &json!({"description": "x"}));
+        // `explain` is argv-only. (`where`/`related`/`stale` gained Phase-2 cores;
+        // `notes-*` mutations have a gated core — covered by the tests below.)
+        let err = build_batch_cmd("explain", &json!({"name": "x"}));
         assert!(
             err.is_err(),
             "an argv-only command must be rejected on the JSON-args path"
@@ -1552,16 +1635,11 @@ mod tests {
 
         // 2. A representative spread of argv-only / unknown commands is NOT
         //    capable — the catch-all bites, and they are absent from the list.
-        //    (`stats` / `health` ARE capable now — Phase-1 zero-arg read tools —
-        //    so they are deliberately excluded from this not-capable spread.)
-        for cmd in [
-            "where",
-            "explain",
-            "notes",
-            "task",
-            "ping",
-            "nonexistent_cmd",
-        ] {
+        //    (`stats` / `health` are Phase-1 zero-arg read tools and
+        //    `where` / `related` / `stale` are Phase-2 read tools — all capable
+        //    now — so they are deliberately excluded from this not-capable
+        //    spread.)
+        for cmd in ["explain", "notes", "task", "ping", "nonexistent_cmd"] {
             assert!(
                 !is_json_args_capable(cmd),
                 "`{cmd}` is argv-only/unknown but build_batch_cmd treats it as JSON-args-capable"

--- a/src/cli/commands/search/mod.rs
+++ b/src/cli/commands/search/mod.rs
@@ -4,11 +4,11 @@ pub(crate) mod gather;
 mod neighbors;
 pub(crate) mod onboard;
 pub(crate) mod query;
-mod related;
+pub(crate) mod related;
 pub(crate) mod scout;
 pub(crate) mod search_ctx;
 pub(crate) mod similar;
-mod where_cmd;
+pub(crate) mod where_cmd;
 
 pub(crate) use gather::{build_gather_output, cmd_gather, GatherContext};
 pub(crate) use neighbors::cmd_neighbors;

--- a/src/cli/commands/search/related.rs
+++ b/src/cli/commands/search/related.rs
@@ -6,6 +6,38 @@ use std::path::Path;
 
 use anyhow::Result;
 
+// ─── Args (surface-agnostic, MCP-ready) ─────────────────────────────────────
+
+/// Input for the `related` co-occurrence query — the request-shaped knobs both
+/// the CLI (`cmd_related`) and the MCP `cqs_related` tool deserialize into. The
+/// store and root come from the adapter; these are the request settings.
+///
+/// Input-only: it derives `Deserialize` + `JsonSchema` for the wire, never
+/// `Serialize`. The command's JSON OUTPUT is the separate `RelatedOutput`, so
+/// adding these derives cannot change the output wire shape.
+///
+/// `#[serde(default)]` so a wire caller can supply just `name` and inherit the
+/// production default (`limit` mirrors clap's `LimitArg`).
+#[derive(Debug, Clone, PartialEq, serde::Deserialize, schemars::JsonSchema)]
+#[serde(default)]
+pub(crate) struct RelatedArgs {
+    /// Function name or `file:function`.
+    pub name: String,
+    /// Per-category cap on related entries (clamped to `RELATED_LIMIT_MAX` in
+    /// the adapter).
+    pub limit: usize,
+}
+
+impl Default for RelatedArgs {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            // Mirrors clap `LimitArg` default (5).
+            limit: crate::cli::args::DEFAULT_LIMIT,
+        }
+    }
+}
+
 // ─── Output types ──────────────────────────────────────────────────────────
 
 /// A single related-function entry in the JSON output.
@@ -147,6 +179,19 @@ mod tests {
             line,
             overlap_count: overlap,
         }
+    }
+
+    /// The core deserializes from a wire object and applies serde defaults for
+    /// an omitted `limit` (MCP supplies only `name`).
+    #[test]
+    fn related_args_deserialize_applies_defaults() {
+        let only_name: RelatedArgs = serde_json::from_str(r#"{"name":"foo"}"#).unwrap();
+        assert_eq!(only_name.name, "foo");
+        assert_eq!(only_name.limit, crate::cli::args::DEFAULT_LIMIT);
+        let full: RelatedArgs = serde_json::from_str(r#"{"name":"bar","limit":7}"#).unwrap();
+        assert_eq!(full.limit, 7);
+        // Empty object is valid (name defaults to empty).
+        let _empty: RelatedArgs = serde_json::from_str("{}").unwrap();
     }
 
     #[test]

--- a/src/cli/commands/search/where_cmd.rs
+++ b/src/cli/commands/search/where_cmd.rs
@@ -8,6 +8,38 @@ use anyhow::Result;
 
 use cqs::suggest_placement;
 
+// ─── Args (surface-agnostic, MCP-ready) ─────────────────────────────────────
+
+/// Input for the `where` placement query — the request-shaped knobs both the
+/// CLI (`cmd_where`) and the MCP `cqs_where` tool deserialize into. The store,
+/// embedder, and root come from the adapter; these are the request settings.
+///
+/// Input-only: it derives `Deserialize` + `JsonSchema` for the wire, never
+/// `Serialize`. The command's JSON OUTPUT is the separate `WhereOutput`, so
+/// adding these derives cannot change the output wire shape.
+///
+/// `#[serde(default)]` so a wire caller can supply just `description` and
+/// inherit the production default (`limit` mirrors clap's `LimitArg`).
+#[derive(Debug, Clone, PartialEq, serde::Deserialize, schemars::JsonSchema)]
+#[serde(default)]
+pub(crate) struct WhereArgs {
+    /// Natural-language description of the code to add.
+    pub description: String,
+    /// Cap on placement suggestions (clamped to `PLACEMENT_LIMIT_CAP` in the
+    /// adapter).
+    pub limit: usize,
+}
+
+impl Default for WhereArgs {
+    fn default() -> Self {
+        Self {
+            description: String::new(),
+            // Mirrors clap `LimitArg` default (5).
+            limit: crate::cli::args::DEFAULT_LIMIT,
+        }
+    }
+}
+
 // ─── Output types ──────────────────────────────────────────────────────────
 
 /// Patterns detected in a suggested file.
@@ -161,6 +193,19 @@ mod tests {
                 has_inline_tests: true,
             },
         }
+    }
+
+    /// The core deserializes from a wire object and applies serde defaults for
+    /// an omitted `limit` (MCP supplies only `description`).
+    #[test]
+    fn where_args_deserialize_applies_defaults() {
+        let only_desc: WhereArgs = serde_json::from_str(r#"{"description":"add X"}"#).unwrap();
+        assert_eq!(only_desc.description, "add X");
+        assert_eq!(only_desc.limit, crate::cli::args::DEFAULT_LIMIT);
+        let full: WhereArgs = serde_json::from_str(r#"{"description":"add Y","limit":3}"#).unwrap();
+        assert_eq!(full.limit, 3);
+        // Empty object is valid (description defaults to empty).
+        let _empty: WhereArgs = serde_json::from_str("{}").unwrap();
     }
 
     #[test]

--- a/src/cli/mcp/mod.rs
+++ b/src/cli/mcp/mod.rs
@@ -148,10 +148,10 @@ mod tests {
     ///
     /// With `CQS_MCP_ENABLE_MUTATIONS` unset, the exposed MCP tool set must
     /// equal the daemon's JSON-args-capable read command set MINUS the withheld
-    /// set — 21 read tools (the original 19 plus the zero-arg `stats`/`health`),
-    /// zero mutation delta. Fails if a JSON-args command is added/removed
-    /// without updating the MCP surface, or if a withheld command leaks into
-    /// `tools/list`.
+    /// set — 24 read tools (the zero-arg `stats`/`health` plus the Phase-2
+    /// `where`/`related`/`stale`), zero mutation delta. Fails if a JSON-args
+    /// command is added/removed without updating the MCP surface, or if a
+    /// withheld command leaks into `tools/list`.
     #[test]
     #[serial_test::serial(mcp_mutations_env)]
     fn tools_list_matches_json_args_registry() {
@@ -163,18 +163,18 @@ mod tests {
             "MCP tools/list (flag off) must equal the JSON-args read registry minus the \
              withheld set.\nexposed (mapped to commands): {exposed:?}\nexpected: {expected:?}"
         );
-        // The flag-off read surface = exactly 21 read tools.
+        // The flag-off read surface = exactly 24 read tools.
         assert_eq!(
             exposed.len(),
-            21,
-            "flag-off tools/list must expose 21 tools"
+            24,
+            "flag-off tools/list must expose 24 tools"
         );
     }
 
     /// Flag-gating guard: the mutation tools are present IFF
     /// `CQS_MCP_ENABLE_MUTATIONS=1`. With the flag on, the exposed set is the
     /// read set PLUS exactly the three notes mutators AND the fire-and-forget
-    /// `index` (25 total).
+    /// `index` (28 total).
     #[test]
     #[serial_test::serial(mcp_mutations_env)]
     fn mutation_tools_present_iff_flag_set() {
@@ -206,7 +206,7 @@ mod tests {
                 "flag-on tools/list must be the read set plus exactly the 3 notes mutators \
                  and the index queue tool"
             );
-            assert_eq!(on.len(), 25, "flag-on tools/list must expose 25 tools");
+            assert_eq!(on.len(), 28, "flag-on tools/list must expose 28 tools");
         }
     }
 

--- a/src/cli/mcp/tools.rs
+++ b/src/cli/mcp/tools.rs
@@ -180,14 +180,17 @@ fn schema_with_overlay<T: schemars::JsonSchema>() -> Value {
 // `cli::batch::json_args`, so the schema source and the daemon deserialize
 // target are provably the same type.
 use crate::cli::args::ReadArgs;
+use crate::cli::args::StaleArgs as StaleCore;
 use crate::cli::commands::blame::BlameArgs as BlameCore;
 use crate::cli::commands::diff::DiffArgs as DiffCore;
 use crate::cli::commands::drift::DriftArgs as DriftCore;
 use crate::cli::commands::search::gather::GatherArgs as GatherCore;
 use crate::cli::commands::search::onboard::OnboardArgs as OnboardCore;
 use crate::cli::commands::search::query::QueryArgs;
+use crate::cli::commands::search::related::RelatedArgs as RelatedCore;
 use crate::cli::commands::search::scout::ScoutArgs as ScoutCore;
 use crate::cli::commands::search::similar::SimilarArgs as SimilarCore;
+use crate::cli::commands::search::where_cmd::WhereArgs as WhereCore;
 use crate::cli::commands::{
     CalleesArgs as CalleesCore, CallersCoreArgs, CiArgs as CiCore, DeadArgs as DeadCore,
     DepsCoreArgs, HealthArgs as HealthCore, ImpactCoreArgs, PlanArgs as PlanCore,
@@ -377,6 +380,36 @@ fn read_tools() -> &'static [ToolDef] {
                 "Read a project file with cqs notes injected (or, with focus, just one function \
                  plus its type dependencies).",
             input_schema: schema::<ReadArgs>,
+            annotations: ToolAnnotations::READ,
+        },
+        // Simple read tools (MCP Phase 2). Flat cores, no overlay tri-state.
+        ToolDef {
+            name: "cqs_where",
+            command: "where",
+            description:
+                "Suggest where to add new code described in natural language: ranked file \
+                 placements with insertion line, nearby function, and the local patterns \
+                 (imports, error handling, naming, visibility) of each candidate.",
+            input_schema: schema::<WhereCore>,
+            annotations: ToolAnnotations::READ,
+        },
+        ToolDef {
+            name: "cqs_related",
+            command: "related",
+            description:
+                "Functions related to a named one by co-occurrence: shared callers, shared \
+                 callees, and shared custom types, each ranked by overlap count.",
+            input_schema: schema::<RelatedCore>,
+            annotations: ToolAnnotations::READ,
+        },
+        ToolDef {
+            name: "cqs_stale",
+            command: "stale",
+            description:
+                "Index freshness: which indexed files have changed (stale) or been deleted \
+                 (missing) since the last index, plus the total indexed count. Use count_only \
+                 for just the counts.",
+            input_schema: schema::<StaleCore>,
             annotations: ToolAnnotations::READ,
         },
         // Zero-arg read tools (MCP Phase 1). Both take no input — their cores
@@ -722,6 +755,10 @@ fn validate_arguments(command: &str, arguments: &Value) -> Result<(), String> {
         "review" => check::<ReviewCore>(arguments),
         "plan" => check::<PlanCore>(arguments),
         "read" => check::<ReadArgs>(arguments),
+        // Phase-2 simple read tools — flat cores, shape check only.
+        "where" => check::<WhereCore>(arguments),
+        "related" => check::<RelatedCore>(arguments),
+        "stale" => check::<StaleCore>(arguments),
         // Zero-arg read tools (Phase 1). The core has no advertised properties,
         // so the shape check just rejects a non-object / wrong-typed `arguments`.
         "stats" => check::<StatsCore>(arguments),


### PR DESCRIPTION
Phase 2 of #2021. Adds JsonSchema command-cores for the three simple read commands where/related/stale, exposed as cqs_where/cqs_related/cqs_stale (read tools 21 to 24). Each serde-verified INPUT-ONLY (separate output structs, no Serialize on the input core), so JSON output is byte-unchanged. The registry/README/exhaustiveness guards are derived from JSON_ARGS_CAPABLE_COMMANDS so the new commands auto-enrolled. Full --tests sweep 4859/0; clippy --all-targets/fmt/provenance clean. Deferred to a later phase (overlay/subaction/gating judgment): task, notes-list, suggest, impact-diff.