### PR TITLE
feat(viz): search_legs backend — surface dense/SPLADE/fused legs (SPLADE viz Stage 1)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -450,9 +450,10 @@ src/
     query.rs    - Query normalization for training pairs
   serve/        - `cqs serve` web UI (gated on `serve` feature; axum + tower)
     mod.rs      - run_server, build_router, server wiring
-    handlers.rs - axum route handlers (search, graph, hierarchy, cluster, chunk detail); each emits a tracing event and wraps sync Store calls in spawn_blocking
+    handlers.rs - axum route handlers (search, search_legs, graph, hierarchy, cluster, chunk detail); each emits a tracing event and wraps sync Store calls in spawn_blocking
+    daemon_client.rs - Synchronous client of the retrieval daemon socket; `/api/search_legs` (SPLADE-fusion inspector) forwards to the daemon rather than loading the embedder/index into the web process
     data.rs     - Wire-format types + builders for `/api/*` (Node/Edge shapes matching Cytoscape.js element-data convention); wire-shaping only — SQL lives in store/serve_queries.rs
-    error.rs    - HTTP-side error type wrapping StoreError → 4xx/5xx responses
+    error.rs    - HTTP-side error type wrapping StoreError → 4xx/5xx responses (incl. 503 ServiceUnavailable for daemon-down mechanism mode)
     assets.rs   - Static assets baked into the binary via `include_str!` (index.html + app.css + app.js; no request-time filesystem reads)
     auth.rs     - Per-launch auth token: 256-bit URL-safe base64, constant-time compare, Bearer/cookie/?token= surfaces (#1118 / SEC-7)
     tests.rs    - Router + auth integration tests (test_router_with_auth helper, host allowlist, gzip)

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -273,6 +273,48 @@ impl SearchArgs {
     }
 }
 
