### PR TITLE
test: consolidate adequacy + orthogonal-auditor guards (test-only)

### DIFF
--- a/src/cli/batch/json_args.rs
+++ b/src/cli/batch/json_args.rs
@@ -1740,4 +1740,224 @@ mod tests {
         )
         .is_err());
     }
+
+    // ── proptest: json-args ↔ argv two-path equivalence over a generated input
+    //    space ──────────────────────────────────────────────────────────────
+    //
+    // The `parity_json_args_equals_argv` / `_with_explicit_fields` guards above
+    // are FIXED examples. These properties generate arbitrary VALID field
+    // combinations (the space between those examples) and assert the JSON-args
+    // dispatch envelope is byte-for-byte equal to the argv dispatch envelope for
+    // the same logical request. A falsifier is a real cross-surface divergence —
+    // a field the converter drops, a name-map (`include_types`↔`type_impact`,
+    // `count_only`) that diverges only at some value, or a clamp (`--limit`
+    // 1..=100) applied on one surface but not the other.
+    //
+    // Each case builds argv and JSON from the SAME generated values, so the two
+    // paths are wired to identical logical inputs by construction; the only way
+    // they differ is a converter/parse asymmetry. The seed corpus is
+    // embedder-free, so `where` is excluded (covered by its own example guard).
+    mod proptest_parity {
+        use super::*;
+        use proptest::prelude::*;
+
+        // limit spans the documented 1..=100 core clamp AND past it (to 200),
+        // so a clamp applied on one surface but not the other falsifies.
+        fn limit_strategy() -> impl Strategy<Value = usize> {
+            1usize..=200
+        }
+
+        // The four argv-expressible edge-kind provenance strings, plus None.
+        fn edge_kind_strategy() -> impl Strategy<Value = Option<&'static str>> {
+            prop_oneof![
+                Just(None),
+                Just(Some("call")),
+                Just(Some("serde_callback")),
+                Just(Some("macro_heuristic")),
+                Just(Some("fn_pointer")),
+            ]
+        }
+
+        // depth in [1,50]: test-map/trace clamp to 1..=50, impact does not —
+        // kept in range so every command accepts it on both surfaces and we test
+        // the value round-trip, not the rejection (rejection is pinned elsewhere).
+        fn depth_strategy() -> impl Strategy<Value = usize> {
+            1usize..=50
+        }
+
+        // Run both surfaces for a generated case; panic with a self-describing
+        // message (naming the inputs and both envelopes) on divergence. A panic
+        // inside `proptest!` is a falsification — proptest catches it and shrinks.
+        fn assert_parity(
+            ctx: &crate::cli::batch::BatchContext,
+            command: &str,
+            argv: &[String],
+            arguments: serde_json::Value,
+        ) {
+            let argv_refs: Vec<&str> = argv.iter().map(|s| s.as_str()).collect();
+            let (v_argv, v_json) = run_both(ctx, command, &argv_refs, arguments.clone());
+            assert!(
+                v_argv == v_json,
+                "json-args ↔ argv DIVERGED for `{command}`\n  argv flags: {argv:?}\n  json args:  {arguments}\n  argv out:   {v_argv}\n  json out:   {v_json}"
+            );
+        }
+
+        proptest! {
+            #![proptest_config(ProptestConfig {
+                cases: 96,
+                ..ProptestConfig::default()
+            })]
+
+            // callers / callees: name fixed to the seeded edge endpoints (so the
+            // result carries real data, not a uniform empty set), limit + edge_kind
+            // generated. The converter maps `edge_kind` enum → string and `limit`
+            // straight through; a clamp asymmetry at limit>100 or a kind-string
+            // drift falsifies.
+            #[test]
+            fn callers_callees_parity(
+                limit in limit_strategy(),
+                edge_kind in edge_kind_strategy(),
+            ) {
+                let (_dir, ctx) = seed_ctx();
+                for (command, name) in [("callers", "callee_fn"), ("callees", "caller_fn")] {
+                    let mut argv = vec![name.to_string(), "--limit".into(), limit.to_string()];
+                    let mut args = serde_json::Map::new();
+                    args.insert("name".into(), json!(name));
+                    args.insert("limit".into(), json!(limit));
+                    if let Some(k) = edge_kind {
+                        argv.push("--edge-kind".into());
+                        argv.push(k.to_string());
+                        args.insert("edge_kind".into(), json!(k));
+                    }
+                    assert_parity(&ctx, command, &argv, serde_json::Value::Object(args));
+                }
+            }
+
+            // impact: depth + limit + the two boolean flags. `--type-impact` is the
+            // argv name; the JSON core field is `include_types` (a deliberate
+            // cross-name) — if the converter ever swaps or drops it, the envelopes
+            // diverge for the `true` value but not the `false` value, which only a
+            // generated both-values run catches.
+            #[test]
+            fn impact_parity(
+                limit in limit_strategy(),
+                depth in depth_strategy(),
+                suggest_tests in any::<bool>(),
+                include_types in any::<bool>(),
+            ) {
+                let (_dir, ctx) = seed_ctx();
+                let mut argv = vec![
+                    "callee_fn".to_string(),
+                    "--depth".into(), depth.to_string(),
+                    "--limit".into(), limit.to_string(),
+                ];
+                if suggest_tests { argv.push("--suggest-tests".into()); }
+                if include_types { argv.push("--type-impact".into()); }
+                let args = json!({
+                    "name": "callee_fn",
+                    "depth": depth,
+                    "limit": limit,
+                    "suggest_tests": suggest_tests,
+                    "include_types": include_types,
+                });
+                assert_parity(&ctx, "impact", &argv, args);
+            }
+
+            // dead: include_pub + min_confidence + verdict, all three on/off and
+            // across every enum variant. The converter re-stringifies the verdict
+            // and confidence enums; a variant that maps to a different string on
+            // one surface falsifies.
+            #[test]
+            fn dead_parity(
+                include_pub in any::<bool>(),
+                min_conf in prop_oneof![Just("low"), Just("medium"), Just("high")],
+                verdict in prop_oneof![
+                    Just(None),
+                    Just(Some("test-only")),
+                    Just(Some("low-confidence-live")),
+                    Just(Some("known-gap")),
+                    Just(Some("dead")),
+                    Just(Some("unclassified")),
+                ],
+            ) {
+                let (_dir, ctx) = seed_ctx();
+                let mut argv = vec!["--min-confidence".to_string(), min_conf.to_string()];
+                let mut args = serde_json::Map::new();
+                args.insert("min_confidence".into(), json!(min_conf));
+                if include_pub {
+                    argv.push("--include-pub".into());
+                    args.insert("include_pub".into(), json!(true));
+                }
+                if let Some(v) = verdict {
+                    argv.push("--verdict".into());
+                    argv.push(v.to_string());
+                    args.insert("verdict".into(), json!(v));
+                }
+                assert_parity(&ctx, "dead", &argv, serde_json::Value::Object(args));
+            }
+
+            // deps: reverse flag + limit. The `reverse` bool selects a DIFFERENT
+            // output shape (`{name,types,count}` vs forward), so a drop of the flag
+            // on one surface changes the entire envelope.
+            #[test]
+            fn deps_parity(
+                limit in limit_strategy(),
+                reverse in any::<bool>(),
+            ) {
+                let (_dir, ctx) = seed_ctx();
+                let mut argv = vec!["caller_fn".to_string(), "--limit".into(), limit.to_string()];
+                let mut args = serde_json::Map::new();
+                args.insert("name".into(), json!("caller_fn"));
+                args.insert("limit".into(), json!(limit));
+                if reverse {
+                    argv.push("--reverse".into());
+                    args.insert("reverse".into(), json!(true));
+                }
+                assert_parity(&ctx, "deps", &argv, serde_json::Value::Object(args));
+            }
+
+            // test-map: depth (clamped 1..=50, generated in range) + limit. The
+            // converter `u16::try_from`s the depth; an in-range value must round-
+            // trip identically on both surfaces.
+            #[test]
+            fn test_map_parity(
+                limit in limit_strategy(),
+                depth in depth_strategy(),
+            ) {
+                let (_dir, ctx) = seed_ctx();
+                let argv = vec![
+                    "callee_fn".to_string(),
+                    "--depth".into(), depth.to_string(),
+                    "--limit".into(), limit.to_string(),
+                ];
+                let args = json!({"name": "callee_fn", "max_depth": depth, "limit": limit});
+                assert_parity(&ctx, "test-map", &argv, args);
+            }
+
+            // related: limit only. Co-occurrence is embedder-free over the seeded
+            // edge, so the envelope is real data.
+            #[test]
+            fn related_parity(limit in limit_strategy()) {
+                let (_dir, ctx) = seed_ctx();
+                let argv = vec!["caller_fn".to_string(), "--limit".into(), limit.to_string()];
+                let args = json!({"name": "caller_fn", "limit": limit});
+                assert_parity(&ctx, "related", &argv, args);
+            }
+
+            // stale: the `count_only` adapter-side render flag projects to a
+            // 3-field count subset. Generated on/off pins that the projection
+            // happens identically on both surfaces.
+            #[test]
+            fn stale_parity(count_only in any::<bool>()) {
+                let (_dir, ctx) = seed_ctx();
+                let mut argv: Vec<String> = vec![];
+                let mut args = serde_json::Map::new();
+                if count_only {
+                    argv.push("--count-only".into());
+                    args.insert("count_only".into(), json!(true));
+                }
+                assert_parity(&ctx, "stale", &argv, serde_json::Value::Object(args));
+            }
+        }
+    }
 }

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -1400,4 +1400,29 @@ mod tests {
         assert_eq!(first, second, "scan must be idempotent (no flag doubling)");
         assert!(first.as_array().map(|a| !a.is_empty()).unwrap_or(false));
     }
