### PR TITLE
fix(mcp): fail closed on slot-qualified cqs_index during daemon ramp-up

### DIFF
--- a/src/cli/batch/handlers/misc.rs
+++ b/src/cli/batch/handlers/misc.rs
@@ -290,10 +290,17 @@ pub(in crate::cli::batch) fn dispatch_notes_remove(
 /// silently reconcile the served slot while reporting `queued` (a wrong-slot
 /// reindex the caller cannot detect across the interop boundary), this handler
 /// REFUSES the mismatch with a client-facing error naming the served slot. A
-/// matching or omitted `slot` proceeds. When the served slot is not yet known
-/// (the watch loop hasn't published a snapshot — daemon ramp-up), the queue
-/// still fires but the response echoes `served_slot: null` so the caller can see
-/// the target was not verified.
+/// matching or omitted `slot` proceeds.
+///
+/// Invariant: a `queued` reindex response always carries a CONFIRMED
+/// `served_slot`; a slot-qualified request whose target cannot be confirmed
+/// fails CLOSED. When the served slot is not yet known (the watch loop hasn't
+/// published a snapshot — daemon ramp-up), a slot-qualified request cannot be
+/// verified against the served slot, so it is REFUSED rather than queued — the
+/// reconcile path can only target the served slot, and reporting `queued` for an
+/// unconfirmed slot would be the same undetectable wrong-slot lie the `Some`
+/// branch refusal prevents. Only the no-slot path queues during ramp-up (there
+/// is no slot to confirm — it reconciles the active slot).
 ///
 /// Reachable only when `build_batch_cmd` constructed `BatchCmd::Index`, which is
 /// gated behind `CQS_MCP_ENABLE_MUTATIONS` (the operator opt-in). The
@@ -311,14 +318,17 @@ pub(in crate::cli::batch) fn dispatch_index(
 
     let served_slot = ctx.served_slot();
 
-    // Refuse a request that names a slot the daemon does not serve. Failing
-    // loud beats a silent wrong-slot reindex: the reconcile path cannot target
-    // a non-served slot, so honoring the request is impossible — reporting
-    // success while reindexing a different slot would be an undetectable lie to
-    // an autonomous caller.
+    // Refuse a slot-qualified request that cannot be CONFIRMED against the slot
+    // the daemon serves. Failing loud beats a silent wrong-slot reindex: the
+    // reconcile path cannot target a non-served slot, so honoring the request is
+    // impossible — reporting success while reindexing a different (or unknown)
+    // slot would be an undetectable lie to an autonomous caller. The match is
+    // exhaustive on `served_slot` so the ramp-up window (`None`) fails closed too:
+    // a slot-qualified request always confirms its target before queueing.
     if let Some(requested) = args.slot.as_deref() {
-        if let Some(served) = served_slot.as_deref() {
-            if requested != served {
+        match served_slot.as_deref() {
+            Some(served) if requested == served => { /* confirmed — proceed to queue below */ }
+            Some(served) => {
                 tracing::warn!(
                     requested,
                     served,
@@ -330,6 +340,25 @@ pub(in crate::cli::batch) fn dispatch_index(
                         "slot '{requested}' is not the slot this daemon serves ('{served}'); \
                          the daemon reconciles only its served slot — restart `cqs watch --serve` \
                          bound to '{requested}', or omit `slot` to reindex the served slot"
+                    ),
+                )
+                .into());
+            }
+            None => {
+                // Ramp-up: the watch loop has not yet published the served slot,
+                // so a slot-qualified request cannot be confirmed. Fail closed
+                // rather than queue against an unverified slot.
+                tracing::warn!(
+                    requested,
+                    "cqs_index slot unconfirmed — refusing a slot-qualified reindex during daemon ramp-up (served slot not yet published)"
+                );
+                return Err(crate::cli::json_envelope::ClientFacingError::new(
+                    crate::cli::json_envelope::ErrorCode::InvalidInput,
+                    format!(
+                        "the daemon has not yet published its served slot (still in its ramp-up \
+                         window), so a request for slot '{requested}' cannot be verified — retry \
+                         once the daemon has published its served slot, or omit `slot` to reindex \
+                         the active slot"
                     ),
                 )
                 .into());
@@ -349,7 +378,11 @@ pub(in crate::cli::batch) fn dispatch_index(
     // that an earlier reconcile request was still un-drained (the watch loop
     // coalesces them into one walk). `served_slot` echoes the slot the queued
     // reconcile actually targets so the caller can confirm the substitution did
-    // not occur (it carries `null` only during the daemon's ramp-up window).
+    // not occur. It carries `null` only for the no-slot path during ramp-up
+    // (omitting `slot` reconciles the active slot, which needs no confirmation);
+    // a slot-QUALIFIED request that reaches this point has already confirmed its
+    // target against a published served slot, so a `queued` response from a
+    // slot-qualified request always carries a non-null, confirmed `served_slot`.
     Ok(serde_json::json!({
         "status": "queued",
         "queued": true,

--- a/src/cli/batch/json_args.rs
+++ b/src/cli/batch/json_args.rs
@@ -1498,6 +1498,72 @@ mod tests {
         );
     }
 
+    /// Ramp-up window: BEFORE the watch loop has published its first snapshot,
+    /// `served_slot()` is `None`. A slot-qualified `cqs_index` request that names
+    /// a slot the daemon does NOT serve must STILL be refused (fail-closed) — not
+    /// accepted as a `queued: true` success against whatever slot the daemon will
+    /// turn out to serve.
+    ///
+    /// The socket binds and answers light reads (`status`, `ping`) for ~10-15s
+    /// before the first snapshot publishes `active_slot`. During that window the
+    /// inner `if let Some(served)` mismatch guard is skipped, so a wrong-slot
+    /// request returns `status: queued, queued: true` while the daemon will
+    /// silently reconcile its own served slot — a success-shaped response for a
+    /// request that was not honored. An autonomous caller reading `queued: true`
+    /// reasonably concludes its requested slot was queued; the `served_slot: null`
+    /// echo is ambiguous, not a refusal.
+    ///
+    /// This is the structural blind spot the existing slot tests miss: every
+    /// other fixture plants `active_slot = Some(..)` first, so none exercises the
+    /// `None` ramp-up state. The fix is to fail closed — refuse a slot-qualified
+    /// reindex while the served slot is unknown — so the boundary holds from the
+    /// moment the socket accepts requests, not only after the first tick.
+    #[test]
+    #[serial_test::serial(mcp_mutations_env)]
+    fn index_slot_qualified_refused_during_rampup_when_served_slot_unknown() {
+        use std::sync::atomic::Ordering;
+        let _guard = MutEnvGuard::set(true);
+        let (_dir, ctx) = seed_ctx();
+        let view = ctx.build_view(None);
+
+        // The watch snapshot at its INITIAL state: `active_slot: None`. This is
+        // the live ramp-up window — the socket is up and answering, but the loop
+        // has not yet published the served slot. Do NOT overwrite it with a
+        // planted slot (unlike the warm-state tests), so `served_slot()` is None.
+        view.test_overwrite_watch_snapshot(cqs::watch_status::WatchSnapshot::unknown());
+        assert!(
+            view.served_slot().is_none(),
+            "precondition: served_slot must be None in the ramp-up window"
+        );
+
+        let mut out = Vec::new();
+        dispatch_via_view_json(
+            &view,
+            "index",
+            &json!({"slot": "attacker-chosen"}),
+            &mut out,
+        );
+        let v: serde_json::Value = serde_json::from_slice(&out).expect("JSON");
+
+        // The boundary: a slot-qualified request whose slot cannot be confirmed
+        // against the served slot must be refused, not reported as queued.
+        assert!(
+            v.get("error").is_some_and(|e| !e.is_null()),
+            "a slot-qualified index during ramp-up (served slot unknown) must be \
+             refused, not reported as a queued success, got: {v}"
+        );
+        assert!(
+            v.get("data").is_none_or(|d| d.is_null()),
+            "a refused ramp-up index must NOT return a queued data payload, got: {v}"
+        );
+        // And it must not have flipped the reconcile signal — no reindex queued
+        // for an unconfirmable slot.
+        assert!(
+            !ctx.reconcile_signal.load(Ordering::Acquire),
+            "a refused ramp-up index must NOT queue a reconcile"
+        );
+    }
+
     /// A `slot` that MATCHES the served slot proceeds to a normal queued
     /// success and echoes `served_slot` so the caller can confirm the target.
     #[test]


### PR DESCRIPTION
## Fail closed on a slot-qualified `cqs_index` during the daemon ramp-up window

### The bug (orthogonal-auditor / legacy-state finding)
`dispatch_index` nested its wrong-slot refusal inside `if let Some(served)`. During the ~10–15s ramp-up window after the daemon socket binds but before the watch loop publishes its first snapshot, `served_slot()` returns `None`, so a **slot-qualified** reindex naming a slot the daemon does **not** serve fell through to `request_reconcile()` and returned `status:queued / queued:true / served_slot:null`. The reconcile path can only target the served slot, so this is the exact undetectable-wrong-slot lie the refusal exists to prevent — leaking through the ramp-up hole. Every existing slot test plants `active_slot = Some(..)` first, so none exercised the `None` state.

### The fix (fail closed)
Replaced the nested `if let` with an exhaustive match on `served_slot` when a slot is requested:
- `Some(served)`, `requested == served` → proceed (unchanged).
- `Some(served)` mismatch → refuse (existing error, unchanged).
- `None` (ramp-up) → **refuse** with a `ClientFacingError(InvalidInput)` explaining the served slot isn't yet published, so the request can't be verified — advise retry-after-publish or omitting `slot`.

The no-slot path is untouched (omitting `slot` still queues against the active slot). Doc comments corrected: a queued reindex response now always carries a confirmed `served_slot`; `served_slot: null` is scoped to the no-slot path.

### Tests
RED guard (`json_args.rs`) pins the fail-closed contract — RED on pre-fix code (panics with the exact `served_slot:null/queued:true` payload), GREEN after. Both pre-existing `Some`-slot tests stay green. `cargo test --lib --bins -- dispatch_index index_ slot`: 164 passed, 0 failed. clippy `--all-targets` clean; provenance lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