+/// Arguments for the `search-legs` SPLADE-fusion inspector verb.
+///
+/// Surfaces the three pre-fusion retrieval legs (dense cosine, sparse SPLADE,
+/// fused) for a query. A focused subset of [`SearchArgs`] — only the knobs that
+/// shape the retrieval pool the legs describe (query, `k`, the filter knobs, and
+/// the SPLADE α). SPLADE is forced on by the adapter, so there is no `--splade`
+/// flag here.
+#[derive(Args, Debug, Clone)]
+pub(crate) struct SearchLegsArgs {
+    /// Search query (quote multi-word queries)
+    pub query: String,
+
+    /// Shared `--limit` arg via `LimitArg` flatten (the `k` of the legs view).
+    #[command(flatten)]
+    pub limit_arg: LimitArg,
+
+    /// Min similarity threshold
+    #[arg(short = 't', long, default_value = "0.3", value_parser = parse_finite_f32)]
+    pub threshold: f32,
+
+    /// Filter by language
+    #[arg(short = 'l', long)]
+    pub lang: Option<String>,
+
+    /// Include only these chunk types in results (e.g., function, struct)
+    #[arg(long, alias = "chunk-type")]
+    pub include_type: Option<Vec<String>>,
+
+    /// Exclude these chunk types from results
+    #[arg(long)]
+    pub exclude_type: Option<Vec<String>>,
+
+    /// Filter by path pattern (glob)
+    #[arg(short = 'p', long)]
+    pub path: Option<String>,
+
+    /// SPLADE fusion weight α (None = per-category router). 1.0 = pure cosine,
+    /// 0.0 = pure sparse.
+    #[arg(long, value_parser = parse_finite_f32)]
+    pub splade_alpha: Option<f32>,
+}
+
 /// Arguments shared between CLI `gather` and batch `gather`.
 #[derive(Args, Debug, Clone)]
 pub(crate) struct GatherArgs {

--- a/src/cli/batch/commands.rs
+++ b/src/cli/batch/commands.rs
@@ -8,8 +8,9 @@ use super::BatchView;
 use crate::cli::args::{
     BlameArgs, CallersArgs, CiArgs, ContextArgs, DeadArgs, DepsArgs, DiffArgs, DriftArgs,
     ExplainArgs, GatherArgs, ImpactArgs, ImpactDiffArgs, NotesListArgs, OnboardArgs, PlanArgs,
-    ReadArgs, ReconcileArgs, RelatedArgs, ReviewArgs, ScoutArgs, SearchArgs, SimilarArgs,
-    StaleArgs, SuggestArgs, TaskArgs, TestMapArgs, TraceArgs, WaitFreshArgs, WhereArgs,
+    ReadArgs, ReconcileArgs, RelatedArgs, ReviewArgs, ScoutArgs, SearchArgs, SearchLegsArgs,
+    SimilarArgs, StaleArgs, SuggestArgs, TaskArgs, TestMapArgs, TraceArgs, WaitFreshArgs,
+    WhereArgs,
 };
 use crate::cli::definitions::{OutputArgs, TextJsonArgs};
 
@@ -51,6 +52,14 @@ pub(crate) enum BatchCmd {
     Search {
         #[command(flatten)]
         args: SearchArgs,
+        #[command(flatten)]
+        #[allow(dead_code, reason = "Task #8: --json accepted for CLI parity")]
+        output: TextJsonArgs,
+    },
+    /// SPLADE-fusion inspector: the three pre-fusion legs (dense / sparse / fused)
+    SearchLegs {
+        #[command(flatten)]
+        args: SearchLegsArgs,
         #[command(flatten)]
         #[allow(dead_code, reason = "Task #8: --json accepted for CLI parity")]
         output: TextJsonArgs,
@@ -450,6 +459,7 @@ macro_rules! for_each_batch_cmd {
 
                 // Not pipeable — queries, paths, git refs.
                 (Search,     dispatch_search,       "search",      false)
+                (SearchLegs, dispatch_search_legs,  "search-legs", false)
                 (Gather,     dispatch_gather,       "gather",      false)
                 (Trace,      dispatch_trace,        "trace",       false)
                 (Dead,       dispatch_dead,         "dead",        false)

--- a/src/cli/batch/handlers/mod.rs
+++ b/src/cli/batch/handlers/mod.rs
@@ -35,7 +35,7 @@ pub(super) use misc::{
     dispatch_ping, dispatch_plan, dispatch_reconcile, dispatch_refresh, dispatch_scout,
     dispatch_status, dispatch_task, dispatch_wait_fresh, dispatch_where,
 };
-pub(super) use search::dispatch_search;
+pub(super) use search::{dispatch_search, dispatch_search_legs};
 
 use super::BatchView;
 use anyhow::Result;

--- a/src/cli/batch/handlers/search.rs
+++ b/src/cli/batch/handlers/search.rs
@@ -3,10 +3,10 @@
 use anyhow::{bail, Result};
 
 use super::super::BatchView;
-use crate::cli::args::SearchArgs;
+use crate::cli::args::{SearchArgs, SearchLegsArgs};
 use crate::cli::commands::search::query::{
-    merge_references, prepare_query, query_core, retrieve_project, retrieve_ref_scoped, Prepared,
-    ProjectSurface, QueryArgs,
+    merge_references, prepare_query, query_core, retrieve_project, retrieve_ref_scoped,
+    search_legs_core, Prepared, ProjectSurface, QueryArgs,
 };
 // Shared search `--limit` cap. The CLI dispatcher clamps `cli.limit` to the
 // same constant (`cli::dispatch`), so daemon-up and daemon-down invocations
@@ -265,6 +265,95 @@ pub(in crate::cli::batch) fn dispatch_search(
 
     let origins = result_origins(&output.results);
     attach_stale_origins_meta(ctx, args, &origins, &mut value);
+    Ok(value)
+}
+
+/// Build the surface-agnostic [`QueryArgs`] for the SPLADE-leg inspector from
+/// the wire [`SearchLegsArgs`].
+///
+/// Forces `splade = true` (the inspector's whole point is fusion) and mirrors
+/// the daemon search posture (`always_route = true`, `fts_first = false`) so the
+/// query preparation — embedding, SPLADE encoding, filter, base-index selection
+/// — is the same one `dispatch_search` would run. Token packing / parent
+/// expansion / overlay are off: the legs describe raw retrieval, not the packed
+/// final view.
+fn legs_query_args(args: &SearchLegsArgs) -> QueryArgs {
+    QueryArgs {
+        query: args.query.clone(),
+        limit: args.limit_arg.limit.clamp(1, SEARCH_LIMIT_CAP),
+        name_only: false,
+        lang: args.lang.clone(),
+        include_type: args.include_type.clone(),
+        exclude_type: args.exclude_type.clone(),
+        path: args.path.clone(),
+        pattern: None,
+        include_docs: false,
+        rrf: false,
+        rerank: false,
+        // Force SPLADE on — the inspector exists to show the fusion legs.
+        splade: true,
+        splade_alpha: args.splade_alpha,
+        threshold: args.threshold,
+        name_boost: 0.2,
+        no_demote: false,
+        tokens: None,
+        expand_parent: false,
+        force_base_index: std::env::var("CQS_FORCE_BASE_INDEX").as_deref() == Ok("1"),
+        json_overhead: 0,
+        always_route: true,
+        fts_first: false,
+        // The legs are the side channel; per-result rank_signals are not needed
+        // for the mechanism view and would only add cost to the final scoring.
+        record_rank_signals: false,
+        overlay: false,
+    }
+}
+
+/// Validate the legs filter args, reusing the search filter validation by
+/// projecting `SearchLegsArgs` onto the fields it checks.
+fn validate_legs_filter_args(args: &SearchLegsArgs) -> Result<()> {
+    if let Some(l) = &args.lang {
+        l.parse::<cqs::parser::Language>()
+            .map_err(|_| anyhow::anyhow!("Invalid language '{}'", l))?;
+    }
+    if let Some(types) = &args.include_type {
+        let parsed: Result<Vec<cqs::parser::ChunkType>, _> =
+            types.iter().map(|t| t.parse()).collect();
+        parsed.map_err(|e| anyhow::anyhow!("Invalid --include-type: {e}"))?;
+    }
+    if let Some(types) = &args.exclude_type {
+        let parsed: Result<Vec<cqs::parser::ChunkType>, _> =
+            types.iter().map(|t| t.parse()).collect();
+        parsed.map_err(|e| anyhow::anyhow!("Invalid --exclude-type: {e}"))?;
+    }
+    Ok(())
+}
+
+/// Dispatches the `search-legs` SPLADE-fusion inspector and returns the three
+/// pre-fusion legs (dense / sparse / fused) plus per-chunk metadata as JSON.
+///
+/// A thin adapter over [`search_legs_core`]: it validates the filter flags at
+/// the wire boundary (same fast-fail contract as `dispatch_search`), maps the
+/// wire [`SearchLegsArgs`] onto a `splade`-forced [`QueryArgs`], runs the core
+/// through the [`BatchView`] `SearchCtx` impl, and serializes the typed
+/// [`crate::cli::commands::search::query::SearchLegsOutput`] verbatim.
+///
+/// # Errors
+/// Returns an error if a filter flag is invalid, the embedder cannot be
+/// initialized, query embedding/encoding fails, or a store operation fails.
+pub(in crate::cli::batch) fn dispatch_search_legs(
+    ctx: &BatchView,
+    args: &SearchLegsArgs,
+) -> Result<serde_json::Value> {
+    let _span = tracing::info_span!("batch_search_legs", query = %args.query).entered();
+
+    validate_legs_filter_args(args)?;
+
+    let qargs = legs_query_args(args);
+    let output = search_legs_core(ctx, &qargs)?;
+
+    let value = serde_json::to_value(&output)
+        .map_err(|e| anyhow::anyhow!("Failed to serialize search-legs output: {e}"))?;
     Ok(value)
 }
 
@@ -634,6 +723,90 @@ mod tests {
             BatchCmd::Search { args, .. } => args,
             other => panic!("Expected Search, got {:?}", other),
         }
+    }
+
+    /// Parse a `SearchLegsArgs` through the same clap pipeline the daemon runs.
+    fn parse_search_legs_args(cli_args: &[&str]) -> crate::cli::args::SearchLegsArgs {
+        let mut full = vec!["search-legs"];
+        full.extend_from_slice(cli_args);
+        let input = BatchInput::try_parse_from(&full).expect("clap parse failed");
+        match input.cmd {
+            BatchCmd::SearchLegs { args, .. } => args,
+            other => panic!("Expected SearchLegs, got {:?}", other),
+        }
+    }
+
+    /// Wire round-trip: the `search-legs` verb parses to `BatchCmd::SearchLegs`
+    /// with the query, `k`, and SPLADE-α threaded through. Pins the registry
+    /// mapping — a missing/misnamed verb row is the bug class here.
+    #[test]
+    fn search_legs_verb_parses_from_wire_tokens() {
+        let args =
+            parse_search_legs_args(&["error handling", "--limit", "7", "--splade-alpha", "0.3"]);
+        assert_eq!(args.query, "error handling");
+        assert_eq!(args.limit_arg.limit, 7);
+        assert_eq!(args.splade_alpha, Some(0.3));
+    }
+
+    /// The verb appears in the dispatch table's command-name set (so the
+    /// exhaustive macro routed it) and is NOT pipeable (query-based).
+    #[test]
+    fn search_legs_verb_is_registered_and_not_pipeable() {
+        let cmd = BatchInput::try_parse_from(["search-legs", "q"])
+            .expect("clap parse")
+            .cmd;
+        assert_eq!(cmd.command_name(), "search-legs");
+        assert!(
+            !cmd.is_pipeable(),
+            "search-legs is query-based, not function-name-piped"
+        );
+    }
+
+    /// Full daemon round-trip through `dispatch_search_legs` with a real
+    /// embedder but NO SPLADE index built: the query embeds, fusion does not run
+    /// (no sparse index), so the envelope carries `legs: null` and a `results`
+    /// array. Exercises the whole adapter → core → store path. Skipped when the
+    /// embedder can't init (CI-without-model).
+    #[cfg(feature = "slow-tests")]
+    #[test]
+    fn search_legs_dispatch_round_trip_no_splade_returns_null_legs() {
+        let embedder = match cqs::Embedder::new_cpu(cqs::embedder::ModelConfig::resolve(None, None))
+        {
+            Ok(e) => e,
+            Err(e) => {
+                eprintln!("skipping search-legs round-trip: embedder init failed: {e}");
+                return;
+            }
+        };
+
+        let (_dir, ctx) = ctx_with_chunks(vec![make_chunk(
+            "src/lib.rs:1:legs0001",
+            "src/lib.rs",
+            Language::Rust,
+            ChunkType::Function,
+            "parse_config",
+            "fn parse_config(path: &str) -> Config",
+            "fn parse_config(path: &str) -> Config { Config::load(path) }",
+        )]);
+        assert!(
+            ctx.adopt_embedder(std::sync::Arc::new(embedder)),
+            "embedder slot must be empty"
+        );
+
+        let args = parse_search_legs_args(&["parse configuration", "--limit", "5"]);
+        let json = dispatch_search_legs(&ctx.build_view(None), &args)
+            .expect("dispatch_search_legs failed");
+
+        assert_eq!(json["query"], "parse configuration");
+        // No SPLADE index in this corpus, so fusion did not run.
+        assert!(
+            json["legs"].is_null(),
+            "legs must be null when SPLADE fusion did not run; got {json}"
+        );
+        assert!(
+            json["results"].is_array(),
+            "results must be present even with no fusion; got {json}"
+        );
     }
 
     /// Exact-name `--name-only` query returns the matching chunk as the *top*

--- a/src/cli/commands/search/query.rs
+++ b/src/cli/commands/search/query.rs
@@ -1058,6 +1058,128 @@ fn run_project_search<Mode>(
     }
 }
 
+// ─── SPLADE-leg inspector (search_legs) ─────────────────────────────────────
+//
+// The mechanism-mode surface: surface the three pre-fusion retrieval legs
+// (dense cosine, sparse SPLADE, fused) for a query, reusing the SAME query
+// preparation (`prepare_query`) the production search uses, then calling
+// `Store::search_hybrid_legs`. `search_legs_core` is the surface-agnostic core;
+// the daemon `dispatch_search_legs` adapter is the thin wrapper over it.
+
+/// Chunk metadata returned alongside the legs so a consumer can resolve a leg's
+/// `chunk_id` to a path/name/line range without a second query. Mirrors the
+/// fields the inspector needs from a `SearchResult`'s [`cqs::store::ChunkSummary`].
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct LegChunkMeta {
+    /// Chunk ID (joins to `dense`/`sparse`/`fused` leg entries by `chunk_id`).
+    pub chunk_id: String,
+    /// Source file path (forward-slash normalized, as stored).
+    #[serde(serialize_with = "cqs::serialize_path_normalized")]
+    pub file: std::path::PathBuf,
+    /// Function/struct/etc. name.
+    pub name: String,
+    /// 1-indexed start line.
+    pub line_start: u32,
+    /// 1-indexed end line.
+    pub line_end: u32,
+}
+
+/// Output of [`search_legs_core`]: the three pre-fusion legs plus per-chunk
+/// metadata for the final result set.
+///
+/// `legs` is `None` when the SPLADE fusion path did not run for this query
+/// (SPLADE could not be enabled — e.g. no SPLADE index built, or the query
+/// short-circuited to FTS-by-name before embedding). The inspector treats a
+/// `None` as "mechanism view unavailable for this query", distinct from an
+/// empty-but-present leg set.
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct SearchLegsOutput {
+    /// Echo of the resolved query string.
+    pub query: String,
+    /// The three pre-fusion legs, or `None` when fusion did not run.
+    pub legs: Option<cqs::search::SearchLegs>,
+    /// Chunk metadata for the final ranked result set (path/name/lines), in
+    /// final-rank order.
+    pub results: Vec<LegChunkMeta>,
+}
+
+/// Surface-agnostic core for the SPLADE-leg inspector.
+///
+/// Forces SPLADE on (`args.splade = true` is the caller's responsibility — the
+/// adapter sets it), runs the shared [`prepare_query`] prelude so the embedding,
+/// SPLADE encoding, filter, and base-index selection are byte-identical to the
+/// production search, then calls [`cqs::Store::search_hybrid_legs`] to capture
+/// the three legs WITHOUT changing the fused result.
+///
+/// Returns `legs: None` (with the dense-only results still populated) when the
+/// query short-circuited before fusion or the project surface resolved no
+/// SPLADE index — the three-leg view is only defined when fusion ran.
+pub(crate) fn search_legs_core(
+    ctx: &dyn search_ctx::SearchCtx,
+    args: &QueryArgs,
+) -> Result<SearchLegsOutput> {
+    let _span = tracing::info_span!("search_legs_core", query_len = args.query.len()).entered();
+
+    let prepared = match prepare_query(ctx, args, ProjectSurface::Resolve)? {
+        // FTS-by-name short-circuited before any embedding/fusion ran: there is
+        // no dense or sparse leg to surface. Return the results with no legs.
+        Prepared::ShortCircuit(results) => {
+            return Ok(SearchLegsOutput {
+                query: args.query.clone(),
+                legs: None,
+                results: leg_chunk_meta(&results),
+            });
+        }
+        Prepared::Dense(p) => p,
+    };
+
+    let splade_arg = prepared
+        .splade_index
+        .as_deref()
+        .zip(prepared.splade_query.as_ref());
+
+    let (code_results, legs) = ctx.store().search_hybrid_legs(
+        &prepared.query_embedding,
+        &prepared.filter,
+        prepared.search_limit,
+        args.threshold,
+        prepared.index.as_deref(),
+        splade_arg,
+    )?;
+
+    if legs.is_none() {
+        // SPLADE was not active for this query (no index resolved on the project
+        // surface, or the filter disabled it). The dense-only results still come
+        // back; the inspector reports "no fusion" via the `None` legs.
+        tracing::debug!("search_legs: SPLADE fusion did not run; returning dense-only results");
+    }
+
+    let results: Vec<UnifiedResult> = code_results.into_iter().map(UnifiedResult::Code).collect();
+    Ok(SearchLegsOutput {
+        query: args.query.clone(),
+        legs,
+        results: leg_chunk_meta(&results),
+    })
+}
+
+/// Project a result set into the per-chunk metadata the inspector joins to the
+/// leg entries by `chunk_id`.
+fn leg_chunk_meta(results: &[UnifiedResult]) -> Vec<LegChunkMeta> {
+    results
+        .iter()
+        .map(|r| {
+            let UnifiedResult::Code(sr) = r;
+            LegChunkMeta {
+                chunk_id: sr.chunk.id.clone(),
+                file: sr.chunk.file.clone(),
+                name: sr.chunk.name.clone(),
+                line_start: sr.chunk.line_start,
+                line_end: sr.chunk.line_end,
+            }
+        })
+        .collect()
+}
+
 // ─── Multi-store fan-out (the seam) ─────────────────────────────────────────
 //
 // The same prepared query that drives the single-store project path also drives

--- a/src/cli/commands/serve.rs
+++ b/src/cli/commands/serve.rs
@@ -107,7 +107,12 @@ pub(crate) fn cmd_serve(port: u16, bind: String, open: bool, no_auth: bool) -> R
         }
     }
 