+
+    // Boundary: a ref of EXACTLY 255 chars is the longest the validator
+    // accepts (`len() > 255`, inclusive upper bound), so it must NOT be
+    // rejected by the length gate — it passes validation and reaches git
+    // (which then fails because no such ref exists, a DIFFERENT error). The
+    // `> 255` -> `>= 255` off-by-one would reject a valid 255-char ref; the
+    // 256-char oversize test cannot see that flip (both reject 256). Pins the
+    // inclusive boundary by asserting the error, if any, is NOT the length
+    // rejection. cwd is the crate dir (a real git repo) so git can run.
+    #[test]
+    fn test_run_git_diff_accepts_max_length_ref() {
+        let max = "a".repeat(255);
+        let result = run_git_diff(Some(&max), std::path::Path::new(env!("CARGO_MANIFEST_DIR")));
+        // A 255-char ref does not exist, so git fails — but the failure must be
+        // git's, not the validator's length rejection. Under the off-by-one
+        // mutation this returns the "1..=255 chars" validation error instead.
+        if let Err(e) = result {
+            let msg = e.to_string();
+            assert!(
+                !msg.contains("must be 1..=255 chars"),
+                "a 255-char ref must pass the length validator (inclusive upper \
+                 bound), not be rejected by it; got: {msg}"
+            );
+        }
+    }
 }

--- a/src/cli/watch/mod.rs
+++ b/src/cli/watch/mod.rs
@@ -119,6 +119,13 @@ mod daemon;
 #[cfg(all(cqs_loom, test))]
 mod reconcile_interleaving_model;
 
+// Loom model of the daemon notes-mutation signal vs the watch-loop drain (the
+// inotify-independent note-reindex protocol). Gated to `--cfg cqs_loom` test
+// builds; absent from a normal build. Pins NO-LOST-REINDEX: a committed note
+// write is always reflected in the index under every drain/write interleaving.
+#[cfg(all(cqs_loom, test))]
+mod notes_signal_interleaving_model;
+
 /// Immutable references shared across the watch loop.
 ///
 /// Does not include `Store` because it is re-opened each cycle.

