### PR TITLE
docs(plans): park autotune-alpha + SPLADE viz design specs

### DIFF
--- a/docs/plans/2026-06-25-autotune-alpha-design.md
+++ b/docs/plans/2026-06-25-autotune-alpha-design.md
@@ -1,0 +1,67 @@
+# Autotune-α — per-codebase fusion-weight tuning (design spec, PARKED)
+
+**Status: PARKED — design only, not scheduled.** Captured 2026-06-25. The end goal of the retrieval-quality program: cqs auto-tunes the dense↔sparse fusion weight α to each codebase it encounters, with no manual sweep — so retrieval is calibrated to *this* corpus's lexical/semantic character automatically.
+
+## Goal
+
+When cqs first indexes a codebase, it produces a fusion-weight α calibrated to that corpus, persisted per-slot, with zero manual eval work. Replaces the hand-run per-category α-sweeps with an automatic, per-codebase, self-supervised tune.
+
+## Why (the case for it over a fixed α)
+
+- **α is corpus- and query-dependent, and the variance is large.** The v3 alpha sweeps show per-category best-α from ~0.05 (multi_step, SPLADE-dominant) to ~0.95 (type_filtered, dense-dominant); a single fixed α is a weighted compromise that serves no category well.
+- **Manual sweeps are noisy and don't adapt.** Per-category sweeps run at n=8–14 single-gold queries — below the noise floor (the reason retunes require test+dev agreement). And whatever α we ship is tuned on *our* corpus, not the user's.
+- **A different codebase has a different optimum.** An identifier-dense codebase wants dense-heavy α; a prose/concept-heavy one wants more SPLADE. Only a per-corpus tune captures that.
+
+## The first-encounter pipeline
+
+```
+index → embed → llm-summaries enrich (2-pass) → auto-generate pseudo-eval → sweep α on the ENRICHED index → persist per-corpus α
+```
+
+### Critical sequencing gate: α tunes AFTER the summaries are APPLIED
+
+α tunes the dense↔sparse balance, and the LLM summaries change the **dense** leg (they enrich the embedded text). Tuning α before the summaries land calibrates against embeddings cqs will not serve — the enrichment then shifts the dense scores out from under the chosen α.
+
+**"Filled" means the two-pass enrichment is *applied*, not merely stored.** `--llm-summaries` stores summaries (Batches lands after the embed pass); a follow-up `--force` re-embeds with them. The dense leg only reflects the summaries after pass 2. The α-tune must gate on pass-2 completion, ideally on the `0 chunks-with-summary-unenriched` invariant — the same trap that made a recall gate on a partially-enriched index *understate*. An α-tune on a partially-enriched index mis-tunes identically.
+
+## The pseudo-eval (self-supervised gold)
+
+No user codebase ships with a labeled eval set, so the tune must generate one:
+- **Queries from the code** — LLM generates queries from chunk docstrings/signatures/comments (the existing fixture-generation path), source chunk = pseudo-gold. Reuses the query-gen machinery; no new science.
+- **Gold model:** single-gold-pseudo (source chunk) is the cheap first version; **multi-gold-pseudo** (pooled + judged, see below) is the richer one that un-saturates the metric.
+
+## Metric: nDCG, not R@K
+
+α is a **rank-shuffling** knob — it moves a result from rank 8 to rank 3, it rarely flips in/out of the top-20. R@K is a step function blind to within-K rank order, so it gives α almost no gradient. **nDCG** (rank-discounted) responds to the shuffle. With multi-gold, nDCG/MAP also stay discriminative past R@20 (more relevant items → ranking quality matters deeper). Tuning a ranking weight demands a ranking metric.
+
+## Multi-gold fixture (the prototype of the pseudo-eval's gold model)
+
+Build + validate on *our* corpus first, then port the gold model to the auto-generated per-codebase pseudo-eval:
+- **Pooling:** judge the union of top-K from *diverse* configs.
+- **Judge:** the existing dual-judge / local-LLM relevance harness (graded 0–3 → nDCG; binary → multi-gold R@K/MAP).
+- **α-circularity caveat (load-bearing for this use case):** if the pool is built only from α-fusion configs and you then tune α against it, you score α among the very configs that *defined* "relevant" — circular. **The pool MUST include legs that are not α-fusion** — dense-only, sparse-only, FTS/BM25 — so the gold set is not defined by the knob being turned.
+
+## Design forks (decide when un-parked)
+
+1. **LLM-query-gen dependency.** Needs a local model on the user's box (fits local-first). Required, or graceful-skip "run `cqs autotune` when a model is available"? — lean graceful-skip; never block indexing on it.
+2. **Eager vs background.** First-index must not block on a sweep. Background pass after the index (and enrichment) settles — recommended.
+3. **Per-corpus α now, per-query-type classifier later.** The variance is mostly per-query-*type*, so a single per-corpus α leaves gain on the table. End-state is likely **per-corpus baseline + a query-type classifier routing each query to its α** (the `evals/classifier_ab_eval.py` direction). Design the persisted-α path so the classifier can layer on; do NOT treat the single corpus α as terminal.
+4. **Single- vs multi-gold pseudo-eval.** Multi-gold is richer but carries the pooling-incompleteness cost; ship single-gold-pseudo first, upgrade to multi-gold-pseudo once the fixture methodology is validated.
+
+## Risks / open questions
+
+- **Pooling incompleteness (TREC's classic):** the gold set is only as complete as the pooled systems; a relevant chunk no config retrieved is a silent false-negative. Mitigate with deep, diverse pools — bound, not eliminate. The multi-gold set is *additive* to single-gold, not a replacement.
+- **α-circularity** (above) — the sharpest risk specific to tuning α against a self-built pool.
+- **Compute cost** of query-gen + sweep at first-encounter — bounded by the background-pass framing + a query-count budget.
+- **Pseudo-gold quality** caps tune quality — LLM-generated queries from chunks may be unrepresentative of real agent queries; validate against the human-labeled fixture before trusting the auto path.
+
+## Program sequence (stages, each gated)
+
+1. **Multi-gold fixture + α-under-nDCG on our corpus.** Gate: pooled+judged multi-gold set built (with non-α legs in the pool); α swept under nDCG shows a smoother, lower-variance curve than single-gold R@5; the located α agrees test+dev.
+2. **Auto-generated per-codebase pseudo-eval.** Gate: query-gen produces a pseudo-eval on an arbitrary corpus; its α-optimum correlates with the human-labeled optimum on our corpus (validation of the auto path).
+3. **Autotune-α pass.** Gate: a background pass, gated on post-enrichment (`0 unenriched`), sweeps + persists per-corpus α per-slot; graceful-skip without a local model; first-index unaffected.
+4. **Query-type classifier (optional terminal).** Gate: per-query α routing beats the single per-corpus α on the multi-gold nDCG, by more than the noise floor on test+dev.
+
+## Relationship to other work
+
+Shares the gold model + sweep harness with the multi-gold eval work; the SPLADE↔dense viz (in build) shows the same fusion mechanism the tune optimizes. All one program: **multi-gold fixture → auto-pseudo-eval → autotune-α → (classifier).**

--- a/docs/plans/2026-06-25-splade-viz-design.md
+++ b/docs/plans/2026-06-25-splade-viz-design.md
@@ -1,0 +1,37 @@
+# SPLADE↔dense viz — locked design (query-anchored mechanism view)
+
+Locked 2026-06-25 after a 4-critic adversarial review of the v2 static-divergence design (which was found **fatally** mis-framed: it measured the wrong object and mislabeled a difference as a value). This is the reframe; it must survive a second adversarial pass before build.
+
+> **Update — second adversarial pass resolved the open questions → v3 (build spec).** Verdict: REFINE-AND-BUILD (frame survives, no FATAL). The four §"Open questions" below were each answered against this doc's hopeful framing: (1) feasibility — `cqs serve` holds no models and the daemon *discards* the three legs, so it's a real cross-surface feature (additive `legs` output on the retrieval core + a daemon `search_legs` verb + serve as a daemon-client), NOT a thin endpoint; (2) representativeness — the eval-gold driver is hybrid-flattering (0–36pp by category; 2 of 8 earn ~0), so the default is a **stratified tour with a pinned per-category anchor** that shows the zero-uplift categories too; (3) legibility — one hue can't carry 4-set Venn, so **step-through on a dimmed base** + the win number rides **text**, not color; (4) honesty — the per-chunk +/− "win" was the v2 sin re-imported (and the fusion math here was misstated: dense is *raw* cosine `[-1,1]`, only sparse is min-max'd, `d=0` is *injected* for SPLADE-only chunks), so the win signal is the **query-level R@K delta (fused vs dense-alone)**, attributable to the fusion not isolable to SPLADE per-chunk. Build is staged: Stage 1 = the `search_legs` backend; Stage 2 = the frontend (step-through, stratified tour, text-win, deck.gl renderer).
+
+## The correction that forced the reframe
+Production hybrid is **query-centric**, not chunk-centric, and the SPLADE↔dense fusion is **linear interpolation**, not RRF:
+- `query.rs:642` dense = HNSW(query→chunks); `:654` sparse = `SpladeIndex::search`(query→chunks); `:747` fuses `α·dense + (1−α)·sparse` over min-max-normalized scores (`CQS_SPLADE_ALPHA`). RRF (`rrf_fuse`) is the separate semantic+FTS leg; the SPLADE leg never touches it.
+- v2's `1−Jaccard@k(dense-kNN, splade-kNN)` was chunk→chunk — a different object than production's query→chunk fusion, and a *difference* (not a *value*): "gold = optimum" was a lie the color would tell.
+
+## The frame
+**Position = the dense semantic map; the query drives the action.** Don't summarize the relationship in a static scalar — *show the mechanism*.
+
+- **Base layer (unchanged):** the existing `cqs serve` cluster view — dense-768 → UMAP → `chunks.umap_x/umap_y`, rendered by `cluster-3d.js` (x=umap_x, z=umap_y). This is honest "semantic context" *only*; it is explicitly NOT a divergence geography. Document on-surface that the plane is dense-cosine UMAP (stochastic, locally faithful, globally distorted, NOT metric) and that SPLADE structure is intentionally non-positional.
+- **Interaction (the new core):** enter a query → highlight three overlaid point-sets on the map:
+  - **dense top-k** (HNSW leg),
+  - **SPLADE top-k** (`SpladeIndex::search` leg),
+  - the **α-fused result** (what production returns).
+  You watch the fusion pull in SPLADE's lexical matches that dense ranked low. Optionally draw on-demand edges from a fused-result chunk to its SPLADE-leg origin when it's dense-far — the "hybrid earns its keep" relation shown as an explicit link across the distorted plane, not implied by proximity.
+- **"Hybrid wins" made honest:** the chunks the fused rank **elevates over dense-alone** are the candidates; overlay the **eval gold** and the elevated-AND-relevant ones light up as *genuine* wins (helpful, +) vs elevated-but-irrelevant (harmful, −). That signed-against-gold quantity is the only thing that may be labeled "where hybrid earns its keep" — answering the "optimum point" question truthfully.
+- **Teaching layer (mandatory, from the interpretive critic):** click a chunk → surface the specific SPLADE-leg neighbors dense missed + the dominant shared **tokens** (decode `top_k_token_ids` via the tokenizer). Turns "color = mystery scalar" into "SPLADE pulled THIS toward THESE on THESE tokens dense ignored" — the two-complementary-spaces-fused-at-retrieval lesson, made visible.
+
+## The static divergence map → optional secondary "explore" mode
+v2's `1−Jaccard@k` is demoted to an optional, honestly-LABELED *descriptive* overlay ("lexical-vs-semantic neighborhood divergence; descriptive, NOT a hybrid-win signal"), gated on a saturation check (sample ~500 chunks, k-sweep, drop if the divergence distribution pins near 1.0), with exact brute-force dense-kNN (not ef-bounded HNSW). It is never the headline and never labeled a value/wins map.
+
+## Build (lightest principled path)
+Reuse the retrieval that already exists — no new persisted column, no schema bump for the headline mode.
+- **OPEN (re-review must resolve):** does `cqs serve` expose the dense / SPLADE / fused legs **separately**, or only the final fused result? The mechanism view needs all three per query. If only fused is exposed, add a debug/observe endpoint that returns the three rankings for a query (the daemon already computes them in `query.rs`; surface them rather than recompute).
+- Frontend: extend `cluster-3d.js` — a query box (search-highlight likely already exists) → three highlight styles + the click-inspector + optional edges. Y-axis: in the divergence *explore* mode, lift Y by the scalar (don't keep n_callers as Y while coloring by divergence); in the query mode, keep the dense plane.
+- The eval-gold overlay needs the eval query set (`evals/queries/*.json`) loaded as the "show me the wins" driver.
+
+## Open questions for the second adversarial pass
+1. **Feasibility:** the three-legs-exposed question above — is it a small serve addition or a deeper change?
+2. **Query representativeness:** whose queries drive the view — the eval set, user-typed, or both? A curated set risks cherry-picking; user-typed risks unrepresentative reads.
+3. **Three-way highlight legibility:** can dense/SPLADE/fused overlaid on one map be read, or does it need small-multiples / a toggle?
+4. **Honesty of the gold overlay:** does "elevated-and-relevant" hold up, or does min-max normalization / the α value distort what "elevated over dense" means?


### PR DESCRIPTION
Two parked design ledgers. autotune-alpha (PARKED, not scheduled): per-codebase fusion-weight tuning gated post-summary-enrichment, self-supervised pseudo-eval, nDCG metric, per-corpus-now/classifier-later end-state. SPLADE viz: the query-anchored mechanism-view design + the v3 build spec the second adversarial pass locked (Stage 1 backend building). Docs-only.