-    cqs::serve::run_server(store, bind_addr, false, auth)
+    // The retrieval daemon's socket — `/api/search_legs` forwards to it (the
+    // serve process holds no embedder/index, so mechanism mode requires
+    // `cqs watch --serve`). Same path resolution the CLI client uses.
+    let daemon_socket = cqs::daemon_translate::daemon_socket_path(&cqs_dir);
+
+    cqs::serve::run_server(store, bind_addr, false, auth, Some(daemon_socket))
 }
 
 /// Reject URLs containing shell metacharacters before handing them to

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -16,6 +16,11 @@ pub mod synonyms;
 // their own (mostly `pub(crate)`) visibility.
 pub use scoring::knob;
 
+// The SPLADE-fusion leg structs surfaced by `Store::search_hybrid_legs`. Public
+// so the daemon/serve inspector surfaces (and integration tests) can serialize
+// the three pre-fusion rankings.
+pub use query::{DenseLegEntry, FusedLegEntry, SearchLegs, SparseLegEntry};
+
 use crate::store::helpers::{ChunkSummary, SearchResult};
 use crate::store::{Store, StoreError};
 

--- a/src/search/query.rs
+++ b/src/search/query.rs
@@ -25,6 +25,188 @@ use super::scoring::{
 };
 use super::synonyms::expand_query_for_fts;
 