--- a/src/cli/watch/notes_signal_interleaving_model.rs
+++ b/src/cli/watch/notes_signal_interleaving_model.rs
@@ -1,0 +1,388 @@
+//! Loom model of the daemon notes-mutation signal vs the watch-loop drain
+//! (the inotify-independent note-reindex protocol; interleaving-auditor lane).
+//!
+//! ## Why this module exists
+//!
+//! In `cqs watch --serve` a daemon connection thread that handles
+//! `notes-add` / `notes-update` / `notes-remove` writes `docs/notes.toml`
+//! (atomic temp+rename, under a file lock) and then flips a shared one-shot
+//! `AtomicBool` — the pending-notes signal — via
+//! `request_notes_reindex` (`view.rs`: `swap(true, Release)`). The watch loop
+//! (a SEPARATE thread) drains that signal once per tick
+//! (`drain_pending_notes_signal`: `swap(false, AcqRel)` → `state.pending_notes
+//! = true`) and, when the debounce is due, runs the note reindex:
+//!
+//! ```text
+//! if state.pending_notes {
+//!     state.pending_notes = false;          // consume, THEN re-read
+//!     process_note_changes(...);            // reindex_notes re-reads notes.toml
+//! }
+//! ```
+//!
+//! The signal exists because inotify on `docs/notes.toml` is unreliable on the
+//! WSL `/mnt/c` (NTFS/9P) deployment: without the explicit writer signal a
+//! committed note could be NEVER indexed. The protocol's whole purpose is to
+//! guarantee a note write is eventually reflected in the index.
+//!
+//! The house unit suite is single-threaded: it cannot schedule a writer's
+//! `swap(true)` against the watch loop's `swap(false)` drain and the later
+//! `pending_notes = false` consume. That is exactly what this module
+//! enumerates with loom.
+//!
+//! ## The invariant under test
+//!
+//! The note reindex re-reads the WHOLE `docs/notes.toml` and rebuilds the notes
+//! table — it is idempotent and content-driven (it indexes whatever the file
+//! currently holds, not a delta). The version counter below stands in for "the
+//! committed file content": each writer bumps it before flipping the signal,
+//! exactly as a write lands a new file before `request_notes_reindex`.
+//!
+//! > **NO-LOST-REINDEX**: after a writer has completed (file write committed +
+//! > signal flipped) and the watch loop has quiesced (it observes the signal
+//! > clear AND has no pending-notes work left), the last reindex the loop ran
+//! > read a file version AT-OR-AFTER the writer's committed version. The index
+//! > is never left strictly behind a committed write.
+//!
+//! Equivalently: there is no interleaving where a `swap(true)` is "absorbed"
+//! (cleared by a drain) without a subsequent reindex that observes the version
+//! that writer committed. The decoupling — the signal is a SEPARATE bit from
+//! `pending_notes`, and the reindex RE-READS the file rather than trusting a
+//! cached delta — is what carries the invariant. The negative control proves it
+//! is the re-read, not luck, that holds.
+//!
+//! ## What the model abstracts (the bounded shape loom needs)
+//!
+//! - `version: AtomicUsize` is the committed file content (monotone; a writer
+//!   bumps it = a new `notes.toml` landed). A reindex "reads" it = the file
+//!   content the reindex walk observed.
+//! - `signal: AtomicBool` is the shared pending-notes signal. Writer:
+//!   `swap(true, Release)` AFTER bumping the version (file write happens-before
+//!   the flip, mirroring the handler). Loop drain: `swap(false, AcqRel)`.
+//! - `pending: bool` is `state.pending_notes`, owned by the loop thread (not
+//!   shared) — the loop is the only thread that touches it, faithful to the
+//!   real code.
+//! - `processed: AtomicUsize` is the last version the loop's reindex observed.
+//!   The invariant compares it to `version` at quiesce.
+//!
+//! ## Running
+//!
+//! ```bash
+//! RUSTFLAGS="--cfg cqs_loom" cargo test --features cuda-index --bin cqs \
+//!     notes_signal_interleaving_model
+//! ```
+//!
+//! All safety models here are GREEN: the protocol upholds NO-LOST-REINDEX under
+//! every interleaving loom explores. The `#[ignore]`d negative control replaces
+//! the version RE-READ with a snapshot captured at drain time (the bug the
+//! re-read avoids) and loom finds the lost-reindex schedule, proving the test
+//! has teeth.
+
+#![cfg(all(cqs_loom, test))]
+
+use loom::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use loom::sync::Arc;
+use loom::thread;
+
+/// The shared world: the committed file version, the pending-notes signal, and
+/// the last-processed version the loop's reindex observed.
+struct World {
+    /// Committed `docs/notes.toml` content, monotone. A writer bumps this
+    /// (the atomic temp+rename) BEFORE flipping the signal.
+    version: AtomicUsize,
+    /// The shared one-shot pending-notes signal (`request_notes_reindex` /
+    /// `drain_pending_notes_signal`).
+    signal: AtomicBool,
+    /// The last version a reindex observed. Compared to `version` at quiesce.
+    processed: AtomicUsize,
+}
+
+impl World {
+    fn new() -> Arc<Self> {
+        Arc::new(World {
+            // version 0 is the seed file; processed 0 = the loop indexed the
+            // seed at startup. The writers below commit version >= 1.
+            version: AtomicUsize::new(0),
+            signal: AtomicBool::new(false),
+            processed: AtomicUsize::new(0),
+        })
+    }
+
+    /// One notes-mutation handler: commit a new file version (the temp+rename),
+    /// then flip the signal. The file write happens-before the flip — program
+    /// order in the handler, and the `Release` on the flip publishes it.
+    fn write_note(&self, new_version: usize) {
+        // The atomic file write (temp+rename): publish the new content.
+        self.version.store(new_version, Ordering::Release);
+        // `request_notes_reindex`: swap(true, Release).
+        self.signal.swap(true, Ordering::Release);
+    }
+
+    /// Drain the signal into the loop-local `pending` flag, faithful to
+    /// `drain_pending_notes_signal`. Returns whether a pending write was
+    /// drained (so the caller can OR it into its running `pending`).
+    fn drain(&self) -> bool {
+        self.signal.swap(false, Ordering::AcqRel)
+    }
+
+    /// The reindex: re-read the CURRENT committed version and record it as the
+    /// last processed version. Faithful to `process_note_changes` →
+    /// `reindex_notes`, which re-reads the whole `notes.toml` (latest-at-read),
+    /// NOT a snapshot taken at drain time. `fetch_max` because two reindexes can
+    /// run and `processed` must reflect the newest version any of them saw —
+    /// the index never goes backwards.
+    fn reindex_reads_current(&self) {
+        let current = self.version.load(Ordering::Acquire);
+        self.processed.fetch_max(current, Ordering::AcqRel);
+    }
+}
+
+/// One watch-loop tick: drain the signal into `pending`, then (debounce due)
+/// consume `pending` BEFORE re-reading — the exact order at `mod.rs`:
+/// `state.pending_notes = false; process_note_changes(...)`. `pending` is the
+/// loop-local flag carried across ticks. Returns the updated `pending`.
+fn watch_tick(world: &World, mut pending: bool, flush_due: bool) -> bool {
+    // Top-of-loop drain (every iteration, independent of the recv arm).
+    if world.drain() {
+        pending = true;
+    }
+    if flush_due && pending {
+        // Consume THEN re-read — the ordering under audit.
+        pending = false;
+        world.reindex_reads_current();
+    }
+    pending
+}
+
+/// MODEL 1 (safety, GREEN): one writer racing a watch loop that ticks enough
+/// times to quiesce. Loom interleaves the writer's `version.store` + `swap(true)`
+/// against the loop's `drain` + consume + re-read across multiple ticks.
+///
+/// After both threads join, the loop must have a final consistent view: a final
+/// reconciling tick (always flush-due, run after join) drains any residual
+/// signal and reindexes, so `processed == version`. The invariant: that final
+/// reindex observes the writer's committed version — the write is never lost.
+#[test]
+fn no_lost_reindex_single_writer() {
+    loom::model(|| {
+        let world = World::new();
+        let w_writer = Arc::clone(&world);
+        let w_loop = Arc::clone(&world);
+
+        let writer = thread::spawn(move || {
+            w_writer.write_note(1);
+        });
+
+        // The watch loop runs several ticks with flush due, racing the writer.
+        let watcher = thread::spawn(move || {
+            let mut pending = false;
+            // Two racing ticks model the loop spinning while the writer commits.
+            pending = watch_tick(&w_loop, pending, true);
+            pending = watch_tick(&w_loop, pending, true);
+            pending
+        });
+
+        writer.join().unwrap();
+        let residual_pending = watcher.join().unwrap();
+
+        // Quiesce: after the writer is done, run reconciling ticks until the
+        // signal is clear AND no pending work remains — the steady state the
+        // real loop reaches once writes stop. The loop ALWAYS runs again on its
+        // next ~100 ms timer, so a residual pending/signal is guaranteed to be
+        // drained; we model that guaranteed convergence here.
+        let mut pending = residual_pending;
+        // At most a couple of extra ticks are ever needed (drain, then flush).
+        for _ in 0..3 {
+            pending = watch_tick(&world, pending, true);
+        }
+
+        let version = world.version.load(Ordering::Acquire);
+        let processed = world.processed.load(Ordering::Acquire);
+        // NO-LOST-REINDEX: the committed write was reindexed.
+        assert!(
+            processed >= version,
+            "NO-LOST-REINDEX VIOLATED: committed version {version} but the index only \
+             reached version {processed} — a note write's reindex was lost; the signal \
+             was absorbed without a reindex observing the committed file"
+        );
+        // The signal must be clear at quiesce (a sticky signal would mean the
+        // loop kept work it never finished).
+        assert!(
+            !world.signal.load(Ordering::Acquire),
+            "signal still set at quiesce — a drained write was not converged"
+        );
+        // And no loop-local pending work remains.
+        assert!(
+            !pending,
+            "pending_notes still set at quiesce — reindex not converged"
+        );
+    });
+}
+
+/// MODEL 2 (safety, GREEN): two concurrent writers (e.g. two daemon connection
+/// threads each handling a notes mutation) racing one watch loop. Each commits a
+/// distinct version and flips the shared signal. The signal COALESCES — the loop
+/// may drain both flips with one `swap(false)` — which is correct precisely
+/// because the reindex re-reads the whole file: one reindex that observes the
+/// latest version covers both writes. The invariant: after quiesce the index
+/// reached the MAX committed version (neither write is lost to coalescing).
+#[test]
+fn no_lost_reindex_two_writers_coalescing_signal() {
+    loom::model(|| {
+        let world = World::new();
+        let w_a = Arc::clone(&world);
+        let w_b = Arc::clone(&world);
+        let w_loop = Arc::clone(&world);
+
+        // Writers commit distinct versions. Loom explores both orders; the MAX
+        // is what the file ends at, so that is what the index must reach.
+        let writer_a = thread::spawn(move || {
+            w_a.write_note(1);
+        });
+        let writer_b = thread::spawn(move || {
+            w_b.write_note(2);
+        });
+
+        let watcher = thread::spawn(move || {
+            let mut pending = false;
+            pending = watch_tick(&w_loop, pending, true);
+            pending = watch_tick(&w_loop, pending, true);
+            pending
+        });
+
+        writer_a.join().unwrap();
+        writer_b.join().unwrap();
+        let residual_pending = watcher.join().unwrap();
+
+        // Converge.
+        let mut pending = residual_pending;
+        for _ in 0..3 {
+            pending = watch_tick(&world, pending, true);
+        }
+
+        let version = world.version.load(Ordering::Acquire);
+        let processed = world.processed.load(Ordering::Acquire);
+        assert!(
+            processed >= version,
+            "NO-LOST-REINDEX VIOLATED (two writers): file at version {version}, index only \
+             reached {processed} — signal coalescing dropped a write the re-read should have caught"
+        );
+        assert!(
+            !world.signal.load(Ordering::Acquire),
+            "signal set at quiesce"
+        );
+        assert!(!pending, "pending set at quiesce");
+    });
+}
+
+/// MODEL 3 (safety, GREEN): the consume-before-read ordering under audit. A
+/// writer commits DURING the loop's flush — between the `pending = false`
+/// consume and the version re-read. Because the reindex re-reads
+/// latest-at-read, it picks up the just-committed version; even if it did not,
+/// the writer's fresh `swap(true)` keeps the signal set for the next tick. This
+/// model isolates that window.
+#[test]
+fn no_lost_reindex_write_during_flush_window() {
+    loom::model(|| {
+        let world = World::new();
+        let w_writer = Arc::clone(&world);
+        let w_loop = Arc::clone(&world);
+
+        // Pre-arm: a first write has already flipped the signal before the loop
+        // starts, so the loop enters flush with pending set.
+        world.version.store(1, Ordering::Release);
+        world.signal.swap(true, Ordering::Release);
+
+        let writer = thread::spawn(move || {
+            // A SECOND write lands while the loop is flushing the first.
+            w_writer.write_note(2);
+        });
+
+        let watcher = thread::spawn(move || {
+            let mut pending = false;
+            // Drain picks up the pre-armed signal; flush consumes + re-reads —
+            // the second write may interleave anywhere in here.
+            pending = watch_tick(&w_loop, pending, true);
+            pending = watch_tick(&w_loop, pending, true);
+            pending
+        });
+
+        writer.join().unwrap();
+        let residual_pending = watcher.join().unwrap();
+
+        let mut pending = residual_pending;
+        for _ in 0..3 {
+            pending = watch_tick(&world, pending, true);
+        }
+
+        let version = world.version.load(Ordering::Acquire);
+        let processed = world.processed.load(Ordering::Acquire);
+        assert!(
+            processed >= version,
+            "NO-LOST-REINDEX VIOLATED (flush-window write): version {version}, index {processed} \
+             — a write that landed during the consume->re-read window was lost"
+        );
+        assert!(
+            !world.signal.load(Ordering::Acquire),
+            "signal set at quiesce"
+        );
+        assert!(!pending, "pending set at quiesce");
+    });
+}
+
+/// NEGATIVE CONTROL (`#[ignore]`, FAILS by design): proves the re-read is what
+/// holds the invariant. Replace the latest-at-read reindex with one that
+/// reindexes a version SNAPSHOTTED at drain time — the bug the real protocol
+/// avoids by re-reading the whole file. Now a writer that commits AFTER the
+/// drain snapshot but whose `swap(true)` was coalesced into that same drain has
+/// its content lost: the loop reindexes the stale snapshot, clears pending, and
+/// the later `swap(true)` was already consumed.
+///
+/// Loom finds the interleaving and the NO-LOST-REINDEX assert fires. This pins
+/// WHY the real code is safe: `reindex_notes` re-reads `notes.toml`
+/// (latest-at-read), it does not trust a delta captured when the signal was
+/// drained.
+///
+/// ```bash
+/// RUSTFLAGS="--cfg cqs_loom" cargo test --features cuda-index --bin cqs \
+///     notes_signal_interleaving_model -- --ignored
+/// ```
+#[test]
+#[ignore = "negative control: reproduces a lost reindex when the loop reindexes a version \
+            SNAPSHOTTED at drain time instead of re-reading the file; FAILS by design"]
+fn snapshot_at_drain_would_lose_a_write() {
+    loom::model(|| {
+        let world = World::new();
+        let w_writer = Arc::clone(&world);
+        let w_loop = Arc::clone(&world);
+
+        let writer = thread::spawn(move || {
+            w_writer.write_note(1);
+        });
+
+        let watcher = thread::spawn(move || {
+            // The BUG: snapshot the version at drain time, reindex THAT instead
+            // of re-reading. A coalesced later flip is then lost.
+            let drained = w_loop.drain();
+            // Snapshot now — before the writer may have stored its version.
+            let snapshot = w_loop.version.load(Ordering::Acquire);
+            if drained {
+                // "Reindex" the stale snapshot.
+                w_loop.processed.fetch_max(snapshot, Ordering::AcqRel);
+                // pending consumed — no further reindex for this drain.
+            }
+        });
+
+        writer.join().unwrap();
+        watcher.join().unwrap();
+
+        let version = world.version.load(Ordering::Acquire);
+        let processed = world.processed.load(Ordering::Acquire);
+        // Under the snapshot bug, a schedule exists where the writer's
+        // swap(true) was the bit the drain consumed, yet the version snapshot
+        // was taken before the store — so processed (0) < version (1).
+        assert!(
+            processed >= version,
+            "lost reindex reproduced: version {version}, index {processed}"
+        );
+    });
+}

