### PR TITLE
feat(mcp): expose task as overlay-capable read tool (MCP cores Phase 3) (#2021)

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ cqs mcp
 ```
 
 **Tool surface**:
-- **Default (read-only)**: 24 `cqs_`-prefixed tools — `cqs_search`, `cqs_gather`, `cqs_scout`, `cqs_onboard`, `cqs_similar`, `cqs_callers`, `cqs_callees`, `cqs_deps`, `cqs_impact`, `cqs_test_map`, `cqs_trace`, `cqs_blame`, `cqs_diff`, `cqs_drift`, `cqs_dead`, `cqs_ci`, `cqs_review`, `cqs_plan`, `cqs_read`, `cqs_where`, `cqs_related`, `cqs_stale`, `cqs_stats`, `cqs_health`. (`cqs_context`/`cqs_explain` are deliberately withheld — their relay would carry unscanned doc/signature content.)
+- **Default (read-only)**: 25 `cqs_`-prefixed tools — `cqs_search`, `cqs_gather`, `cqs_scout`, `cqs_task`, `cqs_onboard`, `cqs_similar`, `cqs_callers`, `cqs_callees`, `cqs_deps`, `cqs_impact`, `cqs_test_map`, `cqs_trace`, `cqs_blame`, `cqs_diff`, `cqs_drift`, `cqs_dead`, `cqs_ci`, `cqs_review`, `cqs_plan`, `cqs_read`, `cqs_where`, `cqs_related`, `cqs_stale`, `cqs_stats`, `cqs_health`. (`cqs_context`/`cqs_explain` are deliberately withheld — their relay would carry unscanned doc/signature content.)
 - **Opt-in mutations** (`CQS_MCP_ENABLE_MUTATIONS=1`): adds 4 mutating tools — `cqs_notes_add`, `cqs_notes_update`, `cqs_notes_remove`, `cqs_index`. Notes mutations write `docs/notes.toml` (the watch loop reindexes); `cqs_index` queues a non-blocking reconcile. Neither writes the daemon's in-memory Store directly.
 - **Permanently withheld**: the destructive set (`gc`, `slot remove`, `index --force`, `model swap`, `cache clear`) is never exposed, regardless of flag value.
 

--- a/src/cli/batch/json_args.rs
+++ b/src/cli/batch/json_args.rs
@@ -48,7 +48,8 @@ use serde::de::DeserializeOwned;
 use crate::cli::args::{
     BlameArgs, CallersArgs, CiArgs, ContextArgs, DeadArgs, DepsArgs, DiffArgs, DriftArgs,
     GatherArgs, ImpactArgs, LimitArg, OnboardArgs, OverlayArgs, PlanArgs, ReadArgs, RelatedArgs,
-    ReviewArgs, ScoutArgs, SearchArgs, SimilarArgs, StaleArgs, TestMapArgs, TraceArgs, WhereArgs,
+    ReviewArgs, ScoutArgs, SearchArgs, SimilarArgs, StaleArgs, TaskArgs, TestMapArgs, TraceArgs,
+    WhereArgs,
 };
 use crate::cli::definitions::{GateThreshold, OutputArgs, OutputFormat, TextJsonArgs};
 
@@ -71,6 +72,7 @@ use crate::cli::commands::search::related::RelatedArgs as RelatedCore;
 use crate::cli::commands::search::scout::ScoutArgs as ScoutCore;
 use crate::cli::commands::search::similar::SimilarArgs as SimilarCore;
 use crate::cli::commands::search::where_cmd::WhereArgs as WhereCore;
+use crate::cli::commands::task::TaskArgs as TaskCore;
 use crate::cli::commands::{
     CalleesArgs as CalleesCore, CallersCoreArgs, CiArgs as CiCore, DeadArgs as DeadCore,
     DepsCoreArgs, HealthArgs as HealthCore, ImpactCoreArgs, PlanArgs as PlanCore,
@@ -183,6 +185,7 @@ pub(crate) const JSON_ARGS_CAPABLE_COMMANDS: &[&str] = &[
     "where",
     "related",
     "stale",
+    "task",
     "stats",
     "health",
     "notes-add",
@@ -241,6 +244,20 @@ pub(super) fn build_batch_cmd(command: &str, arguments: &serde_json::Value) -> R
             let c: ScoutCore = parse_core(command, arguments)?;
             BatchCmd::Scout {
                 args: scout_args_from_core(c, overlay_from_args(arguments)),
+                output: text_json(),
+            }
+        }
+        // `task` is overlay-capable: its handler (`dispatch_task`) overlays the
+        // scout SEED via `resolve_seed_overlay`, so the wire overlay tri-state
+        // rides alongside the core and is stamped onto the argv-side `TaskArgs`
+        // by `overlay_from_args` (the same path scout uses). The CLI-only `brief`
+        // render flag is defaulted here — the daemon emits only the non-brief
+        // `task_json_core` projection. Output is a separate `Serialize` struct,
+        // so the input core stays input-only.
+        "task" => {
+            let c: TaskCore = parse_core(command, arguments)?;
+            BatchCmd::Task {
+                args: task_args_from_core(c, overlay_from_args(arguments)),
                 output: text_json(),
             }
         }
@@ -554,6 +571,19 @@ fn scout_args_from_core(c: ScoutCore, overlay: OverlayArgs) -> ScoutArgs {
         search_limit: c.search_limit,
         search_threshold: c.search_threshold,
         min_gap_ratio: c.min_gap_ratio,
+        overlay,
+    }
+}
+
+/// Build the argv-side `TaskArgs` from the wire core plus the overlay tri-state.
+/// `brief` is CLI-only (the daemon never renders the compact brief — it emits
+/// the `task_json_core` projection), so it is defaulted to `false` here.
+fn task_args_from_core(c: TaskCore, overlay: OverlayArgs) -> TaskArgs {
+    TaskArgs {
+        description: c.description,
+        limit_arg: LimitArg { limit: c.limit },
+        tokens: c.tokens,
+        brief: false,
         overlay,
     }
 }
@@ -959,6 +989,28 @@ mod tests {
         assert_eq!(
             v_argv, v_json,
             "JSON-args output must equal argv output for `where`\nargv:  {v_argv}\njson:  {v_json}"
+        );
+    }
+
+    /// `task` parity: like `where`, the brief needs an embedder (the scout seed
+    /// search), which the embedder-free seed corpus lacks, so both surfaces
+    /// return the SAME error envelope. The assertion is value-equality of the
+    /// two envelopes — it proves the JSON-args path routes through the same
+    /// `dispatch_task` the argv path uses (whether it errors or succeeds, the
+    /// two surfaces agree). Covers the overlay-capable converter
+    /// (`task_args_from_core`) and the wire core round-trip.
+    #[test]
+    fn parity_task_json_args_equals_argv() {
+        let (_dir, ctx) = seed_ctx();
+        let (v_argv, v_json) = run_both(
+            &ctx,
+            "task",
+            &["add a new parser", "--limit", "3"],
+            json!({"description": "add a new parser", "limit": 3}),
+        );
+        assert_eq!(
+            v_argv, v_json,
+            "JSON-args output must equal argv output for `task`\nargv:  {v_argv}\njson:  {v_json}"
         );
     }
 
@@ -1635,11 +1687,11 @@ mod tests {
 
         // 2. A representative spread of argv-only / unknown commands is NOT
         //    capable — the catch-all bites, and they are absent from the list.
-        //    (`stats` / `health` are Phase-1 zero-arg read tools and
-        //    `where` / `related` / `stale` are Phase-2 read tools — all capable
-        //    now — so they are deliberately excluded from this not-capable
-        //    spread.)
-        for cmd in ["explain", "notes", "task", "ping", "nonexistent_cmd"] {
+        //    (`stats` / `health` are Phase-1 zero-arg read tools,
+        //    `where` / `related` / `stale` are Phase-2 read tools, and `task`
+        //    is the Phase-3 overlay-capable brief tool — all capable now — so
+        //    they are deliberately excluded from this not-capable spread.)
+        for cmd in ["explain", "notes", "ping", "nonexistent_cmd"] {
             assert!(
                 !is_json_args_capable(cmd),
                 "`{cmd}` is argv-only/unknown but build_batch_cmd treats it as JSON-args-capable"

--- a/src/cli/commands/train/task.rs
+++ b/src/cli/commands/train/task.rs
@@ -5,6 +5,48 @@ use colored::Colorize;
 
 use cqs::{task, Embedder};
 
+// ─── Args (surface-agnostic, MCP-ready) ─────────────────────────────────────
+
+/// Input for the `task` implementation-brief query — the request-shaped knobs
+/// both the CLI (`cmd_task`) and the MCP `cqs_task` tool deserialize into. The
+/// store, embedder, root, call graph, and test chunks come from the adapter;
+/// these are the request settings the daemon (`dispatch_task`) consumes:
+/// `description`, `limit`, `tokens`. The worktree-overlay tri-state rides
+/// alongside on the wire (read separately by `overlay_from_args`), and the
+/// CLI-only `brief` render flag stays on the clap-side `args::TaskArgs` — the
+/// daemon emits only the non-brief JSON projection.
+///
+/// Input-only: it derives `Deserialize` + `JsonSchema` for the wire, never
+/// `Serialize`. The command's JSON OUTPUT is the separate `task_json_core`
+/// projection (`TaskBriefOutput` / the budgeted scout structs), so adding these
+/// derives cannot change the output wire shape.
+///
+/// `#[serde(default)]` so a wire caller can supply just `description` and
+/// inherit the production defaults (`limit` mirrors clap's `LimitArg`).
+#[derive(Debug, Clone, PartialEq, serde::Deserialize, schemars::JsonSchema)]
+#[serde(default)]
+pub(crate) struct TaskArgs {
+    /// Task description to build the implementation brief for.
+    pub description: String,
+    /// Max file placements to return (clamped to `PLACEMENT_LIMIT_CAP` in the
+    /// adapter).
+    pub limit: usize,
+    /// Token budget — when set, waterfalls chunk content across the brief's
+    /// sections within the budget.
+    pub tokens: Option<usize>,
+}
+
+impl Default for TaskArgs {
+    fn default() -> Self {
+        Self {
+            description: String::new(),
+            // Mirrors clap `LimitArg` default (5).
+            limit: crate::cli::args::DEFAULT_LIMIT,
+            tokens: None,
+        }
+    }
+}
+
 // ─── Output types ──────────────────────────────────────────────────────────
 
 /// Brief task output: files to touch, placements, at-risk functions, tests.

--- a/src/cli/mcp/mod.rs
+++ b/src/cli/mcp/mod.rs
@@ -148,10 +148,11 @@ mod tests {
     ///
     /// With `CQS_MCP_ENABLE_MUTATIONS` unset, the exposed MCP tool set must
     /// equal the daemon's JSON-args-capable read command set MINUS the withheld
-    /// set — 24 read tools (the zero-arg `stats`/`health` plus the Phase-2
-    /// `where`/`related`/`stale`), zero mutation delta. Fails if a JSON-args
-    /// command is added/removed without updating the MCP surface, or if a
-    /// withheld command leaks into `tools/list`.
+    /// set — 25 read tools (the zero-arg `stats`/`health`, the Phase-2
+    /// `where`/`related`/`stale`, and the Phase-3 overlay-capable `task`), zero
+    /// mutation delta. Fails if a JSON-args command is added/removed without
+    /// updating the MCP surface, or if a withheld command leaks into
+    /// `tools/list`.
     #[test]
     #[serial_test::serial(mcp_mutations_env)]
     fn tools_list_matches_json_args_registry() {
@@ -163,18 +164,18 @@ mod tests {
             "MCP tools/list (flag off) must equal the JSON-args read registry minus the \
              withheld set.\nexposed (mapped to commands): {exposed:?}\nexpected: {expected:?}"
         );
-        // The flag-off read surface = exactly 24 read tools.
+        // The flag-off read surface = exactly 25 read tools.
         assert_eq!(
             exposed.len(),
-            24,
-            "flag-off tools/list must expose 24 tools"
+            25,
+            "flag-off tools/list must expose 25 tools"
         );
     }
 
     /// Flag-gating guard: the mutation tools are present IFF
     /// `CQS_MCP_ENABLE_MUTATIONS=1`. With the flag on, the exposed set is the
     /// read set PLUS exactly the three notes mutators AND the fire-and-forget
-    /// `index` (28 total).
+    /// `index` (29 total).
     #[test]
     #[serial_test::serial(mcp_mutations_env)]
     fn mutation_tools_present_iff_flag_set() {
@@ -206,7 +207,7 @@ mod tests {
                 "flag-on tools/list must be the read set plus exactly the 3 notes mutators \
                  and the index queue tool"
             );
-            assert_eq!(on.len(), 28, "flag-on tools/list must expose 28 tools");
+            assert_eq!(on.len(), 29, "flag-on tools/list must expose 29 tools");
         }
     }
 

--- a/src/cli/mcp/tools.rs
+++ b/src/cli/mcp/tools.rs
@@ -191,6 +191,7 @@ use crate::cli::commands::search::related::RelatedArgs as RelatedCore;
 use crate::cli::commands::search::scout::ScoutArgs as ScoutCore;
 use crate::cli::commands::search::similar::SimilarArgs as SimilarCore;
 use crate::cli::commands::search::where_cmd::WhereArgs as WhereCore;
+use crate::cli::commands::task::TaskArgs as TaskCore;
 use crate::cli::commands::{
     CalleesArgs as CalleesCore, CallersCoreArgs, CiArgs as CiCore, DeadArgs as DeadCore,
     DepsCoreArgs, HealthArgs as HealthCore, ImpactCoreArgs, PlanArgs as PlanCore,
@@ -242,6 +243,18 @@ fn read_tools() -> &'static [ToolDef] {
                 "Investigation brief for a task: search + callers + tests + staleness + notes in \
                  one call. The first step before implementing.",
             input_schema: schema_with_overlay::<ScoutCore>,
+            annotations: ToolAnnotations::READ,
+        },
+        // Overlay-capable (seed-overlay): the daemon overlays the scout seed from
+        // an eligible worktree, so the schema injects the overlay tri-state keys.
+        ToolDef {
+            name: "cqs_task",
+            command: "task",
+            description:
+                "Full implementation brief for a task description: scout seed + gathered context \
+                 + impact (who breaks) + placement (where to add) + test coverage, in one call. \
+                 Set tokens to budget the brief across sections.",
+            input_schema: schema_with_overlay::<TaskCore>,
             annotations: ToolAnnotations::READ,
         },
         ToolDef {
@@ -735,6 +748,7 @@ fn validate_arguments(command: &str, arguments: &Value) -> Result<(), String> {
         "search" => check::<QueryArgs>(arguments),
         "gather" => check::<GatherCore>(arguments),
         "scout" => check::<ScoutCore>(arguments),
+        "task" => check::<TaskCore>(arguments),
         "onboard" => check::<OnboardCore>(arguments),
         "similar" => check::<SimilarCore>(arguments),
         "callers" => check::<CallersCoreArgs>(arguments),
@@ -1227,13 +1241,14 @@ mod tests {
     }
 
     /// The MCP tool names whose daemon command consumes the worktree-overlay
-    /// tri-state via `overlay_from_args` (search/gather/scout/callers/callees/
-    /// impact/dead/ci/review). The list mirrors the `overlay_from_args(arguments)`
-    /// call sites in `json_args::build_batch_cmd`.
-    const OVERLAY_CAPABLE_TOOLS: [&str; 9] = [
+    /// tri-state via `overlay_from_args` (search/gather/scout/task/callers/
+    /// callees/impact/dead/ci/review). The list mirrors the
+    /// `overlay_from_args(arguments)` call sites in `json_args::build_batch_cmd`.
+    const OVERLAY_CAPABLE_TOOLS: [&str; 10] = [
         "cqs_search",
         "cqs_gather",
         "cqs_scout",
+        "cqs_task",
         "cqs_callers",
         "cqs_callees",
         "cqs_impact",


### PR DESCRIPTION
Phase 3 of #2021. Adds the cqs_task overlay-capable read tool (read tools 24 to 25). TaskArgs core serde-verified INPUT-ONLY (output via the separate task_json_core projection, byte-unchanged); uses schema_with_overlay since dispatch_task reads overlay via resolve_seed_overlay (added to OVERLAY_CAPABLE_TOOLS 9 to 10). Derived guards auto-enrolled. Full --tests sweep 4860/0. Remaining (scoping tail): notes-list (subaction split), suggest (apply-gating), impact-diff (git-state), explain (re-evaluate post-RT-RELAY).