+/// One chunk's position in the dense (cosine) retrieval leg of SPLADE fusion.
+///
+/// `raw_cosine` is the un-normalized cosine the vector index reported. NOTE the
+/// honest fusion semantics (see [`SearchLegs`]): the dense leg is NOT scaled
+/// before fusion, so this value lives in cosine `[-1, 1]`, not `[0, 1]`.
+///
+/// `present_in_pool` distinguishes "the dense retriever returned this chunk and
+/// it ranked low" (`true`) from "the dense retriever never retrieved this chunk;
+/// fusion injected `raw_cosine = 0.0` for it" (`false`). A chunk found only by
+/// the sparse leg appears here with `present_in_pool = false`, `raw_cosine =
+/// 0.0`, and `rank = 0` — its dense state is *absent*, not *zero-similarity*.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DenseLegEntry {
+    /// Chunk ID (matches `Store` chunk IDs and the other legs' `chunk_id`).
+    pub chunk_id: String,
+    /// Un-normalized cosine in `[-1, 1]` when present; `0.0` (injected) when not.
+    pub raw_cosine: f32,
+    /// 1-indexed rank within the dense pool when present; `0` when absent
+    /// (`rank == 0` iff `present_in_pool == false`).
+    pub rank: usize,
+    /// Whether the dense retriever actually returned this chunk.
+    pub present_in_pool: bool,
+}
+
+/// One chunk's position in the sparse (SPLADE) retrieval leg of SPLADE fusion.
+///
+/// Carries BOTH the value fusion uses and the raw measurement:
+/// - `minmax_score` is the query-relative min-max normalization
+///   (`raw_splade_dot / max_sparse`) in `[0, 1]` — the value that enters the
+///   fusion sum. `max_sparse` is the maximum dot over THIS query's sparse pool,
+///   so the same chunk can normalize differently across queries.
+/// - `raw_splade_dot` is the un-normalized query·document SPLADE dot product —
+///   stable across queries, which token-attribution inspection needs (the
+///   min-max value is query-relative and not comparable across runs).
+///
+/// `present_in_pool` has the same meaning as on [`DenseLegEntry`]: `false`
+/// marks a chunk the sparse retriever never returned (both scores injected
+/// `0.0`, `rank = 0`).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SparseLegEntry {
+    /// Chunk ID (matches `Store` chunk IDs and the other legs' `chunk_id`).
+    pub chunk_id: String,
+    /// Query-relative min-max normalized score in `[0, 1]` (the fused value).
+    pub minmax_score: f32,
+    /// Un-normalized SPLADE dot product (stable across queries).
+    pub raw_splade_dot: f32,
+    /// 1-indexed rank within the sparse pool when present; `0` when absent
+    /// (`rank == 0` iff `present_in_pool == false`).
+    pub rank: usize,
+    /// Whether the sparse retriever actually returned this chunk.
+    pub present_in_pool: bool,
+}
+
+/// One chunk's position in the fused (final pre-truncation) ranking.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct FusedLegEntry {
+    /// Chunk ID (matches `Store` chunk IDs and the other legs' `chunk_id`).
+    pub chunk_id: String,
+    /// The fused score `score = α·dense_raw_cosine + (1−α)·sparse_minmax`.
+    pub fused_score: f32,
+    /// 1-indexed rank in the fused ranking.
+    pub rank: usize,
+}
+
+/// The three pre-fusion retrieval legs surfaced for the SPLADE inspector.
+///
+/// HONEST FUSION SEMANTICS (the inspector must present these, not hide them):
+/// the fused score is
+/// `α·dense_raw_cosine([-1, 1]) + (1−α)·sparse_minmax([0, 1])`. The two legs
+/// are on ASYMMETRIC scales — the dense leg is the raw cosine and is NOT
+/// normalized, while the sparse leg is min-max normalized to `[0, 1]` using a
+/// `max_sparse` that is computed per-query (so a chunk's `minmax_score` is not
+/// comparable across queries; its `raw_splade_dot` is). `α = filter.splade_alpha`.
+///
+/// `dense` and `sparse` are each built over the UNION of candidate IDs from
+/// both legs (sorted by their own leg's rank, present entries first), so a
+/// consumer can align all three arrays by `chunk_id` and read, per chunk,
+/// whether each leg retrieved it (`present_in_pool`) and at what raw score.
+/// `fused` is the post-sort, post-truncate ranking the final result list is
+/// built from — `fused[i].chunk_id` is the i-th candidate fusion produced.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SearchLegs {
+    /// Dense (cosine) leg over the candidate union.
+    pub dense: Vec<DenseLegEntry>,
+    /// Sparse (SPLADE) leg over the candidate union.
+    pub sparse: Vec<SparseLegEntry>,
+    /// Fused leg: the final pre-truncation ranking.
+    pub fused: Vec<FusedLegEntry>,
+}
+
+/// Build the three [`SearchLegs`] from the in-flight fusion state.
+///
+/// Called only on the `capture_legs` path of `search_hybrid_inner`, so its
+/// allocations never touch the production hot path. Every input is borrowed
+/// from data the fusion already computed; this function only reshapes it into
+/// the leg structs (no re-retrieval, no re-scoring).
+///
+/// `dense_results` / `sparse_results` are each already sorted by their leg's
+/// score descending (the vector index and `BoundedScoreHeap::into_sorted_vec`
+/// respectively), so the enumeration index is the 1-indexed leg rank. `fused`
+/// is the sorted-and-truncated fused ranking.
+fn build_search_legs(
+    dense_results: &[crate::index::IndexResult],
+    dense_scores: &std::collections::HashMap<&str, f32>,
+    sparse_results: &[crate::index::IndexResult],
+    sparse_scores: &std::collections::HashMap<&str, f32>,
+    max_sparse: f32,
+    all_ids: &[&str],
+    fused: &[crate::index::IndexResult],
+) -> SearchLegs {
+    // Per-leg rank maps from the already-sorted result vecs. Insertion-order
+    // dedup (`or_insert`) keeps the first (best-ranked) occurrence, matching
+    // the `sparse_ranks` convention used by the rank-signals recorder.
+    let mut dense_rank: std::collections::HashMap<&str, usize> =
+        std::collections::HashMap::with_capacity(dense_results.len());
+    for (i, r) in dense_results.iter().enumerate() {
+        dense_rank.entry(r.id.as_str()).or_insert(i + 1);
+    }
+    // Raw SPLADE dot per id (un-normalized). `sparse_scores` holds the min-max
+    // value; the raw dot lives on `sparse_results.score`.
+    let mut sparse_rank: std::collections::HashMap<&str, usize> =
+        std::collections::HashMap::with_capacity(sparse_results.len());
+    let mut sparse_raw: std::collections::HashMap<&str, f32> =
+        std::collections::HashMap::with_capacity(sparse_results.len());
+    for (i, r) in sparse_results.iter().enumerate() {
+        if sparse_rank.insert(r.id.as_str(), i + 1).is_none() {
+            sparse_raw.insert(r.id.as_str(), r.score);
+        }
+    }
+
+    // Dense + sparse legs over the candidate union, in `all_ids` order (dense
+    // pool first, then sparse-only — the same deterministic order fusion used).
+    let mut dense = Vec::with_capacity(all_ids.len());
+    let mut sparse = Vec::with_capacity(all_ids.len());
+    for &id in all_ids {
+        let dense_present = dense_scores.contains_key(id);
+        dense.push(DenseLegEntry {
+            chunk_id: id.to_string(),
+            // Mirrors the fusion `unwrap_or(0.0)`: absent ⇒ injected zero.
+            raw_cosine: dense_scores.get(id).copied().unwrap_or(0.0),
+            rank: dense_rank.get(id).copied().unwrap_or(0),
+            present_in_pool: dense_present,
+        });
+        let sparse_present = sparse_scores.contains_key(id);
+        sparse.push(SparseLegEntry {
+            chunk_id: id.to_string(),
+            minmax_score: sparse_scores.get(id).copied().unwrap_or(0.0),
+            raw_splade_dot: sparse_raw.get(id).copied().unwrap_or(0.0),
+            rank: sparse_rank.get(id).copied().unwrap_or(0),
+            present_in_pool: sparse_present,
+        });
+    }
+
+    // Sort each leg so present entries lead in rank order; absent entries
+    // (rank 0) sink to the tail keeping `all_ids` order among themselves. This
+    // makes the array directly readable as "the leg's ranking, then the chunks
+    // the other leg contributed".
+    dense.sort_by_key(|e| if e.rank == 0 { usize::MAX } else { e.rank });
+    sparse.sort_by_key(|e| if e.rank == 0 { usize::MAX } else { e.rank });
+
+    let fused_leg = fused
+        .iter()
+        .enumerate()
+        .map(|(i, r)| FusedLegEntry {
+            chunk_id: r.id.clone(),
+            fused_score: r.score,
+            rank: i + 1,
+        })
+        .collect();
+
+    // `max_sparse` is referenced for documentation parity with the fusion math;
+    // the normalized values are already in `sparse_scores`. Keep the param so
+    // the signature names the query-relative normalizer the doc comment cites.
+    let _ = max_sparse;
+
+    SearchLegs {
+        dense,
+        sparse,
+        fused: fused_leg,
+    }
+}
+
 /// Resolve the type-boost factor used by `finalize_results` Step 4b.
 ///
 /// Multiplicative boost applied to chunks whose type matches the