--- a/src/daemon_translate.rs
+++ b/src/daemon_translate.rs
@@ -2779,6 +2779,105 @@ mod tests {
         );
     }
 
+    /// Property (cap boundary): for a generated total line length `L` (the
+    /// newline included) and a fixed cap `C`, the daemon-response read accepts
+    /// the line iff `L <= C` and rejects with `ResponseTooLarge` iff `L > C`.
+    ///
+    /// The fixed `json_args_response_exactly_at_cap_is_accepted` example pins ONE
+    /// point (`L == C`). This sweeps `L` across `[C-3, C+3]` — the exact window
+    /// where the prior `== cap` test mis-fired (it rejected `L == C`, the very
+    /// case a valid full-cap payload occupies). A regression to a `>= cap` or
+    /// `== cap` check falsifies at `L == C`; an off-by-one in the `take(C+1)`
+    /// budget falsifies at `L == C+1`.
+    ///
+    /// Each case sends a JSON envelope padded to exactly `L` bytes including the
+    /// trailing newline, so the only variable is length-vs-cap, never validity.
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial(daemon_response_cap_env)]
+    fn prop_cap_accepts_iff_len_le_cap() {
+        use proptest::prelude::*;
+        use std::io::{BufRead, BufReader, Write};
+        use std::os::unix::net::UnixListener;
+
+        // Fixed cap; the wrapper below is well under it so padding always has room.
+        const CAP: usize = 512;
+        // A valid envelope whose `d` field absorbs the padding. Pre-newline this
+        // is `WRAPPER.len() + pad` bytes; `writeln!` adds 1 for the newline, so
+        // the total line length is `WRAPPER.len() + pad + 1`.
+        const WRAPPER: &str = r#"{"status":"ok","output":{"d":""}}"#;
+
+        // One round-trip for a target TOTAL line length `total` (newline incl.).
+        // Returns the classification: true = accepted (Ok), false = rejected
+        // (ResponseTooLarge). Any other error is a test-harness fault → panic.
+        fn run_one(cap: usize, total: usize) -> bool {
+            let dir = tempfile::tempdir().unwrap();
+            let cqs_dir = dir.path().join(".cqs");
+            std::fs::create_dir_all(&cqs_dir).unwrap();
+            std::env::set_var("CQS_DAEMON_MAX_RESPONSE_BYTES", cap.to_string());
+            set_socket_dir_override_for_test(Some(dir.path().to_path_buf()));
+            let sock_path = daemon_socket_path(&cqs_dir);
+            let listener = UnixListener::bind(&sock_path).unwrap();
+
+            // Pre-newline length = total - 1; pad the `d` field to hit it exactly.
+            let pre_newline = total - 1;
+            let pad = pre_newline - WRAPPER.len();
+            let handle = std::thread::spawn(move || {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut req = String::new();
+                let _ = BufReader::new(&stream).read_line(&mut req);
+                let big = "x".repeat(pad);
+                let line = format!(r#"{{"status":"ok","output":{{"d":"{big}"}}}}"#);
+                assert_eq!(
+                    line.len(),
+                    pre_newline,
+                    "padding math: line must be total-1"
+                );
+                // `writeln!` appends the newline → on-wire line is `total` bytes.
+                // For an OVER-cap payload the client reads only `cap + 1` bytes
+                // then returns `ResponseTooLarge` and drops the stream, so this
+                // write can hit a broken pipe — that is the expected shape, not a
+                // harness fault. Ignore write/flush errors; the assertion is about
+                // the CLIENT's classification, not a clean server-side write.
+                let _ = writeln!(stream, "{line}");
+                let _ = stream.flush();
+            });
+
+            let result = daemon_json_args_request(&cqs_dir, "search", &serde_json::json!({}));
+            let _ = handle.join();
+            let _ = std::fs::remove_file(&sock_path);
+            set_socket_dir_override_for_test(None);
+            std::env::remove_var("CQS_DAEMON_MAX_RESPONSE_BYTES");
+
+            match result {
+                Ok(_) => true,
+                Err(DaemonRpcError::ResponseTooLarge(_)) => false,
+                Err(other) => panic!("unexpected error for total={total} cap={cap}: {other:?}"),
+            }
+        }
+
+        // Sweep the boundary window [CAP-3, CAP+3]. Lower bound stays above the
+        // wrapper length so padding is non-negative.
+        let mut runner = proptest::test_runner::TestRunner::deterministic();
+        let strat = (CAP - 3)..=(CAP + 3);
+        runner
+            .run(&strat, |total| {
+                let accepted = run_one(CAP, total);
+                let expected = total <= CAP;
+                prop_assert_eq!(
+                    accepted,
+                    expected,
+                    "len={} cap={}: accepted={} but len<=cap is {}",
+                    total,
+                    CAP,
+                    accepted,
+                    expected
+                );
+                Ok(())
+            })
+            .unwrap();
+    }
+
     // ── socket parent-dir hardening ───────────────────────────────────
 
     /// Creating a fresh socket parent dir produces an empty 0o700 directory.

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -1029,4 +1029,45 @@ mod tests {
         assert_eq!(parser_max_walk_depth(), PARSER_MAX_WALK_DEPTH);
         std::env::remove_var("CQS_PARSER_MAX_WALK_DEPTH");
     }
+
+    /// Property (depth clamp invariant): for ANY value of
+    /// `CQS_PARSER_MAX_WALK_DEPTH` — a digit string, signed, whitespace-wrapped,
+    /// hex, unicode, empty, or a u64 that overflows usize — the resolved depth
+    /// is ALWAYS within `[1, PARSER_MAX_WALK_DEPTH_CEIL]`. The four examples
+    /// above pin five points (unset / 200 / 1_000_000 / "not_a_number" / "0");
+    /// this generates the env-string space between them (negatives, leading
+    /// zeros, " 5 ", "0x1F", `u64::MAX`-ish, unicode digits, "") and asserts the
+    /// rail never opens above the stack-safe ceiling nor collapses to a
+    /// suppress-all `0`. A regression that forgot the clamp on some parse path,
+    /// or let a value parse to `0` through, falsifies.
+    #[test]
+    #[serial]
+    fn prop_parser_max_walk_depth_always_in_range() {
+        use proptest::prelude::*;
+
+        // A spread covering: pure digit strings (incl. overflow), signed,
+        // whitespace-padded, hex-ish, empty, and arbitrary unicode noise.
+        let value = prop_oneof![
+            "[0-9]{1,25}",
+            "[+-]?[0-9]{1,12}",
+            r"\s*[0-9]{1,6}\s*",
+            "0x[0-9a-fA-F]{1,8}",
+            Just(String::new()),
+            "\\PC{0,12}",
+        ];
+
+        let mut runner = proptest::test_runner::TestRunner::deterministic();
+        runner
+            .run(&value, |s| {
+                std::env::set_var("CQS_PARSER_MAX_WALK_DEPTH", &s);
+                let d = parser_max_walk_depth();
+                std::env::remove_var("CQS_PARSER_MAX_WALK_DEPTH");
+                prop_assert!(
+                    (1..=PARSER_MAX_WALK_DEPTH_CEIL).contains(&d),
+                    "env={s:?} → depth={d}, outside [1, {PARSER_MAX_WALK_DEPTH_CEIL}]"
+                );
+                Ok(())
+            })
+            .unwrap();
+    }
 }

