### PR TITLE
feat(mcp): cqs_notes_list as an unconditional MCP read tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`cqs_notes_list` — the read half of the MCP notes channel (#2021).** Lifts the read-only `notes` (list) subaction to a Phase-0 core: `NotesListArgs` now derives `serde::Deserialize` + `schemars::JsonSchema` (input-only — the `{notes, count}` output is unchanged), a `build_batch_cmd` "notes" arm deserializes the four filter knobs (`warnings`/`patterns`/`kind`/`check`), `notes` joins `JSON_ARGS_CAPABLE_COMMANDS`, and an unconditional `cqs_notes_list` read tool joins `tools/list` (26 read tools, up from 25). Read-only and ungated — `dispatch_notes` only reads the cached notes and the read-only store; the gated `cqs_notes_add/update/remove` mutators are unaffected. CLI==daemon parity pinned (a JSON-args `notes` request lists byte-identically to the argv path).
+
 ## [1.49.0] - 2026-06-24
 
 v1.48.0 16-category audit fix cycle. A full audit (16 parallel category auditors → per-category adversarial verification → triage) produced 36 verified findings consolidating to 19 rows; all P1–P3 and two of three P4 are fixed here across PRs #2038–#2042, weighted to the v1.48.0 MCP/parse/RT-RELAY churn. The scoring path is byte-identical to v1.48.0 — retrieval is unchanged. Triage in `docs/audit-triage.md`, findings in `docs/audit-findings.md`.

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ cqs mcp
 ```
 
 **Tool surface**:
-- **Default (read-only)**: 25 `cqs_`-prefixed tools — `cqs_search`, `cqs_gather`, `cqs_scout`, `cqs_task`, `cqs_onboard`, `cqs_similar`, `cqs_callers`, `cqs_callees`, `cqs_deps`, `cqs_impact`, `cqs_test_map`, `cqs_trace`, `cqs_blame`, `cqs_diff`, `cqs_drift`, `cqs_dead`, `cqs_ci`, `cqs_review`, `cqs_plan`, `cqs_read`, `cqs_where`, `cqs_related`, `cqs_stale`, `cqs_stats`, `cqs_health`. (`cqs_context`/`cqs_explain` are deliberately withheld — their relay would carry unscanned doc/signature content.)
+- **Default (read-only)**: 26 `cqs_`-prefixed tools — `cqs_search`, `cqs_gather`, `cqs_scout`, `cqs_task`, `cqs_onboard`, `cqs_similar`, `cqs_callers`, `cqs_callees`, `cqs_deps`, `cqs_impact`, `cqs_test_map`, `cqs_trace`, `cqs_blame`, `cqs_diff`, `cqs_drift`, `cqs_dead`, `cqs_ci`, `cqs_review`, `cqs_plan`, `cqs_read`, `cqs_where`, `cqs_related`, `cqs_stale`, `cqs_notes_list`, `cqs_stats`, `cqs_health`. (`cqs_context`/`cqs_explain` are deliberately withheld — their relay would carry unscanned doc/signature content.)
 - **Opt-in mutations** (`CQS_MCP_ENABLE_MUTATIONS=1`): adds 4 mutating tools — `cqs_notes_add`, `cqs_notes_update`, `cqs_notes_remove`, `cqs_index`. Notes mutations write `docs/notes.toml` (the watch loop reindexes); `cqs_index` queues a non-blocking reconcile. Neither writes the daemon's in-memory Store directly.
 - **Permanently withheld**: the destructive set (`gc`, `slot remove`, `index --force`, `model swap`, `cache clear`) is never exposed, regardless of flag value.
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -816,7 +816,17 @@ pub(crate) struct ImpactDiffArgs {
 /// `Commands::Search { args: SearchArgs }`). The flattened fields include
 /// `check`, which the daemon batch path picks up via
 /// `BatchCmd::Notes { args, .. }`.
-#[derive(Args, Debug, Clone)]
+///
+/// Also the surface-agnostic core that the daemon JSON-args path (`cqs_notes_list`)
+/// deserializes directly — the four filter knobs (`warnings` / `patterns` /
+/// `kind` / `check`) are read off the wire and consumed by `dispatch_notes`,
+/// mirroring `StaleArgs`. Input-only: it derives `Deserialize` + `JsonSchema`,
+/// never `Serialize`. The command's JSON OUTPUT is the separate `{notes, count}`
+/// object built in `dispatch_notes`, so these derives cannot change the output
+/// wire shape. `#[serde(default)]` lets a wire caller omit any filter and inherit
+/// the clap default (all `false` / `None`).
+#[derive(Args, Debug, Clone, Default, serde::Deserialize, schemars::JsonSchema)]
+#[serde(default)]
 pub(crate) struct NotesListArgs {
     /// Show only warnings (negative sentiment)
     #[arg(long)]

--- a/src/cli/batch/json_args.rs
+++ b/src/cli/batch/json_args.rs
@@ -47,9 +47,9 @@ use serde::de::DeserializeOwned;
 
 use crate::cli::args::{
     BlameArgs, CallersArgs, CiArgs, ContextArgs, DeadArgs, DepsArgs, DiffArgs, DriftArgs,
-    GatherArgs, ImpactArgs, LimitArg, OnboardArgs, OverlayArgs, PlanArgs, ReadArgs, RelatedArgs,
-    ReviewArgs, ScoutArgs, SearchArgs, SimilarArgs, StaleArgs, TaskArgs, TestMapArgs, TraceArgs,
-    WhereArgs,
+    GatherArgs, ImpactArgs, LimitArg, NotesListArgs, OnboardArgs, OverlayArgs, PlanArgs, ReadArgs,
+    RelatedArgs, ReviewArgs, ScoutArgs, SearchArgs, SimilarArgs, StaleArgs, TaskArgs, TestMapArgs,
+    TraceArgs, WhereArgs,
 };
 use crate::cli::definitions::{GateThreshold, OutputArgs, OutputFormat, TextJsonArgs};
 
@@ -186,6 +186,7 @@ pub(crate) const JSON_ARGS_CAPABLE_COMMANDS: &[&str] = &[
     "related",
     "stale",
     "task",
+    "notes",
     "stats",
     "health",
     "notes-add",
@@ -220,8 +221,8 @@ pub(crate) fn is_json_args_capable(command: &str) -> bool {
 /// `commands::dispatch` the argv path uses.
 ///
 /// An unknown command, or a command that has no Phase-0 core struct (and so is
-/// argv-only in Phase 1 — `notes`, `where`, `explain`, `read`'s siblings, the
-/// zero-arg infra commands, …), returns an error rather than dispatching.
+/// argv-only — `explain`, `context`, the zero-arg infra commands, …), returns an
+/// error rather than dispatching.
 pub(super) fn build_batch_cmd(command: &str, arguments: &serde_json::Value) -> Result<BatchCmd> {
     let _span = tracing::info_span!("json_args_build_cmd", command).entered();
 
@@ -419,6 +420,20 @@ pub(super) fn build_batch_cmd(command: &str, arguments: &serde_json::Value) -> R
         "stale" => {
             let c: StaleArgs = parse_core(command, arguments)?;
             BatchCmd::Stale {
+                args: c,
+                output: text_json(),
+            }
+        }
+        // The READ half of the notes channel (`cqs_notes_list`). The filter knobs
+        // live on the clap-side `NotesListArgs`, which IS the deserialize target
+        // here (the `stale` pattern) — so the `BatchCmd::Notes` field and the
+        // schema source are the same type. Read-only and UNGATED: `dispatch_notes`
+        // only reads the cached notes (and, with `check`, the read-only store),
+        // never `docs/notes.toml`. The JSON OUTPUT is the separate `{notes, count}`
+        // object the handler builds, so this input-only core leaves it unchanged.
+        "notes" => {
+            let c: NotesListArgs = parse_core(command, arguments)?;
+            BatchCmd::Notes {
                 args: c,
                 output: text_json(),
             }
@@ -1012,6 +1027,75 @@ mod tests {
             v_argv, v_json,
             "JSON-args output must equal argv output for `task`\nargv:  {v_argv}\njson:  {v_json}"
         );
+    }
+
+    /// Like [`seed_ctx`], plus two notes (one warning, one pattern) written to
+    /// the store BEFORE it is reopened read-only, so the daemon's note cache
+    /// (`ctx.notes()`, built at context creation) reflects them. Backs the
+    /// `notes` parity test, which needs a non-empty list to prove the filter
+    /// knobs round-trip across surfaces.
+    fn seed_ctx_with_notes() -> (TempDir, crate::cli::batch::BatchContext) {
+        use cqs::note::Note;
+        let dir = TempDir::new().expect("tempdir");
+        let cqs_dir = dir.path().join(".cqs");
+        std::fs::create_dir_all(&cqs_dir).expect("mkdir .cqs");
+        let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
+        {
+            let store = Store::open(&index_path).expect("open store");
+            store.init(&ModelInfo::default()).expect("init");
+            let notes = vec![
+                Note {
+                    id: "note:0".to_string(),
+                    text: "watch the read-only store invariant".to_string(),
+                    sentiment: -0.5,
+                    mentions: vec!["json_args.rs".to_string()],
+                    kind: None,
+                },
+                Note {
+                    id: "note:1".to_string(),
+                    text: "the command-core pattern keeps CLI and daemon in parity".to_string(),
+                    sentiment: 0.5,
+                    mentions: vec!["tools.rs".to_string()],
+                    kind: Some("design-decision".to_string()),
+                },
+            ];
+            store
+                .upsert_notes_batch(&notes, Path::new("docs/notes.toml"), 0)
+                .expect("upsert notes");
+        }
+        let ctx = create_test_context(&cqs_dir).expect("create_test_context");
+        (dir, ctx)
+    }
+
+    /// `notes` (the read-only `cqs_notes_list` tool) parity: a JSON-args request
+    /// must produce a list envelope byte-identical to the equivalent argv flags,
+    /// across the bare list, the `--warnings` filter, the `--patterns` filter,
+    /// and a `--kind` filter. Proves the input-only `NotesListArgs` core round-
+    /// trips through `build_batch_cmd` → `dispatch_notes` to the SAME output the
+    /// argv path produces — and that the four filter knobs ride the wire.
+    #[test]
+    fn parity_notes_json_args_equals_argv() {
+        let (_dir, ctx) = seed_ctx_with_notes();
+        let cases: Vec<(Vec<&str>, serde_json::Value)> = vec![
+            (vec![], json!({})),
+            (vec!["--warnings"], json!({"warnings": true})),
+            (vec!["--patterns"], json!({"patterns": true})),
+            (
+                vec!["--kind", "design-decision"],
+                json!({"kind": "design-decision"}),
+            ),
+        ];
+        for (argv, arguments) in cases {
+            let (v_argv, v_json) = run_both(&ctx, "notes", &argv, arguments);
+            assert!(
+                v_argv.get("data").is_some_and(|d| !d.is_null()),
+                "argv path for `notes` {argv:?} should return data, got: {v_argv}"
+            );
+            assert_eq!(
+                v_argv, v_json,
+                "JSON-args output must equal argv output for `notes` {argv:?}\nargv:  {v_argv}\njson:  {v_json}"
+            );
+        }
     }
 
     /// A missing optional field deserializes via `#[serde(default)]` — an empty
@@ -1754,10 +1838,11 @@ mod tests {
         // 2. A representative spread of argv-only / unknown commands is NOT
         //    capable — the catch-all bites, and they are absent from the list.
         //    (`stats` / `health` are Phase-1 zero-arg read tools,
-        //    `where` / `related` / `stale` are Phase-2 read tools, and `task`
-        //    is the Phase-3 overlay-capable brief tool — all capable now — so
-        //    they are deliberately excluded from this not-capable spread.)
-        for cmd in ["explain", "notes", "ping", "nonexistent_cmd"] {
+        //    `where` / `related` / `stale` are Phase-2 read tools, `task` is the
+        //    Phase-3 overlay-capable brief tool, and `notes` is the read-only
+        //    notes-list tool — all capable now — so they are deliberately
+        //    excluded from this not-capable spread.)
+        for cmd in ["explain", "ping", "nonexistent_cmd"] {
             assert!(
                 !is_json_args_capable(cmd),
                 "`{cmd}` is argv-only/unknown but build_batch_cmd treats it as JSON-args-capable"

--- a/src/cli/mcp/mod.rs
+++ b/src/cli/mcp/mod.rs
@@ -148,11 +148,11 @@ mod tests {
     ///
     /// With `CQS_MCP_ENABLE_MUTATIONS` unset, the exposed MCP tool set must
     /// equal the daemon's JSON-args-capable read command set MINUS the withheld
-    /// set — 25 read tools (the zero-arg `stats`/`health`, the Phase-2
-    /// `where`/`related`/`stale`, and the Phase-3 overlay-capable `task`), zero
-    /// mutation delta. Fails if a JSON-args command is added/removed without
-    /// updating the MCP surface, or if a withheld command leaks into
-    /// `tools/list`.
+    /// set — 26 read tools (the zero-arg `stats`/`health`, the Phase-2
+    /// `where`/`related`/`stale`, the Phase-3 overlay-capable `task`, and the
+    /// read-only `notes`), zero mutation delta. Fails if a JSON-args command is
+    /// added/removed without updating the MCP surface, or if a withheld command
+    /// leaks into `tools/list`.
     #[test]
     #[serial_test::serial(mcp_mutations_env)]
     fn tools_list_matches_json_args_registry() {
@@ -164,18 +164,18 @@ mod tests {
             "MCP tools/list (flag off) must equal the JSON-args read registry minus the \
              withheld set.\nexposed (mapped to commands): {exposed:?}\nexpected: {expected:?}"
         );
-        // The flag-off read surface = exactly 25 read tools.
+        // The flag-off read surface = exactly 26 read tools.
         assert_eq!(
             exposed.len(),
-            25,
-            "flag-off tools/list must expose 25 tools"
+            26,
+            "flag-off tools/list must expose 26 tools"
         );
     }
 
     /// Flag-gating guard: the mutation tools are present IFF
     /// `CQS_MCP_ENABLE_MUTATIONS=1`. With the flag on, the exposed set is the
     /// read set PLUS exactly the three notes mutators AND the fire-and-forget
-    /// `index` (29 total).
+    /// `index` (30 total).
     #[test]
     #[serial_test::serial(mcp_mutations_env)]
     fn mutation_tools_present_iff_flag_set() {
@@ -207,7 +207,7 @@ mod tests {
                 "flag-on tools/list must be the read set plus exactly the 3 notes mutators \
                  and the index queue tool"
             );
-            assert_eq!(on.len(), 29, "flag-on tools/list must expose 29 tools");
+            assert_eq!(on.len(), 30, "flag-on tools/list must expose 30 tools");
         }
     }
 

--- a/src/cli/mcp/tools.rs
+++ b/src/cli/mcp/tools.rs
@@ -179,6 +179,7 @@ fn schema_with_overlay<T: schemars::JsonSchema>() -> Value {
 // Core struct aliases — identical import paths to
 // `cli::batch::json_args`, so the schema source and the daemon deserialize
 // target are provably the same type.
+use crate::cli::args::NotesListArgs as NotesListCore;
 use crate::cli::args::ReadArgs;
 use crate::cli::args::StaleArgs as StaleCore;
 use crate::cli::commands::blame::BlameArgs as BlameCore;
@@ -423,6 +424,16 @@ fn read_tools() -> &'static [ToolDef] {
                  (missing) since the last index, plus the total indexed count. Use count_only \
                  for just the counts.",
             input_schema: schema::<StaleCore>,
+            annotations: ToolAnnotations::READ,
+        },
+        ToolDef {
+            name: "cqs_notes_list",
+            command: "notes",
+            description:
+                "List project notes/observations (sentiment-tagged context that biases search \
+                 ranking): filter to warnings (negative) or patterns (positive), or by kind tag. \
+                 Read-only. Set check to flag mentions whose files or symbols are stale.",
+            input_schema: schema::<NotesListCore>,
             annotations: ToolAnnotations::READ,
         },
         // Zero-arg read tools (MCP Phase 1). Both take no input — their cores
@@ -773,6 +784,7 @@ fn validate_arguments(command: &str, arguments: &Value) -> Result<(), String> {
         "where" => check::<WhereCore>(arguments),
         "related" => check::<RelatedCore>(arguments),
         "stale" => check::<StaleCore>(arguments),
+        "notes" => check::<NotesListCore>(arguments),
         // Zero-arg read tools (Phase 1). The core has no advertised properties,
         // so the shape check just rejects a non-object / wrong-typed `arguments`.
         "stats" => check::<StatsCore>(arguments),
@@ -1189,6 +1201,10 @@ mod tests {
         assert_eq!(mcp_name_to_command("cqs_test_map"), "test-map");
         assert_eq!(mcp_name_to_command("cqs_search"), "search");
         assert_eq!(mcp_name_to_command("cqs_callers"), "callers");
+        // `cqs_notes_list` maps to the bare verb `notes` via the table, NOT to
+        // the underscore-strip fallback (`notes-list`) — the multi-word MCP name
+        // resolves through the `name`/`command` columns.
+        assert_eq!(mcp_name_to_command("cqs_notes_list"), "notes");
     }
 
     /// Collect `cqs_<ident>` tokens from `text`, in order.


### PR DESCRIPTION
## `cqs_notes_list` — expose the read-only `notes` list as an unconditional MCP tool

The next command-core increment of the MCP re-introduction. The read-only `notes` (list) subaction was argv-only — not in `JSON_ARGS_CAPABLE_COMMANDS`, no JSON-args `build_batch_cmd` arm, no MCP tool (only the gated `cqs_notes_add/update/remove` mutators existed). This adds the READ half properly.

### What changed
- **Phase-0 core:** `NotesListArgs` now derives `Default + serde::Deserialize + schemars::JsonSchema` with `#[serde(default)]` (input-only — output JSON unaffected). Followed the existing `stale` precedent (one struct deriving both clap `Args` and serde+schemars) rather than minting a parallel `NotesListCore` + converter, which only earns its keep when the clap struct and core diverge (they don't here) — lower drift, no conversion fn that could silently drop a field.
- **JSON-args wiring:** a `notes` arm in `build_batch_cmd`; `notes` added to `JSON_ARGS_CAPABLE_COMMANDS`.
- **MCP tool:** `cqs_notes_list` ToolDef in `read_tools()` (command `notes`, `schema::<NotesListArgs>`, READ annotation), unconditional (flag-off). Tool count: flag-off **25→26**, flag-on **29→30**.

### Guards reconciled (every derived single-source the new const entry touches)
`tools_list_matches_json_args_registry` (count), `mutation_tools_present_iff_flag_set` (count), `json_args_capability_matches_arms` (moved `notes` out of the not-capable spread), `mcp_name_to_command` round-trip (`cqs_notes_list`→`notes`), `readme_read_tool_list_matches_registry` (README order matches `tool_table()`).

### Tests
New `parity_notes_json_args_equals_argv` proves byte-identical CLI==daemon list output across `{}`/`--warnings`/`--patterns`/`--kind`. json_args 40 passed, mcp 31 passed, notes 33 passed, `cli_mcp_bridge_test` 8 passed. clippy `--all-targets` clean; provenance lint clean. Daemon `Store` stays read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