@@ -581,17 +763,81 @@ impl<Mode> Store<Mode> {
             &crate::splade::SparseVector,
         )>,
     ) -> Result<Vec<SearchResult>, StoreError> {
+        // Thin wrapper: production callers never pay for leg capture. The legs
+        // arm allocates nothing when `capture_legs == false`, so the fused
+        // result this returns is byte-for-byte the historical output.
+        let (results, _legs) =
+            self.search_hybrid_inner(query, filter, limit, threshold, index, splade, false)?;
+        Ok(results)
+    }
+
+    /// Like [`Self::search_hybrid`], but additionally surfaces the three
+    /// pre-fusion retrieval legs (dense cosine, sparse SPLADE, fused) for the
+    /// SPLADE inspector, WITHOUT changing the fused result.
+    ///
+    /// Returns `(results, Some(legs))` when the SPLADE fusion path actually
+    /// ran, and `(results, None)` when it short-circuited to dense-only
+    /// retrieval (SPLADE disabled in the filter, or no SPLADE index supplied) —
+    /// the three-leg view is only meaningful when fusion happened, so the
+    /// `None` is honest rather than a synthesized degenerate leg set.
+    ///
+    /// The `results` returned here are identical to what
+    /// [`Self::search_hybrid`] returns for the same arguments; the legs are a
+    /// pure side channel captured during fusion.
+    pub fn search_hybrid_legs(
+        &self,
+        query: &Embedding,
+        filter: &SearchFilter,
+        limit: usize,
+        threshold: f32,
+        index: Option<&dyn VectorIndex>,
+        splade: Option<(
+            &crate::splade::index::SpladeIndex,
+            &crate::splade::SparseVector,
+        )>,
+    ) -> Result<(Vec<SearchResult>, Option<SearchLegs>), StoreError> {
+        self.search_hybrid_inner(query, filter, limit, threshold, index, splade, true)
+    }
+
+    /// Shared body for [`Self::search_hybrid`] and [`Self::search_hybrid_legs`].
+    ///
+    /// `capture_legs` gates EVERY leg allocation: when `false` the function
+    /// runs the exact historical fusion code and returns `None` legs, so the
+    /// production hot path (`search_hybrid`) is unchanged. When `true` it
+    /// additionally materializes the three pre-fusion rankings during the same
+    /// fusion pass — so the captured `fused` leg is, by construction, the same
+    /// ranking the result list is built from, not a parallel recomputation.
+    #[allow(clippy::too_many_arguments)]
+    fn search_hybrid_inner(
+        &self,
+        query: &Embedding,
+        filter: &SearchFilter,
+        limit: usize,
+        threshold: f32,
+        index: Option<&dyn VectorIndex>,
+        splade: Option<(
+            &crate::splade::index::SpladeIndex,
+            &crate::splade::SparseVector,
+        )>,
+        capture_legs: bool,
+    ) -> Result<(Vec<SearchResult>, Option<SearchLegs>), StoreError> {
         // The "not enabled OR no index" guard and the `splade` unwrap collapse
         // into a single match so the unwrap branch is structurally impossible.
+        // The dense-only fallbacks carry `None` legs: the three-leg view is
+        // only defined when SPLADE fusion ran.
         let (splade_index, sparse_query) = match (filter.enable_splade, splade) {
             (false, _) => {
-                return self.search_filtered_with_index(query, filter, limit, threshold, index);
+                let results =
+                    self.search_filtered_with_index(query, filter, limit, threshold, index)?;
+                return Ok((results, None));
             }
             (true, None) => {
                 tracing::debug!(
                     "SPLADE requested but index unavailable, falling back to dense-only search"
                 );
-                return self.search_filtered_with_index(query, filter, limit, threshold, index);
+                let results =
+                    self.search_filtered_with_index(query, filter, limit, threshold, index)?;
+                return Ok((results, None));
             }
             (true, Some(s)) => s,
         };
@@ -778,6 +1024,26 @@ impl<Mode> Store<Mode> {
             fused_map.insert(r.id.clone(), r.score);
         }
 
+        // Capture the three pre-fusion legs for the SPLADE inspector. Gated
+        // entirely behind `capture_legs`: when false NOTHING below this point
+        // allocates, so the fused result the production path returns is
+        // byte-identical. The legs are built from the SAME `dense_results`,
+        // `sparse_results`, `max_sparse`, and `fused` the fusion just used, so
+        // they describe the exact ranking the result list is derived from.
+        let legs = if capture_legs {
+            Some(build_search_legs(
+                &dense_results,
+                &dense_scores,
+                &sparse_results,
+                &sparse_scores,
+                max_sparse,
+                &all_ids,
+                &fused,
+            ))
+        } else {
+            None
+        };
+
         // Capture the sparse leg's per-result rank for the `rank_signals`
         // recorder. `sparse_results` is already sorted by sparse score
         // descending (BoundedScoreHeap::into_sorted_vec), so the enumeration
@@ -795,7 +1061,7 @@ impl<Mode> Store<Mode> {
             None
         };
 
-        self.search_by_candidate_ids_with_notes(
+        let results = self.search_by_candidate_ids_with_notes(
             &candidate_ids,
             query,
             filter,
@@ -804,7 +1070,8 @@ impl<Mode> Store<Mode> {
             &notes,
             Some(&fused_map),
             sparse_ranks,
-        )
+        )?;
+        Ok((results, legs))
     }
 
     pub fn search_filtered_with_index(

--- a/src/serve/daemon_client.rs
+++ b/src/serve/daemon_client.rs
@@ -1,0 +1,139 @@
+//! Synchronous client of the retrieval daemon socket for the `cqs serve` web UI.
+//!
+//! The serve process holds no embedder, vector index, or SPLADE index — it
+//! opens the store read-only for the graph/chunk views. The SPLADE-leg
+//! inspector (`/api/search_legs`) needs the live retrieval stack, so instead of
+//! loading the models into the web process it forwards the query to the
+//! retrieval daemon (`cqs watch --serve`) over the SAME Unix socket the CLI
+//! client uses, and returns the daemon's three-leg response.
+//!
+//! The wire protocol mirrors the CLI client (`src/cli/dispatch.rs`): a single
+//! request line `{"command": <verb>, "args": [<argv>...]}` followed by a single
+//! response line `{"status": "ok"|..., "output": <value>}`.
+
+use std::io::{BufRead, Write};
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+
+use super::error::ServeError;
+
+/// Forward a `search-legs` query to the retrieval daemon and return its parsed
+/// `output` JSON (the [`crate::cli::commands`]-built legs payload).
+///
+/// Returns [`ServeError::ServiceUnavailable`] when the socket is absent or the
+/// daemon is unresponsive — the caller renders that as a 503 with the
+/// "mechanism mode requires `cqs watch --serve`" hint rather than silently
+/// falling back to a degraded surface. A daemon error response (status != ok)
+/// surfaces as [`ServeError::Internal`].
+///
+/// `args` are the argv tokens after the verb (e.g. `["my query", "--limit",
+/// "5"]`). This function builds the request frame, runs the round-trip on the
+/// CALLING thread (it does blocking socket I/O — call it from a blocking
+/// context), and parses one response line.
+pub(crate) fn query_search_legs(
+    socket: &Path,
+    args: &[String],
+) -> Result<serde_json::Value, ServeError> {
+    let _span = tracing::info_span!("serve_daemon_client", verb = "search-legs").entered();
+
+    // Socket-absent is the normal "no daemon running" case — a clean 503, no
+    // warn. The hint names the fix.
+    if !socket.exists() {
+        tracing::debug!(path = %socket.display(), "search-legs: daemon socket absent");
+        return Err(daemon_down_error());
+    }
+
+    let stream = match UnixStream::connect(socket) {
+        Ok(s) => s,
+        Err(e) => {
+            // The socket file exists but connect failed — a wedged/crashed
+            // daemon. Warn so the journal explains the 503.
+            tracing::warn!(
+                path = %socket.display(),
+                error = %e,
+                stage = "connect",
+                "search-legs: daemon connect failed"
+            );
+            return Err(daemon_down_error());
+        }
+    };
+
+    // Single shared timeout knob across CLI client and daemon.
+    let timeout = crate::daemon_translate::resolve_daemon_timeout_ms();
+    if let Err(e) = stream.set_read_timeout(Some(timeout)) {
+        tracing::warn!(error = %e, "search-legs: failed to set read timeout");
+    }
+    if let Err(e) = stream.set_write_timeout(Some(timeout)) {
+        tracing::warn!(error = %e, "search-legs: failed to set write timeout");
+    }
+
+    let request = serde_json::json!({
+        "command": "search-legs",
+        "args": args,
+    });
+
+    let mut stream = stream;
+    if let Err(e) = writeln!(stream, "{request}") {
+        tracing::warn!(error = %e, stage = "write", "search-legs: daemon write failed");
+        return Err(daemon_down_error());
+    }
+    if let Err(e) = stream.flush() {
+        tracing::warn!(error = %e, stage = "flush", "search-legs: daemon flush failed");
+        return Err(daemon_down_error());
+    }
+
+    // Bound the response so a rogue daemon can't force an unbounded allocation.
+    let max_response = crate::limits::max_daemon_response_bytes();
+    use std::io::Read as _;
+    let mut reader = std::io::BufReader::new(&stream).take(max_response.saturating_add(1));
+    let mut response_line = String::new();
+    let bytes_read = match reader.read_line(&mut response_line) {
+        Ok(n) => n,
+        Err(e) => {
+            tracing::warn!(error = %e, stage = "read", "search-legs: daemon read failed");
+            return Err(daemon_down_error());
+        }
+    };
+    if bytes_read as u64 > max_response {
+        tracing::warn!(
+            bytes = bytes_read,
+            "search-legs: daemon response exceeded cap"
+        );
+        return Err(ServeError::Internal(
+            "daemon response exceeded size cap".to_string(),
+        ));
+    }
+
+    let resp: serde_json::Value = serde_json::from_str(response_line.trim())
+        .map_err(|e| ServeError::Internal(format!("daemon response parse failed: {e}")))?;
+
+    match resp.get("status").and_then(|v| v.as_str()) {
+        Some("ok") => resp
+            .get("output")
+            .cloned()
+            .ok_or_else(|| ServeError::Internal("daemon ok response missing 'output'".to_string())),
+        Some(other) => {
+            // The daemon ran but the command failed (bad filter flag, embedder
+            // error, …). Surface the daemon's message when present.
+            let detail = resp
+                .get("message")
+                .or_else(|| resp.get("error"))
+                .and_then(|v| v.as_str())
+                .unwrap_or(other)
+                .to_string();
+            tracing::warn!(status = other, detail = %detail, "search-legs: daemon error response");
+            Err(ServeError::Internal(format!("daemon error: {detail}")))
+        }
+        None => Err(ServeError::Internal(
+            "daemon response missing 'status'".to_string(),
+        )),
+    }
+}
+
+/// The canonical "mechanism mode needs the daemon" 503 error.
+fn daemon_down_error() -> ServeError {
+    ServeError::ServiceUnavailable(
+        "mechanism mode requires the retrieval daemon — start it with `cqs watch --serve`"
+            .to_string(),
+    )
+}

--- a/src/serve/error.rs
+++ b/src/serve/error.rs
@@ -26,6 +26,13 @@ pub enum ServeError {
 
     #[error("internal error: {0}")]
     Internal(String),
+
+    /// A required upstream is down — e.g. mechanism mode (`/api/search_legs`)
+    /// when the retrieval daemon socket is absent or unresponsive. Renders 503
+    /// so the client distinguishes "transiently unavailable, retry after
+    /// starting the daemon" from a 4xx/5xx.
+    #[error("service unavailable: {0}")]
+    ServiceUnavailable(String),
 }
 
 #[derive(Serialize)]
@@ -39,6 +46,9 @@ impl IntoResponse for ServeError {
         let (status, code) = match &self {
             ServeError::NotFound(_) => (StatusCode::NOT_FOUND, "not_found"),
             ServeError::BadRequest(_) => (StatusCode::BAD_REQUEST, "bad_request"),
+            ServeError::ServiceUnavailable(_) => {
+                (StatusCode::SERVICE_UNAVAILABLE, "service_unavailable")
+            }
             ServeError::Store(_) | ServeError::Internal(_) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, "internal")
             }

--- a/src/serve/handlers.rs
+++ b/src/serve/handlers.rs
@@ -134,6 +134,23 @@ fn default_search_limit() -> usize {
 }
 
 #[derive(Debug, Deserialize)]
+pub(crate) struct SearchLegsQuery {
+    /// The search query.
+    pub q: String,
+    /// Number of results (`k`). Defaults to `default_legs_k`, clamped 1..=200.
+    #[serde(default = "default_legs_k")]
+    pub k: usize,
+    /// Optional constant SPLADE fusion weight α (overrides the per-category
+    /// router). 1.0 = pure cosine, 0.0 = pure sparse.
+    #[serde(default)]
+    pub splade_alpha: Option<f32>,
+}
+
+fn default_legs_k() -> usize {
+    10
+}
+
+#[derive(Debug, Deserialize)]
 pub(crate) struct HierarchyQuery {
     /// `callers` (BFS up) or `callees` (BFS down). Defaults to `callees`.
     #[serde(default)]
@@ -262,6 +279,74 @@ pub(crate) async fn search(
 
     tracing::info!(matches = matches.len(), "search returned");
     Ok(Json(SearchResponse { matches }))
+}
+
+/// `GET /api/search_legs?q=…&k=…[&splade_alpha=…]` — the SPLADE-fusion
+/// inspector ("mechanism mode").
+///
+/// Unlike the other `/api/*` handlers, this one holds NO retrieval stack in the
+/// serve process: the embedder / vector index / SPLADE index live only in the
+/// retrieval daemon (`cqs watch --serve`). This handler is a CLIENT of that
+/// daemon's socket — it forwards the query as a `search-legs` verb and returns
+/// the daemon's three pre-fusion legs (dense / sparse / fused) verbatim.
+///
+/// If the daemon is down (or no socket path was resolved), it returns a clean
+/// 503 with the "mechanism mode requires `cqs watch --serve`" hint — it never
+/// silently falls back to FTS.
+pub(crate) async fn search_legs(
+    State(state): State<AppState>,
+    Query(params): Query<SearchLegsQuery>,
+) -> Result<Json<serde_json::Value>, ServeError> {
+    tracing::debug!(query = %params.q, "serve::search_legs query received");
+    tracing::info!(q_len = params.q.len(), k = params.k, "serve::search_legs");
+
+    if params.q.trim().is_empty() {
+        return Err(ServeError::BadRequest(
+            "missing query parameter 'q'".to_string(),
+        ));
+    }
+
+    let socket = match &state.daemon_socket {
+        Some(s) => s.clone(),
+        None => {
+            // No socket path was resolved at launch — mechanism mode is
+            // structurally unavailable. Same 503 the daemon-down path returns.
+            return Err(ServeError::ServiceUnavailable(
+                "mechanism mode requires the retrieval daemon — start it with `cqs watch --serve`"
+                    .to_string(),
+            ));
+        }
+    };
+
+    // Build the daemon argv: the verb is supplied by the client; these are the
+    // tokens after it. Clamp `k` to the same bound the name-search handler uses.
+    let k = params.k.clamp(1, 200);
+    let mut args = vec![params.q.clone(), "--limit".to_string(), k.to_string()];
+    if let Some(alpha) = params.splade_alpha {
+        args.push("--splade-alpha".to_string());
+        args.push(alpha.to_string());
+    }
+
+    // The daemon round-trip is blocking socket I/O; run it off the async
+    // executor. The permit cap shares the same semaphore the SQL handlers use
+    // so a fan-out client can't pin unbounded blocking threads.
+    let permit = state
+        .blocking_permits
+        .clone()
+        .acquire_owned()
+        .await
+        .map_err(|e| ServeError::Internal(format!("blocking permit: {e}")))?;
+    let span = tracing::Span::current();
+    let output = tokio::task::spawn_blocking(move || {
+        let _permit = permit;
+        let _entered = span.enter();
+        super::daemon_client::query_search_legs(&socket, &args)
+    })
+    .await
+    .map_err(|e| ServeError::Internal(format!("search_legs join: {e}")))??;
+
+    tracing::info!("serve::search_legs forwarded to daemon");
+    Ok(Json(output))
 }
 
 /// `GET /api/hierarchy/{id}?direction={callers|callees}&depth=N`

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -40,6 +40,7 @@ use crate::store::{ReadOnly, Store};
 
 mod assets;
 mod auth;
+mod daemon_client;
 mod data;
 mod error;
 mod handlers;
@@ -71,6 +72,12 @@ pub(crate) struct AppState {
     pub(crate) store: Arc<Store<ReadOnly>>,
     pub(crate) blocking_permits: Arc<tokio::sync::Semaphore>,
     pub(crate) last_request_epoch: Arc<std::sync::atomic::AtomicU64>,
+    /// Path to the retrieval daemon's Unix socket (the SAME socket the CLI
+    /// connects to). `/api/search_legs` is a CLIENT of this socket — the serve
+    /// process holds no embedder / vector index / SPLADE index, so mechanism
+    /// mode forwards the query to the daemon and returns its three legs. `None`
+    /// when no socket path was resolved (legs mode then always 503s).
+    pub(crate) daemon_socket: Option<Arc<std::path::PathBuf>>,
 }
 
 /// Allowed `Host` header values, built at router-build time from the
@@ -109,6 +116,7 @@ pub fn run_server(
     bind_addr: SocketAddr,
     quiet: bool,
     auth: AuthMode,
+    daemon_socket: Option<std::path::PathBuf>,
 ) -> Result<()> {
     let _span = tracing::info_span!("serve", addr = %bind_addr).entered();
 
@@ -123,6 +131,7 @@ pub fn run_server(
         store: Arc::new(store),
         blocking_permits: Arc::new(tokio::sync::Semaphore::new(permits)),
         last_request_epoch: Arc::clone(&last_request_epoch),
+        daemon_socket: daemon_socket.map(Arc::new),
     };
     let allowed_hosts = allowed_host_set(&bind_addr);
     let idle_minutes = crate::limits::serve_idle_minutes();
@@ -371,6 +380,7 @@ pub(crate) fn build_router(state: AppState, allowed_hosts: AllowedHosts, auth: A
         .route("/api/hierarchy/{id}", get(handlers::hierarchy))
         .route("/api/embed/2d", get(handlers::cluster_2d))
         .route("/api/search", get(handlers::search))
+        .route("/api/search_legs", get(handlers::search_legs))
         .route("/", get(assets::index_html))
         .route("/static/{*path}", get(assets::static_asset))
         .with_state(state);

--- a/src/serve/tests.rs
+++ b/src/serve/tests.rs
@@ -95,6 +95,9 @@ fn fixture_state() -> Fixture {
             // handler shape, not the wall-clock-driven eviction future, so
             // any starting value is fine.
             last_request_epoch: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            // No daemon socket in the handler-shape tests — mechanism mode
+            // (`/api/search_legs`) is exercised by its own dedicated tests.
+            daemon_socket: None,
         }),
         _dir: Some(dir),
     }
@@ -234,6 +237,9 @@ fn populated_fixture(n_chunks: usize, with_umap: bool) -> Fixture {
             // handler shape, not the wall-clock-driven eviction future, so
             // any starting value is fine.
             last_request_epoch: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            // No daemon socket in the handler-shape tests — mechanism mode
+            // (`/api/search_legs`) is exercised by its own dedicated tests.
+            daemon_socket: None,
         }),
         _dir: Some(dir),
     }
@@ -315,6 +321,9 @@ fn single_chunk_fixture(content: &str, vendored: bool) -> (Fixture, String) {
                 crate::limits::serve_blocking_permits(),
             )),
             last_request_epoch: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            // No daemon socket in the handler-shape tests — mechanism mode