--- a/src/parser/calls.rs
+++ b/src/parser/calls.rs
@@ -2946,6 +2946,22 @@ struct Wrapper<T> {
                 1
             )
             .is_empty());
+            // Non-Rust language whose text DOES contain the word `serde` AND a
+            // callback-shaped attribute must STILL be ignored: the language
+            // guard, not the cheap `contains("serde")` fast-path, is what keeps
+            // the regex off non-Rust text. The case above omits `serde`, so it
+            // only exercises the substring fast-path; this one pins the language
+            // half of the `language != Rust || !contains("serde")` guard.
+            assert!(
+                extract_serde_callback_calls(
+                    r#"# serde-style config
+opts = {deserialize_with = "some_fn"}"#,
+                    Language::Python,
+                    1
+                )
+                .is_empty(),
+                "a non-Rust source mentioning serde must not produce serde edges"
+            );
         }
 
         /// End-to-end through `parse_file_relationships`: the carrying struct

--- a/src/parser/calls.rs
+++ b/src/parser/calls.rs
@@ -2613,6 +2613,29 @@ fn caller() {
             );
         }
 
+        /// The macro EDGE pass must emit NOTHING for source that contains no
+        /// macro `token_tree` at all. The whole heuristic is gated on
+        /// `in_token_tree` — outside a token-tree the ordinary call query owns
+        /// the edges, and re-emitting them here would double-count and mislabel
+        /// real calls / fn names as `MacroHeuristic`. The other macro tests all
+        /// feed sources that DO contain a macro, so they never exercise the gate
+        /// being load-bearing; they assert which names appear, never that a
+        /// non-macro identifier (a fn definition name, a plain callee) is
+        /// suppressed. This fixture has two same-file fns and a plain call but
+        /// zero macros, so the macro pass must return an empty edge set.
+        #[test]
+        fn test_macro_pass_emits_nothing_without_token_tree() {
+            // `outer` and `inner` are both in `known_fns`; `inner()` is a plain
+            // `call_expression`, not a macro arg. With the `in_token_tree` gate
+            // defeated, the known-fn names would leak as macro-heuristic edges.
+            let macro_only = macro_edges_for("fn inner() {}\nfn outer() { inner(); }\n");
+            assert!(
+                macro_only.is_empty(),
+                "macro pass must emit no edges when the source has no macro \
+                 token_tree, got: {macro_only:?}"
+            );
+        }
+
         /// Regression: a plain (non-macro) call still emits exactly ONE edge —
         /// the macro heuristic must not double-count real `call_expression`s.
         #[test]
@@ -2928,6 +2951,64 @@ struct Wrapper<T> {
                 calls.is_empty(),
                 "bound must not emit a serde call edge, got: {:?}",
                 calls
+            );
+        }
+
+        /// The emitted `line_number` must point at the source row carrying the
+        /// `#[serde(... = "fn")]` attribute, not just be non-zero. The line is
+        /// computed by counting NEWLINE bytes before the capture; a walk that
+        /// counted the wrong bytes (or dropped the `line_offset`) would still
+        /// produce a correctly-NAMED edge with a wrong location, which every
+        /// other serde test tolerates because they assert only `callee_name`.
+        /// Two callbacks on different rows pin both the per-attribute newline
+        /// count AND the `line_offset` addition.
+        #[test]
+        fn test_extract_serde_callback_calls_line_numbers() {
+            // Row layout (1-indexed within this slice, before line_offset):
+            //   1: (empty)
+            //   2: #[derive(serde::Deserialize)]
+            //   3: struct Config {
+            //   4:     #[serde(default = "first_cb")]
+            //   5:     a: u32,
+            //   6:     #[serde(serialize_with = "second_cb")]
+            //   7:     b: u32,
+            //   8: }
+            let source = "\n\
+#[derive(serde::Deserialize)]\n\
+struct Config {\n    \
+#[serde(default = \"first_cb\")]\n    \
+a: u32,\n    \
+#[serde(serialize_with = \"second_cb\")]\n    \
+b: u32,\n\
+}\n";
+            // line_offset = 10 → absolute line = 10 + (newlines before match).
+            let calls = extract_serde_callback_calls(source, Language::Rust, 10);
+            let first = calls
+                .iter()
+                .find(|c| c.callee_name == "first_cb")
+                .expect("first_cb edge");
+            let second = calls
+                .iter()
+                .find(|c| c.callee_name == "second_cb")
+                .expect("second_cb edge");
+            // `first_cb` capture sits on slice row 4 → 3 newlines precede it →
+            // 10 + 3 = 13. `second_cb` on slice row 6 → 5 newlines → 10 + 5 = 15.
+            assert_eq!(
+                first.line_number, 13,
+                "first_cb attribute must report absolute line 13, got {}",
+                first.line_number
+            );
+            assert_eq!(
+                second.line_number, 15,
+                "second_cb attribute must report absolute line 15, got {}",
+                second.line_number
+            );
+            // The two callbacks are two source rows apart: a constant or a
+            // wrong-byte-count line computation cannot satisfy both at once.
+            assert_eq!(
+                second.line_number - first.line_number,
+                2,
+                "the two callbacks are two source rows apart"
             );
         }
 

