### PR TITLE
fix(serve): peel daemon dispatch envelope in /api/search_legs

### DIFF
--- a/src/daemon_translate.rs
+++ b/src/daemon_translate.rs
@@ -1170,13 +1170,15 @@ fn daemon_request_with_timeout<T: serde::de::DeserializeOwned>(
 /// is present — i.e. the value is already the bare handler payload — return
 /// it as-is so the legacy mock-test path keeps working.
 //
-// Compiled on unix (its only production caller, `daemon_request_with_timeout`,
-// is `#[cfg(unix)]`) and under any test build (the unit tests below are
-// cross-platform `#[test]`). On a non-unix release build it has no caller, so
-// gating it here keeps `clippy -D warnings` (run per-target in release.yml)
-// from tripping dead_code on the Windows cross-build.
+// Compiled on unix (its production callers are unix-confined:
+// `daemon_request_with_timeout` is `#[cfg(unix)]`, and the serve
+// `/api/search_legs` daemon client speaks `std::os::unix::net::UnixStream`)
+// and under any test build (the unit tests below are cross-platform `#[test]`).
+// On a non-unix release build it has no caller, so gating it here keeps
+// `clippy -D warnings` (run per-target in release.yml) from tripping dead_code
+// on the Windows cross-build.
 #[cfg(any(unix, test))]
-fn unwrap_dispatch_payload(
+pub(crate) fn unwrap_dispatch_payload(
     output: &serde_json::Value,
     type_name: &str,
 ) -> Result<serde_json::Value, String> {

--- a/src/serve/daemon_client.rs
+++ b/src/serve/daemon_client.rs
@@ -17,14 +17,22 @@ use std::path::Path;
 
 use super::error::ServeError;
 
-/// Forward a `search-legs` query to the retrieval daemon and return its parsed
-/// `output` JSON (the [`crate::cli::commands`]-built legs payload).
+/// Forward a `search-legs` query to the retrieval daemon and return the clean
+/// handler payload (`{query, legs, results}`).
+///
+/// The daemon's socket-layer `output` is the dispatch ENVELOPE
+/// (`{"data": <payload>, "error": null, "version": N, "_meta": …}`), not the
+/// payload itself. This function peels it (via the shared
+/// [`crate::daemon_translate::unwrap_dispatch_payload`]) so the web surface
+/// returns the same clean shape as `/api/search` — the caller can `Json`-wrap
+/// it directly.
 ///
 /// Returns [`ServeError::ServiceUnavailable`] when the socket is absent or the
 /// daemon is unresponsive — the caller renders that as a 503 with the
 /// "mechanism mode requires `cqs watch --serve`" hint rather than silently
 /// falling back to a degraded surface. A daemon error response (status != ok)
-/// surfaces as [`ServeError::Internal`].
+/// or a non-null `error` inside the dispatch envelope surfaces as
+/// [`ServeError::Internal`].
 ///
 /// `args` are the argv tokens after the verb (e.g. `["my query", "--limit",
 /// "5"]`). This function builds the request frame, runs the round-trip on the
@@ -108,10 +116,22 @@ pub(crate) fn query_search_legs(
         .map_err(|e| ServeError::Internal(format!("daemon response parse failed: {e}")))?;
 
     match resp.get("status").and_then(|v| v.as_str()) {
-        Some("ok") => resp
-            .get("output")
-            .cloned()
-            .ok_or_else(|| ServeError::Internal("daemon ok response missing 'output'".to_string())),
+        Some("ok") => {
+            // The socket-layer `output` is the daemon DISPATCH ENVELOPE
+            // (`{"data": <payload>, "error": null, "version": N, "_meta": …}`),
+            // not the handler payload. Peel it via the shared helper so this
+            // surface matches the rest of the codebase (and `/api/search`):
+            // a non-null envelope `error` surfaces as an error rather than
+            // returning null `data`; otherwise the inner `{query, legs,
+            // results}` payload is returned clean.
+            let output = resp.get("output").ok_or_else(|| {
+                ServeError::Internal("daemon ok response missing 'output'".to_string())
+            })?;
+            crate::daemon_translate::unwrap_dispatch_payload(output, "search-legs").map_err(|e| {
+                tracing::warn!(detail = %e, "search-legs: dispatch envelope carried an error");
+                ServeError::Internal(format!("daemon error: {e}"))
+            })
+        }
         Some(other) => {
             // The daemon ran but the command failed (bad filter flag, embedder
             // error, …). Surface the daemon's message when present.

--- a/src/serve/tests.rs
+++ b/src/serve/tests.rs
@@ -1704,7 +1704,10 @@ async fn search_legs_forwards_daemon_legs_response() {
     let dir = TempDir::new().expect("tempdir");
     let socket = dir.path().join("daemon.sock");
 
-    // The fake daemon returns a minimal three-leg payload as the `output`.
+    // The fake daemon emits the REAL wire shape: the socket-layer `output` is
+    // the dispatch ENVELOPE (`{"data": <payload>, "error": null, "version": N,
+    // "_meta": …}`), not the bare payload. The handler must peel `data` —
+    // wrapping the payload in the envelope is what exercises that peel.
     let legs_payload = serde_json::json!({
         "query": "parse config",
         "legs": {
@@ -1714,7 +1717,13 @@ async fn search_legs_forwards_daemon_legs_response() {
         },
         "results": [{"chunk_id": "A", "file": "src/lib.rs", "name": "parse_config", "line_start": 1, "line_end": 5}]
     });
-    let daemon_response = serde_json::json!({"status": "ok", "output": legs_payload});
+    let envelope = serde_json::json!({
+        "data": legs_payload,
+        "error": null,
+        "version": 1,
+        "_meta": {"stale_origins": []}
+    });
+    let daemon_response = serde_json::json!({"status": "ok", "output": envelope});
 
     let handle = spawn_fake_daemon(socket.clone(), daemon_response);
     // Give the listener a moment to bind before the request connects.
@@ -1739,9 +1748,22 @@ async fn search_legs_forwards_daemon_legs_response() {
     let bytes = axum::body::to_bytes(resp.into_body(), 65536).await.unwrap();
     let body: serde_json::Value = serde_json::from_slice(&bytes).expect("parse body JSON");
 
-    // The handler forwards the daemon's `output` verbatim — the three legs are
-    // present at the top level of the response body.
+    // The handler PEELS the dispatch envelope's `data` — the clean
+    // `{query, legs, results}` payload is at the top level of the response body
+    // (no `data`/`error`/`version`/`_meta` envelope keys leak through).
     assert_eq!(body["query"], "parse config");
+    assert!(
+        body.get("data").is_none(),
+        "envelope `data` key must not leak"
+    );
+    assert!(
+        body.get("error").is_none(),
+        "envelope `error` key must not leak"
+    );
+    assert!(
+        body.get("version").is_none(),
+        "envelope `version` key must not leak"
+    );
     assert!(body["legs"]["dense"].is_array(), "dense leg forwarded");
     assert!(body["legs"]["sparse"].is_array(), "sparse leg forwarded");
     assert!(body["legs"]["fused"].is_array(), "fused leg forwarded");
@@ -1759,6 +1781,59 @@ async fn search_legs_forwards_daemon_legs_response() {
     assert_eq!(args[0], "parse config");
     assert!(args.contains(&"--limit".to_string()) && args.contains(&"5".to_string()));
     assert!(args.contains(&"--splade-alpha".to_string()) && args.contains(&"0.4".to_string()));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn search_legs_envelope_error_surfaces_as_500() {
+    // A daemon that ran the verb but whose handler failed returns
+    // `status: "ok"` at the socket layer with a non-null `error` *inside* the
+    // dispatch envelope (and a null `data`). The peel must surface that error
+    // as a 500 rather than handing the frontend a 200 with null data.
+    let dir = TempDir::new().expect("tempdir");
+    let socket = dir.path().join("daemon.sock");
+
+    let envelope = serde_json::json!({
+        "data": null,
+        "error": {"code": "internal", "message": "splade index not loaded"},
+        "version": 1
+    });
+    let daemon_response = serde_json::json!({"status": "ok", "output": envelope});
+
+    let handle = spawn_fake_daemon(socket.clone(), daemon_response);
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    let fixture = fixture_state_with_socket(socket);
+    let state = fixture.state();
+    let app = test_router(state);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/search_legs?q=parse+config&k=5")
+                .header("host", "127.0.0.1:8080")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("oneshot");
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "non-null envelope error must surface as 500, not a 200 with null data"
+    );
+    let bytes = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&bytes).expect("parse error body JSON");
+    // The error body is the serve `ErrorBody` shape, NOT a 200 legs payload.
+    assert_eq!(body["error"], "internal", "got: {body}");
+    assert!(
+        body["detail"]
+            .as_str()
+            .is_some_and(|d| d.contains("splade index not loaded")),
+        "daemon error message must reach the detail; got: {body}"
+    );
+
+    let _ = handle.join();
 }
 
 // ===== per-launch auth token integration tests =====


### PR DESCRIPTION
## Peel the daemon dispatch envelope in `/api/search_legs`

`GET /api/search_legs` leaked the raw daemon dispatch envelope (`{"data":…,"error":null,"version":N,"_meta":…}`) to the web UI, while sibling `/api/search` returns a clean shape. The frontend papered over it with a `body.data ? body.data : body` peel, and the unit test asserted the unwrapped shape its fake daemon never actually wrapped — a green test guarding a wire shape the real daemon doesn't emit.

### Fix
- `query_search_legs` (`src/serve/daemon_client.rs`) now peels the socket `output` dispatch envelope via the shared `daemon_translate::unwrap_dispatch_payload` helper (the same one `daemon_request_with_timeout` uses). A non-null envelope `error` surfaces as `ServeError::Internal` (→ 500) instead of returning null data; otherwise the clean inner `{query, legs, results}` is returned — consistent with `/api/search`.
- `unwrap_dispatch_payload` made `pub(crate)` for reuse (no duplicated peel).
- `search_legs_forwards_daemon_legs_response` fixed: its fake daemon now emits the **real** envelope so the peel is exercised, and asserts no envelope keys leak. New `search_legs_envelope_error_surfaces_as_500` pins the error path.
- Frontend unchanged: `cluster-3d.js`'s `body.data ? body.data : body` falls through to the now-clean `body` (verified).

### Tests
`cargo test --lib serve`: 141 passed (all 4 `search_legs_*`); `daemon_translate`: 51 passed. build/clippy `--all-targets`/fmt/provenance clean. No envelope-shape change emitted (this consumes the existing envelope), so the targeted serve gate is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