+            // (`/api/search_legs`) is exercised by its own dedicated tests.
+            daemon_socket: None,
         }),
         _dir: Some(dir),
     };
@@ -1600,6 +1609,156 @@ async fn host_allowlist_rejects_missing_host_header() {
         body.contains("Host"),
         "rejection body should mention Host, got {body:?}"
     );
+}
+
+// ===== /api/search_legs (mechanism mode) — daemon-client forwarding =====
+//
+// `/api/search_legs` holds NO retrieval stack in the serve process — it is a
+// client of the retrieval daemon socket. These pin: (1) a clean 503 with the
+// "requires `cqs watch --serve`" hint when the daemon is absent, and (2) that
+// a present daemon's three-leg response is forwarded verbatim.
+
+/// A `Fixture` whose `AppState.daemon_socket` points at `socket`.
+fn fixture_state_with_socket(socket: std::path::PathBuf) -> Fixture {
+    let mut fixture = fixture_state();
+    let mut state = fixture.state.take().expect("fixture state");
+    state.daemon_socket = Some(Arc::new(socket));
+    fixture.state = Some(state);
+    fixture
+}
+
+/// Spawn a one-shot fake daemon on `socket`: accept a single connection, read
+/// the request line, hand it to `responder`, and write the response line back.
+/// Returns the join handle (carrying the parsed request for assertions).
+fn spawn_fake_daemon(
+    socket: std::path::PathBuf,
+    response: serde_json::Value,
+) -> std::thread::JoinHandle<serde_json::Value> {
+    use std::io::{BufRead, BufReader, Write};
+    use std::os::unix::net::UnixListener;
+    let listener = UnixListener::bind(&socket).expect("bind fake daemon socket");
+    std::thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("accept");
+        let mut reader = BufReader::new(&stream);
+        let mut line = String::new();
+        reader.read_line(&mut line).expect("read request");
+        let request: serde_json::Value =
+            serde_json::from_str(line.trim()).expect("parse request JSON");
+        let mut w = &stream;
+        writeln!(w, "{response}").expect("write response");
+        w.flush().expect("flush");
+        request
+    })
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn search_legs_503_when_no_daemon_socket() {
+    let fixture = fixture_state(); // daemon_socket: None
+    let state = fixture.state();
+    let app = test_router(state);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/search_legs?q=parse+config&k=5")
+                .header("host", "127.0.0.1:8080")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("oneshot");
+
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let bytes = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+    let body = std::str::from_utf8(&bytes).expect("utf8");
+    assert!(
+        body.contains("cqs watch --serve"),
+        "503 body must name the fix; got {body}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn search_legs_503_when_socket_path_absent() {
+    let dir = TempDir::new().expect("tempdir");
+    let socket = dir.path().join("nonexistent.sock");
+    let fixture = fixture_state_with_socket(socket);
+    let state = fixture.state();
+    let app = test_router(state);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/search_legs?q=foo")
+                .header("host", "127.0.0.1:8080")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("oneshot");
+
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn search_legs_forwards_daemon_legs_response() {
+    let dir = TempDir::new().expect("tempdir");
+    let socket = dir.path().join("daemon.sock");
+
+    // The fake daemon returns a minimal three-leg payload as the `output`.
+    let legs_payload = serde_json::json!({
+        "query": "parse config",
+        "legs": {
+            "dense":  [{"chunk_id": "A", "raw_cosine": 0.9, "rank": 1, "present_in_pool": true}],
+            "sparse": [{"chunk_id": "A", "minmax_score": 1.0, "raw_splade_dot": 0.5, "rank": 1, "present_in_pool": true}],
+            "fused":  [{"chunk_id": "A", "fused_score": 0.7, "rank": 1}]
+        },
+        "results": [{"chunk_id": "A", "file": "src/lib.rs", "name": "parse_config", "line_start": 1, "line_end": 5}]
+    });
+    let daemon_response = serde_json::json!({"status": "ok", "output": legs_payload});
+
+    let handle = spawn_fake_daemon(socket.clone(), daemon_response);
+    // Give the listener a moment to bind before the request connects.
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    let fixture = fixture_state_with_socket(socket);
+    let state = fixture.state();
+    let app = test_router(state);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/search_legs?q=parse+config&k=5&splade_alpha=0.4")
+                .header("host", "127.0.0.1:8080")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("oneshot");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), 65536).await.unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&bytes).expect("parse body JSON");
+
+    // The handler forwards the daemon's `output` verbatim — the three legs are
+    // present at the top level of the response body.
+    assert_eq!(body["query"], "parse config");
+    assert!(body["legs"]["dense"].is_array(), "dense leg forwarded");
+    assert!(body["legs"]["sparse"].is_array(), "sparse leg forwarded");
+    assert!(body["legs"]["fused"].is_array(), "fused leg forwarded");
+    assert_eq!(body["legs"]["sparse"][0]["raw_splade_dot"], 0.5);
+
+    // The daemon saw the right verb + forwarded query/k/α args.
+    let request = handle.join().expect("fake daemon join");
+    assert_eq!(request["command"], "search-legs");
+    let args: Vec<String> = request["args"]
+        .as_array()
+        .expect("args array")
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(args[0], "parse config");
+    assert!(args.contains(&"--limit".to_string()) && args.contains(&"5".to_string()));
+    assert!(args.contains(&"--splade-alpha".to_string()) && args.contains(&"0.4".to_string()));
 }
 
 // ===== per-launch auth token integration tests =====