--- a/src/search/scoring/candidate.rs
+++ b/src/search/scoring/candidate.rs
@@ -661,6 +661,51 @@ mod tests {
         assert_eq!(names, vec!["a", "b"]);
     }
 
+    /// Coverage guard for `BoundedScoreHeap::would_accept` — the cheap
+    /// pre-flight `SpladeIndex::search_with_filter` uses to gate id-cloning
+    /// while scoring ~18k candidates per query. No test in this module routed
+    /// through it, so the at-capacity branch (`heap.len() < capacity` and
+    /// `!score.total_cmp(worst).is_lt()`) was unconstrained: mutating
+    /// `<`→`<=` (accepts when full) or dropping the `!` (inverts the
+    /// keep/drop decision) both survived. A wrong `would_accept` either drops
+    /// a top-k chunk that should have been scored (false negative → recall
+    /// loss) or wastes work (false positive). Pin both the below-capacity and
+    /// at-capacity contracts.
+    #[test]
+    fn would_accept_below_and_at_capacity() {
+        // Below capacity: anything finite is accepted; non-finite rejected.
+        let mut heap = BoundedScoreHeap::new(2);
+        assert!(heap.would_accept(0.1), "empty heap has space");
+        heap.push("a".to_string(), 0.5);
+        assert!(heap.would_accept(-1.0), "1/2 full still has space");
+        assert!(!heap.would_accept(f32::NAN), "non-finite always rejected");
+
+        // Fill to capacity with worst = 0.5 (ids a,b).
+        heap.push("b".to_string(), 0.9);
+        // Now at capacity (2/2), worst score is 0.5.
+        // Strictly-better score is accepted (would evict the 0.5 entry).
+        assert!(
+            heap.would_accept(0.7),
+            "score above the worst must be accepted when full"
+        );
+        // Strictly-worse score is rejected (kills `!is_lt()` -> `is_lt()`).
+        assert!(
+            !heap.would_accept(0.1),
+            "score below the worst must be rejected when full"
+        );
+        // Tied-with-worst is permissively accepted (push applies the full
+        // id comparator) — and this also kills `<` -> `<=` indirectly, since
+        // the at-capacity branch must run at all.
+        assert!(
+            heap.would_accept(0.5),
+            "score tied with the worst is permissively accepted when full"
+        );
+
+        // Capacity-zero heap accepts nothing.
+        let zero = BoundedScoreHeap::new(0);
+        assert!(!zero.would_accept(1.0), "capacity-0 heap accepts nothing");
+    }
+
     // ===== parent_boost tests =====
 
     /// Constructs a test SearchResult with minimal required fields populated.

--- a/src/search/scoring/candidate.rs
+++ b/src/search/scoring/candidate.rs
@@ -792,6 +792,132 @@ mod tests {
         assert_eq!(results[1].score, score_before);
     }
 
+    /// Adequacy regression: pin the EXACT parent-boost multiplier at the
+    /// unsaturated child counts (2 and 3 children).
+    ///
+    /// The existing parent-boost tests only assert loose inequalities
+    /// (`circuit_breaker`: `score > 0.90`) or the *saturated* 5-children case
+    /// (`caps_at_1_15`), where the value already equals `parent_boost_cap`.
+    /// At saturation the final `.min(cap)`, the inner `.min(max_children)`
+    /// clamp, and the `count - 1` term are all masked, so mutating any of them
+    /// (`count - 1` → `count + 1`; inner `.min` → `.max`; final `.min` →
+    /// `.max`) left every parent-boost test green. The boost is the score-mover
+    /// the recall gate protects, so an unpinned multiplier is a silent
+    /// ranking-regression hole.
+    ///
+    /// `apply_parent_boost` returns the per-id multiplier it actually applied,
+    /// so we read it directly. With defaults `per_child = 0.05`, `cap = 1.15`
+    /// (`max_children = 3.0`): 2 children → 1.05, 3 children → 1.10. Neither
+    /// equals the cap, so all three inner-arithmetic mutations move the value.
+    #[test]
+    fn test_parent_boost_exact_multiplier_unsaturated() {
+        let cfg = ScoringConfig::DEFAULT;
+
+        // Exactly TWO children of `Hub` + the container → boost = 1.0 +
+        // 0.05 * (2 - 1) = 1.05. Kills `count + 1` (→1.10) and inner
+        // `.max(max_children)` (→1.15).
+        let mut two = vec![
+            make_result("childA", ChunkType::Method, Some("Hub"), 0.88),
+            make_result("childB", ChunkType::Method, Some("Hub"), 0.87),
+            make_result("Hub", ChunkType::Class, None, 0.50),
+        ];
+        let applied = apply_parent_boost(&mut two);
+        let boost2 = *applied
+            .get("Hub")
+            .expect("Hub must be boosted with 2 children present");
+        let expected2 = 1.0 + cfg.parent_boost_per_child * 1.0; // 1.05
+        assert!(
+            (boost2 - expected2).abs() < 1e-6,
+            "2-children boost must be exactly {expected2}, got {boost2}"
+        );
+
+        // Exactly THREE children → boost = 1.0 + 0.05 * (3 - 1) = 1.10.
+        // Still below cap (1.15), so the final `.min(cap)` → `.max(cap)`
+        // mutation (which would force 1.15) is caught here.
+        let mut three = vec![
+            make_result("m1", ChunkType::Method, Some("Hub"), 0.88),
+            make_result("m2", ChunkType::Method, Some("Hub"), 0.87),
+            make_result("m3", ChunkType::Method, Some("Hub"), 0.86),
+            make_result("Hub", ChunkType::Class, None, 0.50),
+        ];
+        let applied3 = apply_parent_boost(&mut three);
+        let boost3 = *applied3
+            .get("Hub")
+            .expect("Hub must be boosted with 3 children present");
+        let expected3 = 1.0 + cfg.parent_boost_per_child * 2.0; // 1.10
+        assert!(
+            (boost3 - expected3).abs() < 1e-6,
+            "3-children boost must be exactly {expected3}, got {boost3}"
+        );
+        // Sanity: 3-children boost is strictly larger than 2-children and both
+        // are strictly below the cap (so none is saturated).
+        assert!(boost3 > boost2);
+        assert!(boost3 < cfg.parent_boost_cap);
+    }
+
+    /// Adequacy regression: pin the inner `count >= 2` gate inside
+    /// `apply_parent_boost`'s per-container filter.
+    ///
+    /// `test_parent_boost_needs_minimum_two_children` exercises the *outer*
+    /// guard (`any parent appears 2+ times`) — with a single 1-child container
+    /// the function returns early before the inner check. So mutating the inner
+    /// `count >= 2` → `count >= 1` survived: no test put a 2+-children parent
+    /// (to pass the outer guard) alongside a *separate* 1-child container (to
+    /// expose the inner gate). This test does exactly that: `Big` has 2
+    /// children (passes the outer guard), `Solo` has 1 child and is a
+    /// container present in results. Real code must NOT boost `Solo`; the
+    /// mutant boosts it.
+    #[test]
+    fn test_parent_boost_inner_count_gate_excludes_single_child() {
+        let mut results = vec![
+            make_result("b1", ChunkType::Method, Some("Big"), 0.90),
+            make_result("b2", ChunkType::Method, Some("Big"), 0.89),
+            make_result("s1", ChunkType::Method, Some("Solo"), 0.88),
+            make_result("Big", ChunkType::Class, None, 0.50),
+            make_result("Solo", ChunkType::Class, None, 0.50),
+        ];
+        let applied = apply_parent_boost(&mut results);
+        assert!(
+            applied.contains_key("Big"),
+            "Big has 2 children — must be boosted"
+        );
+        assert!(
+            !applied.contains_key("Solo"),
+            "Solo has only 1 child — must NOT be boosted (inner count >= 2 gate)"
+        );
+    }
+
+    /// Adequacy regression: pin the deterministic id tie-break of the
+    /// re-sort at the end of `apply_parent_boost`.
+    ///
+    /// After boosting, results are re-sorted `score desc, then id asc`. No
+    /// existing parent-boost test produces two *equal* post-boost scores, so
+    /// the secondary `a.chunk.id.cmp(&b.chunk.id)` was unconstrained — flipping
+    /// it to descending left every test green. Here two boosted containers tie
+    /// on score (both `0.50 * 1.05`), so the tie-break alone decides order:
+    /// `Aaa` must precede `Zzz`.
+    #[test]
+    fn test_parent_boost_resort_id_tiebreak_ascending() {
+        let mut results = vec![
+            make_result("za", ChunkType::Method, Some("Zzz"), 0.10),
+            make_result("zb", ChunkType::Method, Some("Zzz"), 0.10),
+            make_result("aa", ChunkType::Method, Some("Aaa"), 0.10),
+            make_result("ab", ChunkType::Method, Some("Aaa"), 0.10),
+            make_result("Zzz", ChunkType::Class, None, 0.50),
+            make_result("Aaa", ChunkType::Class, None, 0.50),
+        ];
+        let applied = apply_parent_boost(&mut results);
+        // Both containers get the 2-child boost (1.05) on an identical base
+        // (0.50), so their post-boost scores are bit-identical and only the id
+        // tie-break orders them.
+        assert!(applied.contains_key("Zzz") && applied.contains_key("Aaa"));
+        let pos = |name: &str| results.iter().position(|r| r.chunk.name == name).unwrap();
+        assert!(
+            pos("Aaa") < pos("Zzz"),
+            "equal-score containers must order by id ascending (Aaa before Zzz)"
+        );
+    }
+
     // ===== chunk_importance tests =====
 
     #[test]
