### PR TITLE
feat(serve): SPLADE viz Stage 2a — query-anchored mechanism step-through

### DIFF
--- a/src/serve/assets/app.css
+++ b/src/serve/assets/app.css
@@ -168,3 +168,95 @@ main {
 
 .hint { color: #888; font-size: 13px; }
 .error { color: #c33; font-size: 13px; padding: 8px; background: #fee; border-radius: 4px; }
+
+/* ── Cluster mechanism mode (query-anchored SPLADE↔dense step-through) ── */
+
+/* The mechanism query control rides inside #cluster-controls. The .btn-group
+   shell is shared with color/hierarchy; here it wraps an input + trace btn. */
+#cluster-mech { overflow: visible; }
+#cluster-mech #mech-query {
+  border: none;
+  padding: 5px 8px;
+  font-size: 12px;
+  width: 230px;
+  outline: none;
+}
+#cluster-mech #mech-run {
+  background: #4a86e8;
+  color: #fff;
+  border: none;
+  border-left: 1px solid #d0d0d0;
+  padding: 5px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+#cluster-mech #mech-run:hover { background: #3a76d8; }
+
+/* The mechanism side panel floats over the cluster canvas (the cluster view
+   appends it into #cy, which is position:relative). It carries the honest
+   per-leg numbers — the mechanism is read here, not encoded in node color. */
+.mech-panel {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  width: 340px;
+  max-height: calc(100% - 24px);
+  overflow-y: auto;
+  background: rgba(20, 26, 38, 0.94);
+  color: #d8dee9;
+  border: 1px solid #2a3550;
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-size: 12px;
+  z-index: 20;
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.4);
+}
+.mech-panel code { background: rgba(255, 255, 255, 0.08); color: #e8edf5; padding: 1px 4px; border-radius: 3px; }
+.mech-panel .error { color: #ff9a9a; background: rgba(120, 30, 30, 0.4); }
+
+.mech-panel-head { border-bottom: 1px solid #2a3550; padding-bottom: 8px; margin-bottom: 8px; }
+.mech-title { font-weight: 600; font-size: 13px; margin-bottom: 6px; color: #fff; }
+
+.mech-steptabs { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; margin-bottom: 6px; }
+.mech-btn {
+  background: #2a3550;
+  color: #cdd6e6;
+  border: 1px solid #3a4870;
+  border-radius: 3px;
+  padding: 3px 9px;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.mech-btn:hover:not(:disabled) { background: #36456b; }
+.mech-btn:disabled { opacity: 0.4; cursor: default; }
+.mech-btn.mech-clear { margin-left: auto; background: transparent; border-color: #555f78; color: #98a4bd; }
+.mech-stepname { font-size: 11px; color: #9aa6bf; }
+
+.mech-legend { display: flex; gap: 12px; font-size: 11px; color: #9aa6bf; margin-bottom: 6px; }
+.mech-legend span { display: inline-flex; align-items: center; gap: 4px; }
+.mech-dot { display: inline-block; width: 9px; height: 9px; border-radius: 50%; flex-shrink: 0; }
+
+.mech-note { font-size: 10.5px; line-height: 1.45; color: #8591ab; }
+
+.mech-rows { margin-top: 8px; }
+.mech-row {
+  padding: 6px 6px;
+  border-radius: 4px;
+  margin-bottom: 4px;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid transparent;
+}
+.mech-row:hover { background: rgba(255, 255, 255, 0.08); border-color: #3a4870; }
+.mech-row-head { display: flex; align-items: center; gap: 6px; margin-bottom: 2px; }
+.mech-name { font-weight: 600; color: #e8edf5; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.mech-offview { font-size: 10px; color: #c9a04a; border: 1px solid #6b5a2a; border-radius: 3px; padding: 0 3px; }
+.mech-loc { font-size: 10.5px; color: #8591ab; margin-bottom: 3px; }
+.mech-loc code { background: transparent; padding: 0; color: #8591ab; }
+.mech-legs { display: flex; flex-direction: column; gap: 1px; }
+.mech-leg { font-size: 11px; color: #b8c2d8; font-variant-numeric: tabular-nums; }
+
+.mech-status { color: #9aa6bf; font-size: 12px; padding: 4px 0; line-height: 1.4; }
+.mech-status.error { color: #ff9a9a; }

--- a/src/serve/assets/app.js
+++ b/src/serve/assets/app.js
@@ -24,6 +24,8 @@
   const $depthGroup = document.getElementById("hierarchy-depth");
   const $clusterControls = document.getElementById("cluster-controls");
   const $colorGroup = document.getElementById("cluster-color");
+  const $mechQuery = document.getElementById("mech-query");
+  const $mechRun = document.getElementById("mech-run");
 
   // --- View registry ---
   const VIEWS = {
@@ -306,6 +308,17 @@
     }
   }
 
+  // Drive the cluster view's query-anchored mechanism step-through. Only the
+  // cluster view implements `runMechanism`; for any other view this is a no-op.
+  function runMechanism() {
+    if (!$mechQuery) return;
+    const q = $mechQuery.value.trim();
+    if (currentView && typeof currentView.runMechanism === "function") {
+      setStatus(q ? `mechanism: ${q}` : "");
+      currentView.runMechanism(q);
+    }
+  }
+
   async function loadChunkDetail(id) {
     $sidebar.innerHTML = `<p class="hint">loading…</p>`;
     try {
@@ -452,6 +465,18 @@
         const v = btn.getAttribute("data-color");
         if (v) setClusterColor(v);
       });
+    });
+  }
+  // Cluster mechanism mode: trace button + Enter in the query input.
+  if ($mechRun) {
+    $mechRun.addEventListener("click", () => runMechanism());
+  }
+  if ($mechQuery) {
+    $mechQuery.addEventListener("keydown", (ev) => {
+      if (ev.key === "Enter") {
+        ev.preventDefault();
+        runMechanism();
+      }
     });
   }
   $search.addEventListener("input", onSearchInput);

--- a/src/serve/assets/index.html
+++ b/src/serve/assets/index.html
@@ -22,6 +22,12 @@
         <button type="button" data-color="type" class="active">type</button>
         <button type="button" data-color="language">language</button>
       </div>
+      <div id="cluster-mech" class="btn-group" role="group" aria-label="mechanism mode">
+        <span class="btn-group-label">mechanism</span>
+        <input id="mech-query" type="text" placeholder="query → dense→+SPLADE→fused" autocomplete="off"
+               title="Step through how SPLADE fusion changes the ranking, overlaid on the dense-cosine UMAP plane">
+        <button type="button" id="mech-run" title="run the dense / +SPLADE / fused step-through">trace</button>
+      </div>
     </div>
     <div id="hierarchy-controls" class="hierarchy-controls" style="display:none;" aria-label="hierarchy controls">
       <div id="hierarchy-direction" class="btn-group" role="group" aria-label="direction">

--- a/src/serve/assets/views/cluster-3d.js
+++ b/src/serve/assets/views/cluster-3d.js
@@ -63,6 +63,23 @@
   const XY_SCALE = 60; // tightens or spreads the UMAP layout
   const Y_SCALE = 12; // amplification on caller_count → vertical lift
 
+  // Mechanism-mode palette. Each step lights a role; the win framing is
+  // rank-elevation (fused rank better than dense-alone rank), NOT a per-chunk
+  // good/bad color and NOT gold-relevance (that is a later stage). Roles:
+  //   dense   — chunk the dense (cosine) leg ranked (HNSW leg)
+  //   splade  — chunk SPLADE found that dense ranked low/absent (the story)
+  //   fused   — chunk fusion elevated over its dense-alone rank
+  //   base    — every other node, dimmed
+  const MECH_COLORS = {
+    dense: "#4a86e8", // blue    — dense leg
+    splade: "#e0529c", // magenta — SPLADE-only / dense-low pulls
+    fused: "#f5a623", // amber   — fusion elevated over dense-alone
+    dimmed: "rgba(120,130,150,0.16)", // dimmed base layer
+  };
+
+  // Number of top entries per leg used to drive the step-through highlight.
+  const MECH_TOP_K = 20;
+
   function colorByType(kind) {
     return TYPE_COLORS[kind] || "#999";
   }
@@ -75,6 +92,15 @@
     return Math.max(1.5, Math.min(8, 1.5 + Math.sqrt(callers) * 0.6));
   }
 
+  function fmtScore(x) {
+    if (x === null || x === undefined || Number.isNaN(x)) return "—";
+    return Number(x).toFixed(3);
+  }
+
+  function fmtRank(r) {
+    return r && r > 0 ? `#${r}` : "absent";
+  }
+
   window.CqsCluster3D = {
     graph: null,
     container: null,
@@ -84,6 +110,23 @@
     selected: null,
     nodeIndex: new Map(),
     colorMode: "type", // "type" or "language"
+
+    // ── Mechanism mode (query-anchored step-through) ──────────────────────
+    // `mechActive` gates the dimmed-base + per-step highlight rendering.
+    // `mechLegs` holds the last `/api/search_legs` payload's `.legs`
+    //   ({dense, sparse, fused} arrays, or null when fusion did not run).
+    // `mechResults` holds the payload's `.results` chunk metadata (path/name).
+    // `mechStep` is 0 (dense) / 1 (+SPLADE) / 2 (fused).
+    // `mechRole` maps chunk_id → role string ("dense"|"splade"|"fused") for the
+    //   ACTIVE step only; recomputed on every step change.
+    // `mechPanel` is the overlay DOM node carrying the per-leg numbers.
+    mechActive: false,
+    mechLegs: null,
+    mechResults: [],
+    mechQuery: "",
+    mechStep: 0,
+    mechRole: new Map(),
+    mechPanel: null,
 
     async init(container, options) {
       this.container = container;
@@ -163,11 +206,17 @@
       this.graph = ForceGraph3D()(this.container)
         .graphData({ nodes, links: [] })
         .backgroundColor("#0d1117")
-        .nodeLabel(
-          (n) =>
-            `${n.name} · ${n.kind} · ${n.language} · ${n.callers} callers`,
-        )
+        .nodeLabel((n) => this.nodeLabelText(n))
         .nodeColor((n) => {
+          // Mechanism mode overrides the base palette: dimmed base layer with
+          // the active step's role chunks lit. Selection still wins so a
+          // clicked chunk stays findable.
+          if (this.mechActive) {
+            if (this.selected === n.id) return "#fff";
+            const role = this.mechRole.get(n.id);
+            if (role) return MECH_COLORS[role] || MECH_COLORS.dense;
+            return MECH_COLORS.dimmed;
+          }
           if (this.selected === n.id) return "#fc0";
           if (this.highlighted.has(n.id)) return "#ff8c00";
           if (n.dead) return "#c33";
@@ -175,7 +224,15 @@
             ? colorByLanguage(n.language)
             : colorByType(n.kind);
         })
-        .nodeVal((n) => Math.pow(nodeRadius(n.callers), 2))
+        .nodeVal((n) => {
+          // In mech mode, inflate role chunks so the lit set reads against the
+          // dimmed base; base nodes shrink so the highlight carries.
+          if (this.mechActive) {
+            const base = Math.pow(nodeRadius(n.callers), 2);
+            return this.mechRole.has(n.id) ? base * 3.5 : base * 0.5;
+          }
+          return Math.pow(nodeRadius(n.callers), 2);
+        })
         .nodeOpacity(0.85)
         // No edges — explicitly empty links makes the cluster shape
         // legible. Edges add too much visual noise at this density.
@@ -188,9 +245,7 @@
         })
         .onNodeHover((node) => {
           if (node && this.cb.onNodeHover) {
-            this.cb.onNodeHover(
-              `${node.name} · ${node.kind} · ${node.language} · ${node.callers} callers`,
-            );
+            this.cb.onNodeHover(this.nodeLabelText(node));
           } else if (!node && this.cb.onNodeHover) {
             this.cb.onNodeHover("");
           }
@@ -217,6 +272,360 @@
       if (mode !== "type" && mode !== "language") return;
       this.colorMode = mode;
       if (this.graph) this.graph.refresh();
+    },
+
+    // Hover/label text. In mechanism mode, append the per-leg roles so the
+    // tooltip carries the mechanism even before the panel is read.
+    nodeLabelText(n) {
+      const base = `${n.name} · ${n.kind} · ${n.language} · ${n.callers} callers`;
+      if (!this.mechActive) return base;
+      const role = this.mechRole.get(n.id);
+      const roleTag = role ? ` · [${role}]` : "";
+      return base + roleTag;
+    },
+
+    // ── Mechanism mode entry point ────────────────────────────────────────
+    // Fetches the three pre-fusion legs for `query` and enters the dimmed-base
+    // step-through. Honesty: dense scores are RAW cosine in [-1,1], only the
+    // sparse leg is min-max'd; a dense `present_in_pool=false` chunk has an
+    // INJECTED 0.0 cosine (absent, not zero-similar). Handles the daemon-down
+    // 503 and the "fusion did not run" (legs:null) cases without crashing.
+    async runMechanism(query) {
+      if (!this.graph) return;
+      const q = (query || "").trim();
+      if (q.length < 2) {
+        this.clearMechanism();
+        return;
+      }
+      this.ensureMechPanel();
+      this.mechSetPanelHtml(
+        `<div class="mech-status">querying legs for <code>${escapeHtml(q)}</code>…</div>`,
+      );
+      let resp;
+      try {
+        resp = await fetch(
+          `/api/search_legs?q=${encodeURIComponent(q)}&k=${MECH_TOP_K}`,
+        );
+      } catch (e) {
+        this.mechSetPanelHtml(
+          `<div class="mech-status error">mechanism fetch error: ${escapeHtml(e.message)}</div>`,
+        );
+        return;
+      }
+      if (resp.status === 503) {
+        let msg = "mechanism mode requires the retrieval daemon (cqs watch --serve)";
+        try {
+          const body = await resp.text();
+          if (body) msg = body.slice(0, 240);
+        } catch (_e) {
+          /* keep default */
+        }
+        this.mechSetPanelHtml(
+          `<div class="mech-status error">mechanism unavailable (503): ${escapeHtml(msg)}</div>`,
+        );
+        return;
+      }
+      if (!resp.ok) {
+        let body = "";
+        try {
+          body = await resp.text();
+        } catch (_e) {
+          /* ignore */
+        }
+        this.mechSetPanelHtml(
+          `<div class="mech-status error">legs HTTP ${resp.status}: ${escapeHtml(body.slice(0, 200))}</div>`,
+        );
+        return;
+      }
+      let body;
+      try {
+        body = await resp.json();
+      } catch (e) {
+        this.mechSetPanelHtml(
+          `<div class="mech-status error">legs parse error: ${escapeHtml(e.message)}</div>`,
+        );
+        return;
+      }
+
+      // The serve handler forwards the daemon's dispatch envelope verbatim,
+      // which wraps the SearchLegsOutput under a `data` key (sibling of an
+      // optional `_meta`). Peel it; tolerate a bare/unwrapped shape too so the
+      // join is robust to either envelope.
+      const data = body && body.data ? body.data : body;
+
+      this.mechQuery = data.query || q;
+      this.mechResults = Array.isArray(data.results) ? data.results : [];
+
+      if (!data.legs) {
+        // Fusion did not run for this query (no SPLADE index, or an
+        // FTS-by-name short-circuit before embedding). The three-leg view is
+        // only defined when fusion ran — say so, don't fake it.
+        this.mechLegs = null;
+        this.mechActive = false;
+        this.mechRole = new Map();
+        this.graph.refresh();
+        this.mechSetPanelHtml(
+          `<div class="mech-status">no SPLADE fusion ran for <code>${escapeHtml(this.mechQuery)}</code> ` +
+            `(query short-circuited or no SPLADE index on this surface). ` +
+            `The three-leg mechanism view is only defined when fusion runs.</div>`,
+        );
+        return;
+      }
+
+      this.mechLegs = {
+        dense: Array.isArray(data.legs.dense) ? data.legs.dense : [],
+        sparse: Array.isArray(data.legs.sparse) ? data.legs.sparse : [],
+        fused: Array.isArray(data.legs.fused) ? data.legs.fused : [],
+      };
+      this.mechActive = true;
+      this.mechSetStep(0);
+    },
+
+    // Leave mechanism mode: restore the base palette + clear the panel.
+    clearMechanism() {
+      this.mechActive = false;
+      this.mechLegs = null;
+      this.mechResults = [];
+      this.mechQuery = "";
+      this.mechStep = 0;
+      this.mechRole = new Map();
+      if (this.graph) this.graph.refresh();
+      if (this.mechPanel) {
+        this.mechPanel.style.display = "none";
+        this.mechPanel.innerHTML = "";
+      }
+    },
+
+    // Move to step `s` (0=dense, 1=+SPLADE, 2=fused), recompute roles, repaint.
+    mechSetStep(s) {
+      if (!this.mechActive || !this.mechLegs) return;
+      this.mechStep = Math.max(0, Math.min(2, s));
+      this.mechRole = this.computeMechRoles(this.mechStep);
+      if (this.graph) this.graph.refresh();
+      this.renderMechPanel();
+    },
+
+    mechNextStep() {
+      this.mechSetStep(this.mechStep + 1);
+    },
+
+    mechPrevStep() {
+      this.mechSetStep(this.mechStep - 1);
+    },
+
+    // Compute the chunk_id → role map for the active step. Roles are CUMULATIVE
+    // across steps (a dense chunk stays "dense" in step 1 unless SPLADE claims
+    // it as a low-dense pull). The "story" sets:
+    //   step 0: dense top-k present_in_pool      → role "dense"
+    //   step 1: + sparse top-k; chunks SPLADE found that dense ranked low/absent
+    //           → role "splade"; the rest of dense stays "dense"
+    //   step 2: fused ranking; chunks whose fused rank beats their dense-alone
+    //           rank (or were dense-absent) → role "fused"; the rest of the
+    //           fused set stays "dense"
+    computeMechRoles(step) {
+      const roles = new Map();
+      const legs = this.mechLegs;
+      if (!legs) return roles;
+
+      // Dense rank lookup (0 = absent). Used to judge "dense ranked low".
+      const denseRank = new Map();
+      for (const e of legs.dense) denseRank.set(e.chunk_id, e.rank || 0);
+
+      // Step 0 + base for later steps: dense top-k that the dense leg returned.
+      const denseTop = legs.dense
+        .filter((e) => e.present_in_pool && e.rank > 0)
+        .slice(0, MECH_TOP_K);
+      for (const e of denseTop) roles.set(e.chunk_id, "dense");
+
+      if (step >= 1) {
+        // SPLADE top-k. A chunk SPLADE ranks but dense ranked low (worse than
+        // the dense top-k window) or never retrieved is the "SPLADE found what
+        // dense missed" story → role "splade". Otherwise it overlaps dense.
+        const sparseTop = legs.sparse
+          .filter((e) => e.present_in_pool && e.rank > 0)
+          .slice(0, MECH_TOP_K);
+        for (const e of sparseTop) {
+          const dr = denseRank.get(e.chunk_id) || 0;
+          const denseLowOrAbsent = dr === 0 || dr > MECH_TOP_K;
+          if (denseLowOrAbsent) {
+            roles.set(e.chunk_id, "splade");
+          } else if (!roles.has(e.chunk_id)) {
+            roles.set(e.chunk_id, "dense");
+          }
+        }
+      }
+
+      if (step >= 2) {
+        // Fused ranking. A chunk the fusion ELEVATES over its dense-alone rank
+        // (better fused rank than dense rank, or dense-absent) is the
+        // "fusion pulled this up" set → role "fused". The win framing here is
+        // strictly rank-elevation — NOT gold relevance, NOT a per-chunk +/−.
+        for (const e of legs.fused) {
+          const fr = e.rank || 0;
+          if (fr === 0) continue;
+          const dr = denseRank.get(e.chunk_id) || 0;
+          const elevated = dr === 0 || fr < dr;
+          if (elevated) {
+            roles.set(e.chunk_id, "fused");
+          } else if (!roles.has(e.chunk_id)) {
+            roles.set(e.chunk_id, "dense");
+          }
+        }
+      }
+
+      return roles;
+    },
+
+    // ── Side panel (per-leg numbers, honest labels) ───────────────────────
+    ensureMechPanel() {
+      if (this.mechPanel || !this.container) return;
+      const panel = document.createElement("div");
+      panel.className = "mech-panel";
+      panel.style.display = "none";
+      // Click a row to focus that chunk in the cluster (joins by chunk_id).
+      panel.addEventListener("click", (ev) => {
+        const row = ev.target.closest("[data-chunk-id]");
+        if (!row) return;
+        const id = row.getAttribute("data-chunk-id");
+        if (id) {
+          this.onNodeFocus(id);
+          if (this.cb && this.cb.onNodeClick) this.cb.onNodeClick(id);
+        }
+      });
+      this.container.appendChild(panel);
+      this.mechPanel = panel;
+    },
+
+    mechSetPanelHtml(html) {
+      this.ensureMechPanel();
+      if (!this.mechPanel) return;
+      this.mechPanel.style.display = "block";
+      this.mechPanel.innerHTML = html;
+    },
+
+    // Render the per-leg numbers for the chunks the active step lights, joined
+    // by chunk_id. Numbers ride on text (the mechanism is read here, not
+    // encoded in color). Honest labels per leg.
+    renderMechPanel() {
+      this.ensureMechPanel();
+      if (!this.mechPanel || !this.mechLegs) return;
+
+      const denseById = new Map(this.mechLegs.dense.map((e) => [e.chunk_id, e]));
+      const sparseById = new Map(this.mechLegs.sparse.map((e) => [e.chunk_id, e]));
+      const fusedById = new Map(this.mechLegs.fused.map((e) => [e.chunk_id, e]));
+      const metaById = new Map(this.mechResults.map((r) => [r.chunk_id, r]));
+
+      const stepNames = ["dense top-k", "+ SPLADE top-k", "α-fused result"];
+      const stepName = stepNames[this.mechStep] || "";
+
+      // The chunks in focus = those the active step assigns a (non-dimmed) role,
+      // ordered by the leg most relevant to the step.
+      let focusIds;
+      if (this.mechStep === 0) {
+        focusIds = this.mechLegs.dense
+          .filter((e) => this.mechRole.get(e.chunk_id) === "dense")
+          .map((e) => e.chunk_id);
+      } else if (this.mechStep === 1) {
+        // SPLADE pulls first (the story), then the dense overlap.
+        const splade = this.mechLegs.sparse
+          .filter((e) => this.mechRole.get(e.chunk_id) === "splade")
+          .map((e) => e.chunk_id);
+        const dense = this.mechLegs.dense
+          .filter((e) => this.mechRole.get(e.chunk_id) === "dense")
+          .map((e) => e.chunk_id);
+        focusIds = splade.concat(dense.filter((id) => !splade.includes(id)));
+      } else {
+        focusIds = this.mechLegs.fused
+          .filter((e) => this.mechRole.has(e.chunk_id))
+          .map((e) => e.chunk_id);
+      }
+      // De-dup preserving order.
+      focusIds = Array.from(new Set(focusIds));
+
+      const rolesCount = { dense: 0, splade: 0, fused: 0 };
+      for (const r of this.mechRole.values()) {
+        if (rolesCount[r] !== undefined) rolesCount[r] += 1;
+      }
+
+      const rows = focusIds
+        .map((id) => {
+          const d = denseById.get(id);
+          const s = sparseById.get(id);
+          const f = fusedById.get(id);
+          const meta = metaById.get(id);
+          const role = this.mechRole.get(id) || "—";
+          const node = this.nodeIndex.get(id);
+          const inView = this.nodeIds.has(id);
+          const name = meta
+            ? meta.name
+            : node
+              ? node.name
+              : id.slice(0, 12);
+          const loc = meta
+            ? `${meta.file}:${meta.line_start}`
+            : node
+              ? `${node.file}:${node.line}`
+              : "";
+          const dotColor = MECH_COLORS[role] || "#888";
+          const offView = inView
+            ? ""
+            : ` <span class="mech-offview" title="not in the loaded cluster (raise ?max=N)">off-view</span>`;
+          const denseAbsent = d && !d.present_in_pool;
+          const sparseAbsent = s && !s.present_in_pool;
+          return (
+            `<div class="mech-row" data-chunk-id="${escapeHtml(id)}">` +
+            `<div class="mech-row-head">` +
+            `<span class="mech-dot" style="background:${dotColor}"></span>` +
+            `<span class="mech-name">${escapeHtml(name)}</span>${offView}` +
+            `</div>` +
+            `<div class="mech-loc"><code>${escapeHtml(loc)}</code></div>` +
+            `<div class="mech-legs">` +
+            `<span class="mech-leg" title="raw cosine in [-1,1], NOT normalized${denseAbsent ? "; injected 0.0 (dense-absent)" : ""}">` +
+            `dense ${fmtRank(d ? d.rank : 0)} · cos ${fmtScore(d ? d.raw_cosine : null)}${denseAbsent ? " (inj)" : ""}</span>` +
+            `<span class="mech-leg" title="min-max normalized to [0,1] per-query (the fused value); raw dot is stable across queries${sparseAbsent ? "; absent from sparse pool" : ""}">` +
+            `splade ${fmtRank(s ? s.rank : 0)} · mm ${fmtScore(s ? s.minmax_score : null)} · dot ${fmtScore(s ? s.raw_splade_dot : null)}</span>` +
+            `<span class="mech-leg" title="fused = α·dense_raw_cosine + (1−α)·sparse_minmax">` +
+            `fused ${fmtRank(f ? f.rank : 0)} · ${fmtScore(f ? f.fused_score : null)}</span>` +
+            `</div>` +
+            `</div>`
+          );
+        })
+        .join("");
+
+      const html =
+        `<div class="mech-panel-head">` +
+        `<div class="mech-title">mechanism · <code>${escapeHtml(this.mechQuery)}</code></div>` +
+        `<div class="mech-steptabs">` +
+        `<button type="button" class="mech-btn" data-mech="prev"${this.mechStep === 0 ? " disabled" : ""}>‹ prev</button>` +
+        `<span class="mech-stepname">step ${this.mechStep + 1}/3 · ${escapeHtml(stepName)}</span>` +
+        `<button type="button" class="mech-btn" data-mech="next"${this.mechStep === 2 ? " disabled" : ""}>next ›</button>` +
+        `<button type="button" class="mech-btn mech-clear" data-mech="clear">clear</button>` +
+        `</div>` +
+        `<div class="mech-legend">` +
+        `<span><span class="mech-dot" style="background:${MECH_COLORS.dense}"></span>dense</span>` +
+        `<span><span class="mech-dot" style="background:${MECH_COLORS.splade}"></span>SPLADE-pull</span>` +
+        `<span><span class="mech-dot" style="background:${MECH_COLORS.fused}"></span>fused-elevated</span>` +
+        `</div>` +
+        `<div class="mech-note">Plane = dense-cosine UMAP (stochastic, locally faithful, ` +
+        `globally distorted — NOT a metric, NOT a divergence map). SPLADE structure is ` +
+        `non-positional. "Elevated" = fused rank beats dense-alone rank (rank-elevation, ` +
+        `not gold relevance).</div>` +
+        `</div>` +
+        `<div class="mech-rows">${rows || '<div class="mech-status">no chunks in focus for this step</div>'}</div>`;
+
+      this.mechPanel.style.display = "block";
+      this.mechPanel.innerHTML = html;
+
+      // Wire the step buttons (innerHTML replaced them, so re-bind).
+      this.mechPanel.querySelectorAll("[data-mech]").forEach((btn) => {
+        btn.addEventListener("click", (ev) => {
+          ev.stopPropagation();
+          const action = btn.getAttribute("data-mech");
+          if (action === "next") this.mechNextStep();
+          else if (action === "prev") this.mechPrevStep();
+          else if (action === "clear") this.clearMechanism();
+        });
+      });
     },
 
     onSearchHighlight(matchedIds) {
@@ -292,6 +701,14 @@
       this.highlighted = new Set();
       this.selected = null;
       this.nodeIndex = new Map();
+      // Mechanism state. The panel is a child of `container`, cleared below.
+      this.mechActive = false;
+      this.mechLegs = null;
+      this.mechResults = [];
+      this.mechQuery = "";
+      this.mechStep = 0;
+      this.mechRole = new Map();
+      this.mechPanel = null;
       if (this.container) {
         this.container.innerHTML = "";
       }


### PR DESCRIPTION
## SPLADE viz — Stage 2a: query-anchored mechanism step-through

Frontend-only, additive (4 asset files). Implements Stage 2a of the locked design (`docs/plans/2026-06-25-splade-viz-design.md`) — the core "see SPLADE overlaid on the embedding" view — consuming the already-merged `GET /api/search_legs` seam (Stage 1, #2060). Keeps the existing three.js cluster renderer (deck.gl deferred to Stage 2c).

### The interaction
A `mechanism` query box in the cluster view drives a **dimmed-base step-through**, joining `chunk_id` → cluster node by Store chunk ID:
- **Step 0 (dense)** — lights the dense top-k (blue).
- **Step 1 (+SPLADE)** — adds the SPLADE-leg chunks dense ranked low/absent (magenta = "what dense missed"), dense rest stays blue.
- **Step 2 (fused)** — lights chunks whose fused rank beats their dense-alone rank, or were dense-absent (amber = "fusion pulled this up").

Prev/Next/Clear controls. Chunks outside the loaded cluster window are marked `off-view` in the panel.

### Honesty (per the design's killed-v2 constraints)
Side panel surfaces per-leg numbers **on text**, not color: dense `rank`/`raw_cosine` (raw cosine [-1,1], `(inj)` when dense-absent), sparse `rank`/`minmax_score`/`raw_splade_dot` (min-max per-query), fused `rank`/`fused_score` (α formula in tooltip). Plane labeled dense-cosine UMAP (stochastic, not a metric, not a divergence map); no divergence recolor; "win" = rank-elevation only (not gold-relevance, no per-chunk +/− color). Local `escapeHtml` guard on all server-derived strings. Graceful 503 + `legs:null` ("fusion did not run") messages.

### Verification
`cargo build` clean (assets compile via `include_str!`); `cargo test --lib serve` 140 passed; clippy `--all-targets` clean; `node --check` clean; provenance lint clean. Live end-to-end: stood up an isolated temp index + freshly-built daemon, curled `GET /api/search_legs?q=error+handling&k=20`, confirmed all three populated legs (this caught a real envelope-shape gap — see below). **Not verified in-lane:** the live browser pixel render (temp-index UMAP cold-start too slow on WSL) — covered by a post-merge visual check against the main index.

### Known follow-up (residual)
`search_legs_forwards_daemon_legs_response` (`src/serve/tests.rs`) asserts the **unwrapped** payload, but the real daemon dispatch envelope wraps it under `data` (the frontend peels it, tolerating both). The test's fake daemon doesn't replicate the envelope — a green test guarding a shape the real wire doesn't emit. To be fixed separately (make the fake return the `{data:...}` envelope, or unwrap server-side for sibling-endpoint consistency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