--- a/tests/search_test.rs
+++ b/tests/search_test.rs
@@ -531,6 +531,287 @@ fn search_hybrid_records_sparse_signal() {
     );
 }
 
+// ===== search_hybrid_legs: the SPLADE-fusion inspector =====
+//
+// `search_hybrid_legs` surfaces the three pre-fusion legs (dense cosine, sparse
+// SPLADE, fused) WITHOUT changing the fused result. These pin: (1) the
+// production hot path is byte-identical with legs on vs off, (2) the captured
+// fused leg equals the production fused ranking, (3) the dense leg carries raw
+// cosine and the sparse leg carries BOTH min-max and raw dot, and (4)
+// `present_in_pool` is false for a leg-exclusive chunk.
+
+/// Build a corpus where the dense and sparse retrieval pools deliberately
+/// DIFFER, so the union carries a dense-only chunk and a sparse-only chunk.
+///
+/// Dense pool (MockIndex): chunks A, B with distinct cosines.
+/// Sparse pool (SPLADE):   chunks B, C.
+/// Union:                  A (dense-only), B (both), C (sparse-only).
+fn legs_corpus() -> (
+    TestStore,
+    Vec<String>,
+    cqs::splade::index::SpladeIndex,
+    cqs::splade::SparseVector,
+    MockIndex,
+    Embedding,
+) {
+    use cqs::splade::index::SpladeIndex;
+
+    let store = TestStore::new();
+    let a = test_chunk("legsDenseOnly", "fn legsDenseOnly() { a }");
+    let b = test_chunk("legsBoth", "fn legsBoth() { b }");
+    let c = test_chunk("legsSparseOnly", "fn legsSparseOnly() { c }");
+    let ids = insert_chunks(&store, &[a, b, c], 1.0);
+
+    // Dense pool: A and B only (C is NOT returned by the dense index).
+    let mock = MockIndex::new(vec![
+        IndexResult {
+            id: ids[0].clone(),
+            score: 0.92,
+        },
+        IndexResult {
+            id: ids[1].clone(),
+            score: 0.61,
+        },
+    ]);
+
+    // Sparse pool: B and C only (A is NOT in the SPLADE index). Token 1 is the
+    // query token; B's weight (0.8) > C's (0.5), so B outranks C in the sparse
+    // leg and its raw dot is the larger value.
+    let splade_index = SpladeIndex::build(vec![
+        (ids[1].clone(), vec![(1, 0.8)]),
+        (ids[2].clone(), vec![(1, 0.5)]),
+    ]);
+    let sparse_query: cqs::splade::SparseVector = vec![(1, 1.0)];
+
+    let query = mock_embedding(1.0);
+    (store, ids, splade_index, sparse_query, mock, query)
+}
+
+fn legs_filter() -> SearchFilter {
+    let mut f = SearchFilter::default();
+    f.enable_splade = true;
+    f.splade_alpha = 0.5;
+    f
+}
+
+/// The production hot path is byte-identical: `search_hybrid` (legs off) and the
+/// results returned by `search_hybrid_legs` (legs on) agree bit-for-bit on
+/// id order and score. Leg capture is a pure side channel.
+#[test]
+fn search_hybrid_legs_production_result_byte_identical() {
+    let (store, _ids, splade_index, sparse_query, mock, query) = legs_corpus();
+    let filter = legs_filter();
+
+    let off = store
+        .search_hybrid(
+            &query,
+            &filter,
+            10,
+            0.0,
+            Some(&mock),
+            Some((&splade_index, &sparse_query)),
+        )
+        .unwrap();
+    let (on, legs) = store
+        .search_hybrid_legs(
+            &query,
+            &filter,
+            10,
+            0.0,
+            Some(&mock),
+            Some((&splade_index, &sparse_query)),
+        )
+        .unwrap();
+
+    assert_eq!(off.len(), on.len(), "legs-on changed the result count");
+    for (a, b) in off.iter().zip(on.iter()) {
+        assert_eq!(a.chunk.id, b.chunk.id, "legs-on changed the result order");
+        assert_eq!(
+            a.score.to_bits(),
+            b.score.to_bits(),
+            "legs-on changed the score bits for {}",
+            a.chunk.id
+        );
+    }
+    assert!(legs.is_some(), "fusion ran, so legs must be present");
+}
+
+/// The captured `fused` leg equals the production fused ranking for the same
+/// query: `legs.fused` (in rank order) is the same id sequence the result list
+/// is built from. (The result list re-sorts via the scoring pipeline, but with
+/// no notes/boosts the fused order is the final order, so they coincide.)
+#[test]
+fn search_hybrid_legs_fused_leg_matches_production_ranking() {
+    let (store, _ids, splade_index, sparse_query, mock, query) = legs_corpus();
+    let filter = legs_filter();
+
+    let (results, legs) = store
+        .search_hybrid_legs(
+            &query,
+            &filter,
+            10,
+            0.0,
+            Some(&mock),
+            Some((&splade_index, &sparse_query)),
+        )
+        .unwrap();
+    let legs = legs.expect("fusion ran");
+
+    // The fused leg ranks are 1..=N and strictly increasing in array order.
+    for (i, e) in legs.fused.iter().enumerate() {
+        assert_eq!(
+            e.rank,
+            i + 1,
+            "fused leg rank must be 1-indexed array position"
+        );
+    }
+    // Fused scores are non-increasing (sorted descending by fusion).
+    for w in legs.fused.windows(2) {
+        assert!(
+            w[0].fused_score >= w[1].fused_score,
+            "fused leg must be sorted by descending score"
+        );
+    }
+    // The result list (no boosts) is exactly the fused leg's id order.
+    let result_ids: Vec<&str> = results.iter().map(|r| r.chunk.id.as_str()).collect();
+    let fused_ids: Vec<&str> = legs.fused.iter().map(|e| e.chunk_id.as_str()).collect();
+    assert_eq!(
+        result_ids, fused_ids,
+        "fused leg order must equal the production result order"
+    );
+}
+
+/// The dense leg carries raw cosine (the index scores) and the sparse leg
+/// carries BOTH the min-max-normalized value and the raw SPLADE dot.
+#[test]
+fn search_hybrid_legs_dense_raw_cosine_sparse_minmax_and_raw_dot() {
+    let (store, ids, splade_index, sparse_query, mock, query) = legs_corpus();
+    let filter = legs_filter();
+
+    let (_results, legs) = store
+        .search_hybrid_legs(
+            &query,
+            &filter,
+            10,
+            0.0,
+            Some(&mock),
+            Some((&splade_index, &sparse_query)),
+        )
+        .unwrap();
+    let legs = legs.expect("fusion ran");
+
+    // Dense leg: A=0.92, B=0.61 are the raw cosines we configured.
+    let dense_of = |id: &str| legs.dense.iter().find(|e| e.chunk_id == id).unwrap();
+    assert_eq!(dense_of(&ids[0]).raw_cosine, 0.92, "A dense raw cosine");
+    assert_eq!(dense_of(&ids[1]).raw_cosine, 0.61, "B dense raw cosine");
+
+    // Sparse leg: raw dot = query_weight(1.0) * doc_weight. B=0.8, C=0.5.
+    // max_sparse = 0.8, so minmax(B) = 1.0 and minmax(C) = 0.5/0.8 = 0.625.
+    let sparse_of = |id: &str| legs.sparse.iter().find(|e| e.chunk_id == id).unwrap();
+    assert!(
+        (sparse_of(&ids[1]).raw_splade_dot - 0.8).abs() < 1e-6,
+        "B raw SPLADE dot"
+    );
+    assert!(
+        (sparse_of(&ids[2]).raw_splade_dot - 0.5).abs() < 1e-6,
+        "C raw SPLADE dot"
+    );
+    assert!(
+        (sparse_of(&ids[1]).minmax_score - 1.0).abs() < 1e-6,
+        "B min-max (the per-query max)"
+    );
+    assert!(
+        (sparse_of(&ids[2]).minmax_score - 0.625).abs() < 1e-6,
+        "C min-max = 0.5/0.8"
+    );
+    // The min-max value differs from the raw dot — both are surfaced.
+    assert_ne!(
+        sparse_of(&ids[2]).minmax_score,
+        sparse_of(&ids[2]).raw_splade_dot,
+        "min-max and raw dot must be distinct values on the leg"
+    );
+}
+
+/// `present_in_pool` is false for a leg-exclusive chunk, and the injected score
+/// for an absent chunk is 0.0 (distinguishing "ranked low" from "not retrieved").
+#[test]
+fn search_hybrid_legs_present_in_pool_flags_leg_exclusive_chunks() {
+    let (store, ids, splade_index, sparse_query, mock, query) = legs_corpus();
+    let filter = legs_filter();
+
+    let (_results, legs) = store
+        .search_hybrid_legs(
+            &query,
+            &filter,
+            10,
+            0.0,
+            Some(&mock),
+            Some((&splade_index, &sparse_query)),
+        )
+        .unwrap();
+    let legs = legs.expect("fusion ran");
+
+    let dense_of = |id: &str| legs.dense.iter().find(|e| e.chunk_id == id).unwrap();
+    let sparse_of = |id: &str| legs.sparse.iter().find(|e| e.chunk_id == id).unwrap();
+
+    // A is dense-only: present in the dense pool, ABSENT from the sparse pool.
+    assert!(dense_of(&ids[0]).present_in_pool, "A is in the dense pool");
+    let a_sparse = sparse_of(&ids[0]);
+    assert!(
+        !a_sparse.present_in_pool,
+        "A was never retrieved by the sparse leg"
+    );
+    assert_eq!(a_sparse.minmax_score, 0.0, "A's sparse score is injected 0");
+    assert_eq!(a_sparse.raw_splade_dot, 0.0, "A's raw dot is injected 0");
+    assert_eq!(a_sparse.rank, 0, "A has no sparse rank (rank 0 == absent)");
+
+    // C is sparse-only: present in the sparse pool, ABSENT from the dense pool.
+    assert!(
+        sparse_of(&ids[2]).present_in_pool,
+        "C is in the sparse pool"
+    );
+    let c_dense = dense_of(&ids[2]);
+    assert!(
+        !c_dense.present_in_pool,
+        "C was never retrieved by the dense leg"
+    );
+    assert_eq!(c_dense.raw_cosine, 0.0, "C's dense cosine is injected 0");
+    assert_eq!(c_dense.rank, 0, "C has no dense rank (rank 0 == absent)");
+
+    // B is in both pools.
+    assert!(dense_of(&ids[1]).present_in_pool, "B is in the dense pool");
+    assert!(
+        sparse_of(&ids[1]).present_in_pool,
+        "B is in the sparse pool"
+    );
+
+    // Every union chunk appears in BOTH legs (the legs span the union).
+    assert_eq!(legs.dense.len(), 3, "dense leg spans the candidate union");
+    assert_eq!(legs.sparse.len(), 3, "sparse leg spans the candidate union");
+}
+
+/// SPLADE disabled in the filter ⇒ no fusion ran ⇒ `legs` is `None`, but the
+/// dense-only results still come back.
+#[test]
+fn search_hybrid_legs_none_when_splade_disabled() {
+    let (store, _ids, splade_index, sparse_query, mock, query) = legs_corpus();
+    let mut filter = SearchFilter::default();
+    filter.enable_splade = false; // no fusion
+
+    let (results, legs) = store
+        .search_hybrid_legs(
+            &query,
+            &filter,
+            10,
+            0.0,
+            Some(&mock),
+            Some((&splade_index, &sparse_query)),
+        )
+        .unwrap();
+    assert!(legs.is_none(), "no fusion ran, so legs must be None");
+    assert!(!results.is_empty(), "dense-only results still returned");
+}
+
 // ===== #37: search_filtered with glob =====
 
 #[test]


### PR DESCRIPTION
Stage 1 (backend only) of the SPLADE-dense mechanism viz. Adds the three pre-fusion retrieval legs across three layers: (1) retrieval core — SearchLegs output on search_hybrid_inner(capture_legs), GATED so production search_hybrid allocates nothing (hot path byte-identical, pinned by a to_bits()-exact proof test); (2) daemon search-legs verb; (3) serve /api/search_legs as a daemon-socket CLIENT (AppState gains the socket path, not models; clean 503 if daemon down, no FTS fallback). Honest fusion semantics surfaced: dense raw_cosine [-1,1], sparse minmax_score (fusion value) + raw_splade_dot (stable token attribution), present_in_pool flag (leg never retrieved the chunk). Verified e2e against the live index (679 dense + 679 sparse union, 500 fused). Full --tests sweep green. Stage 2 (frontend: step-through, stratified tour, text-win, deck.gl) consumes the /api/search_legs JSON seam.