@@ -1141,6 +1267,111 @@ mod tests {
         assert!(
             score_boosted > score_plain,
             "Positive note should boost score"
+        );
+    }
+
+    /// Adequacy regression: pin the UPPER bound of NameBlend's
+    /// `name_boost.clamp(0.0, 1.0)`.
+    ///
+    /// `test_score_candidate_name_boost` only feeds `name_boost = 0.3` (inside
+    /// `[0,1]`) and asserts `score > 0.0`, so widening the clamp ceiling
+    /// (`clamp(0.0, 1.0)` → `clamp(0.0, 5.0)`) had no effect — the mutant
+    /// survived. The clamp is documented defense-in-depth: a deserialised
+    /// `name_boost = 5.0` would make `(1 - 5) * current` sign-flip results. We
+    /// feed an out-of-range `name_boost = 5.0` and pin that the blend behaves
+    /// as if it were clamped to exactly 1.0 (→ pure `name_score`), not the
+    /// unclamped `-4*current + 5*name_score`.
+    #[test]
+    fn test_name_blend_clamps_name_boost_above_one() {
+        let emb = test_embedding(1.0);
+        let query = test_embedding(1.0); // cosine ≈ 1.0 → base clamps to 1.0
+        let note_index = NoteBoost::Borrowed(NoteBoostIndex::new(&[]));
+        let matcher = NameMatcher::new("parseConfig");
+
+        // Out-of-range name_boost; only the clamp ceiling stops it from
+        // sign-flipping the blend.
+        let filter = SearchFilter {
+            name_boost: 5.0,
+            query_text: "parseConfig".to_string(),
+            ..Default::default()
+        };
+        let ctx = ScoringContext {
+            query: &query,
+            filter: &filter,
+            name_matcher: Some(&matcher),
+            glob_matcher: None,
+            note_index: &note_index,
+            threshold: f32::NEG_INFINITY, // never gate, observe the raw blend
+        };
+
+        // "parse" vs query "parseConfig" is the contained-by tier
+        // (name_score = name_contained_by = 0.6); base ≈ 1.0. With the boost
+        // clamped to 1.0: blend = (1-1)*1 + 1*0.6 = 0.6. With the mutant clamp
+        // to 5.0 and boost 5.0: (1-5)*1 + 5*0.6 = -4 + 3 = -1.0.
+        let score = score_candidate(&emb, Some("parse"), "src/a.rs", &ctx).unwrap();
+
+        let cfg = ScoringConfig::DEFAULT;
+        let expected = cfg.name_contained_by; // 0.6
+        assert!(
+            (score - expected).abs() < 1e-5,
+            "name_boost above 1.0 must clamp to 1.0 (blend → name_score {expected}), got {score}"
+        );
+        // Hard floor: a correctly-clamped blend can never go negative here;
+        // the unclamped mutant produces -1.0.
+        assert!(
+            score >= 0.0,
+            "clamped blend must stay non-negative, got {score}"
+        );
+    }
+
+    /// Adequacy regression: pin the LOWER bound of
+    /// `apply_scoring_pipeline`'s `embedding_score.clamp(0.0, 1.0)`.
+    ///
+    /// No existing test feeds a negative base (cosine) into the pipeline, so
+    /// loosening the floor (`clamp(0.0, 1.0)` → `clamp(-1.0, 1.0)`) survived.
+    /// The floor is documented: a negative base must not contaminate the name
+    /// blend, where the downstream `.max(0.0)` would then silently delete a
+    /// good name-only match. Here the embedding is opposite the query (cosine
+    /// ≈ -1.0) but the name matches exactly. Real code clamps base to 0.0, so
+    /// the name signal survives (score = name_score = 1.0). The mutant keeps
+    /// base = -1.0, blends to `(1-1)*(-1) + 1*1 = 1.0`... so we drop the name
+    /// weight below 1.0 to expose the contamination: with name_boost = 0.5 and
+    /// floored base 0.0 → blend = 0.5*0 + 0.5*1 = 0.5 (survives); with the
+    /// mutant base -1.0 → 0.5*(-1) + 0.5*1 = 0.0, then note `.max(0.0)` floors
+    /// it and the threshold gate drops it (→ None).
+    #[test]
+    fn test_pipeline_clamps_negative_base_floor() {
+        let emb = test_embedding(1.0);
+        let query = test_embedding(-1.0); // cosine ≈ -1.0
+        let note_index = NoteBoost::Borrowed(NoteBoostIndex::new(&[]));
+        let matcher = NameMatcher::new("parseConfig");
+
+        let filter = SearchFilter {
+            name_boost: 0.5,
+            query_text: "parseConfig".to_string(),
+            ..Default::default()
+        };
+        let ctx = ScoringContext {
+            query: &query,
+            filter: &filter,
+            name_matcher: Some(&matcher),
+            glob_matcher: None,
+            note_index: &note_index,
+            threshold: 0.25, // floored blend (0.5) clears it; contaminated (0.0) does not
+        };
+
+        // Exact name match → name_score = 1.0. With base floored to 0.0:
+        // blend = (1-0.5)*0 + 0.5*1 = 0.5, survives the threshold.
+        let score = score_candidate(&emb, Some("parseConfig"), "src/a.rs", &ctx);
+        let got = score.expect(
+            "a negative-cosine but exact-name-match candidate must survive — \
+             the base clamp floor (0.0) protects the name signal",
+        );
+        let cfg = ScoringConfig::DEFAULT;
+        let expected = 0.5 * cfg.name_exact; // 0.5
+        assert!(
+            (got - expected).abs() < 1e-5,
+            "floored base → blend equals {expected}, got {got}"
         );
     }
 

--- a/tests/cli_telemetry_render_test.rs
+++ b/tests/cli_telemetry_render_test.rs
@@ -1,0 +1,153 @@
+//! End-to-end guard for the `cqs telemetry` text renderer's kind-fallback
+//! rate branch.
+//!
+//! The renderer in `print_telemetry_text` chooses between two displays per
+//! command in the `Kind Fallbacks` section:
+//!
+//! - `fb_count <= cmd_total` → a per-invocation percentage
+//!   (`N / M  (P% of invocations)`), and
+//! - `fb_count >  cmd_total` → a bare-count fallback line
+//!   (`N / M  (fallbacks / invocations)`), because a fan-out invocation can
+//!   fire more fallbacks than there are invocations, and a percentage there
+//!   would read >100% — the misleading output the branch exists to avoid.
+//!
+//! That branch is `println!`-only (the function returns `()`), so the
+//! sibling data-layer unit tests — which assert `fallbacks <= invocations`
+//! on the aggregated `TelemetryOutput` — pass whether or not the renderer
+//! picks the right branch. Flipping the comparison (`<=` → `>`) in
+//! `print_telemetry_text` leaves every unit test green while the dashboard
+//! prints `150% of invocations`. This re-execs the real binary and reads
+//! the rendered stdout so the branch is actually constrained.
+
+mod common;
+
+use common::cqs_v1 as cqs;
+use serial_test::serial;
+use std::fs;
+use tempfile::TempDir;
+
+/// Build a tempdir whose `.cqs/telemetry.jsonl` holds the given lines.
+/// `find_project_root` falls back to CWD when no markers exist, and the
+/// child's `current_dir` is the tempdir, so cqs_dir resolves to
+/// `<tempdir>/.cqs/`.
+fn setup(lines: &[&str]) -> TempDir {
+    let dir = TempDir::new().expect("tempdir");
+    let cqs_dir = dir.path().join(".cqs");
+    fs::create_dir(&cqs_dir).expect("mkdir .cqs");
+    let body: String = lines.iter().map(|l| format!("{l}\n")).collect();
+    fs::write(cqs_dir.join("telemetry.jsonl"), body).expect("write telemetry.jsonl");
+    dir
+}
+
+/// Extract the `Kind Fallbacks` section lines from rendered text output.
+fn fallback_section(stdout: &str) -> String {
+    let mut out = String::new();
+    let mut in_section = false;
+    for line in stdout.lines() {
+        if line.contains("Kind Fallbacks") {
+            in_section = true;
+            continue;
+        }
+        if in_section {
+            // Section ends at the next blank line or top-level header.
+            if line.trim().is_empty() || line.starts_with("Sessions:") {
+                break;
+            }
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+/// When a single command's fallback count EXCEEDS its invocation count
+/// (fan-out: two `callers` invocations, three fallbacks fired within one of
+/// them), the renderer must show the bare-count line, NOT a >100% percentage.
+///
+/// Bites the `fb_count <= cmd_total` → `fb_count > cmd_total` mutation: under
+/// it the renderer enters the percentage branch and prints
+/// `(150% of invocations)`. This test then sees a `% of invocations` token
+/// in the fallback section and fails. On real code the section carries
+/// `(fallbacks / invocations)` and no percentage.
+#[test]
+#[serial]
+fn fallback_over_invocations_renders_bare_count_not_over_100_percent() {
+    let dir = setup(&[
+        r#"{"cmd":"callers","query":"a","ts":1700000001}"#,
+        r#"{"cmd":"callers","query":"b","ts":1700000002}"#,
+        // Three fallbacks all tagged with the top-level command `callers`
+        // (a fan-out within the second invocation). 3 fallbacks > 2 invokes.
+        r#"{"event":"kind_fallback","cmd":"callers","fallback_from":"impact","kind":"const","name":"X","definitions":1,"ts":1700000002}"#,
+        r#"{"event":"kind_fallback","cmd":"callers","fallback_from":"deps","kind":"const","name":"X","definitions":1,"ts":1700000002}"#,
+        r#"{"event":"kind_fallback","cmd":"callers","fallback_from":"trace","kind":"const","name":"X","definitions":1,"ts":1700000002}"#,
+    ]);
+
+    let output = cqs()
+        .arg("telemetry")
+        .env("CQS_TELEMETRY", "0")
+        .env("CQS_NO_DAEMON", "1")
+        .env("NO_COLOR", "1")
+        .current_dir(dir.path())
+        .output()
+        .expect("spawn cqs telemetry");
+
+    assert!(
+        output.status.success(),
+        "telemetry render should succeed. stderr={}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let section = fallback_section(&stdout);
+
+    assert!(
+        section.contains("callers") && section.contains("3 / 2"),
+        "expected a `callers  3 / 2` fallback line, got section:\n{section}\nfull:\n{stdout}"
+    );
+    assert!(
+        section.contains("fallbacks / invocations"),
+        "fb-count exceeding invocations must render the bare-count label, \
+         got section:\n{section}"
+    );
+    // The load-bearing guard: NO per-invocation percentage may appear for a
+    // command whose fallback count exceeds its invocations — that is exactly
+    // the misleading >100% the branch suppresses.
+    assert!(
+        !section.contains("% of invocations"),
+        "fb-count exceeding invocations must NOT render a `% of invocations` \
+         rate (would be the misleading >100% output), got section:\n{section}"
+    );
+}
+
+/// When the fallback count is WITHIN the invocation count (one fallback over
+/// two invocations), the renderer shows the per-invocation percentage. Pins
+/// the OTHER side of the branch: the `<= cmd_total` arm must produce the
+/// percentage (here 50%), so a mutation that swaps `>`/`==`/`<` on the
+/// comparison or deletes the percentage arm is caught.
+#[test]
+#[serial]
+fn fallback_within_invocations_renders_percentage() {
+    let dir = setup(&[
+        r#"{"cmd":"callers","query":"a","ts":1700000001}"#,
+        r#"{"cmd":"callers","query":"b","ts":1700000002}"#,
+        r#"{"event":"kind_fallback","cmd":"callers","fallback_from":"impact","kind":"const","name":"X","definitions":1,"ts":1700000002}"#,
+    ]);
+
+    let output = cqs()
+        .arg("telemetry")
+        .env("CQS_TELEMETRY", "0")
+        .env("CQS_NO_DAEMON", "1")
+        .env("NO_COLOR", "1")
+        .current_dir(dir.path())
+        .output()
+        .expect("spawn cqs telemetry");
+
+    assert!(output.status.success(), "telemetry render should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let section = fallback_section(&stdout);
+
+    assert!(
+        section.contains("50% of invocations"),
+        "one fallback over two invocations must render `50% of invocations`, \
+         got section:\n{section}\nfull:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## Test-hardening consolidation — adequacy/orthogonal-auditor guards

Test-only lane. Consolidates the durable guards written during the orthogonal-auditor + mutation sweep. No production code changed; every test was calibrated to go **RED under its target mutation** and **GREEN on real code**, with the pre-existing siblings staying green.

### Scoring (adequacy — parent-boost / clamp survivors)
- `test_parent_boost_exact_multiplier_unsaturated`, `test_parent_boost_inner_count_gate_excludes_single_child`, `test_parent_boost_resort_id_tiebreak_ascending` — pin the parent-boost multiplier, the single-child gate, and the resort tiebreak that the old suite routed through but did not constrain.
- `test_name_blend_clamps_name_boost_above_one`, `test_pipeline_clamps_negative_base_floor` — clamp boundaries.
- `would_accept_below_and_at_capacity` — `BoundedScoreHeap::would_accept` coverage guard (the at-capacity arm was uncovered).

### Parser (vacuous-test mutants in calls.rs)
- `test_macro_pass_emits_nothing_without_token_tree`, `test_extract_serde_callback_calls_line_numbers`, plus the serde-language guard — three mutants the macro/serde walk tests passed through without asserting.

### Watch (loom — notes-signal drain protocol)
- `notes_signal_interleaving_model`: loom model proving no lost reindex under two coalescing writers; run via `RUSTFLAGS="--cfg cqs_loom"`. (One model is `#[ignore]` — it documents the lost-write the protocol prevents.)

### Proptest (json-args ↔ argv parity)
- `test_map_parity`, `prop_cap_accepts_iff_len_le_cap`, `prop_parser_max_walk_depth_always_in_range` — algebraic properties over the json-args↔argv mapping, the response-cap boundary, and the parser depth clamp.

### Adequacy (telemetry render + diff-ref boundary)
- `tests/cli_telemetry_render_test.rs`: re-execs the binary and reads rendered stdout, pinning both arms of the `print_telemetry_text` fallback-rate branch (the println-only branch the data-layer unit test couldn't see).
- `test_run_git_diff_accepts_max_length_ref`: pins the inclusive 255-char upper bound the 256-char oversize test couldn't observe.

### Verification
All targeted tests green on real code: 5 RT-RELAY guards + 11 scoring/parser/proptest + 2 telemetry re-exec + 3 loom (1 ignored by design). `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
