### PR TITLE
fix(index): make --umap work on WSL /mnt/c (no silent-drop under daemon, no 9h v9fs hang)

### DIFF
--- a/src/cli/commands/index/build.rs
+++ b/src/cli/commands/index/build.rs
@@ -36,6 +36,65 @@ pub(crate) struct IndexSummaryOutput {
     pub total_type_edges: usize,
 }
 
+/// Run the UMAP projection on the daemon-delegation path.
+///
+/// When `cqs index` (without `--force`) finds a live daemon, it delegates the
+/// reconcile and returns early — before the main build's projection step. The
+/// daemon's reconcile does not run the projection, so `--umap` would be a
+/// silent no-op whenever the (normally always-on) daemon is up. This runs the
+/// projection CLI-side against the active slot's store on that path.
+///
+/// Returns `Some(rows_projected)` when the projection ran (even `Some(0)` for a
+/// graceful skip such as no-Python), or `None` when `umap_flag` is unset or the
+/// slot store could not be opened. A projection failure is logged but never
+/// fatal — the daemon still keeps the index fresh.
+///
+/// Factored out of the inline delegation branch so the "project even when
+/// delegating" decision is unit-testable without a live daemon: the decision is
+/// purely `umap_flag`, and the projection runs against a real store at
+/// `index_path`.
+fn project_umap_on_delegation(umap_flag: bool, index_path: &Path, quiet: bool) -> Option<usize> {
+    if !umap_flag {
+        return None;
+    }
+    // The daemon holds only a shared HNSW lock, so a ReadWrite open for the
+    // coord write-back succeeds, and the UMAP UPDATE is safe to run
+    // concurrently with the daemon reconcile (SQLite serializes the writers
+    // under WAL; a chunk deleted mid-update just no-ops its UPDATE).
+    match Store::open(index_path) {
+        Ok(slot_store) => {
+            if !quiet {
+                println!("Running UMAP projection...");
+            }
+            match super::umap::run_umap_projection(&slot_store, index_path, quiet) {
+                Ok(updated) => {
+                    if !quiet && updated > 0 {
+                        println!("  UMAP: {updated} chunks projected to 2D");
+                    }
+                    Some(updated)
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "UMAP projection failed — cluster view will be unavailable");
+                    if !quiet {
+                        eprintln!("  Warning: UMAP projection failed ({e}); cluster view skipped");
+                    }
+                    Some(0)
+                }
+            }
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, path = %index_path.display(), "UMAP projection skipped — could not open slot store");
+            if !quiet {
+                eprintln!(
+                    "  Warning: UMAP projection skipped (could not open {}): {e}",
+                    index_path.display()
+                );
+            }
+            None
+        }
+    }
+}
+
 /// Index codebase files for semantic search
 ///
 /// Parses source files, generates embeddings, and stores them in the index database.
@@ -281,12 +340,23 @@ pub(crate) fn cmd_index(cli: &Cli, args: &IndexArgs) -> Result<()> {
                                     "Use `cqs index --force` (after stopping the daemon) to fully rebuild from scratch."
                                 );
                             }
+                            // `--umap` is a CLI-side projection pass the daemon's
+                            // reconcile does NOT run. Without this the flag is a
+                            // silent no-op whenever the (normally always-on)
+                            // daemon is up, because the delegation returns before
+                            // the projection at the end of the main build path.
+                            // Run it here against the active slot's store
+                            // regardless of which delegation branch was taken.
+                            let umap_updated =
+                                project_umap_on_delegation(umap_flag, &index_path, cli.quiet);
+
                             if cli.json || args.json {
                                 let env = serde_json::json!({
                                     "data": {
                                         "daemon_reconcile_queued": true,
                                         "was_pending": resp.was_pending,
                                         "socket": sock_path.display().to_string(),
+                                        "umap_projected": umap_updated,
                                     },
                                     "version": 1,
                                     "error": null,
@@ -1027,7 +1097,7 @@ pub(crate) fn cmd_index(cli: &Cli, args: &IndexArgs) -> Result<()> {
         if !cli.quiet {
             println!("Running UMAP projection...");
         }
-        match super::umap::run_umap_projection(&store, cli.quiet) {
+        match super::umap::run_umap_projection(&store, &index_path, cli.quiet) {
             Ok(updated) => {
                 if !cli.quiet && updated > 0 {
                     println!("  UMAP: {updated} chunks projected to 2D");
@@ -2036,6 +2106,64 @@ mentions = []
         assert!(
             msg.contains("--force"),
             "error must point at --force as the recovery path: {msg}"
+        );
+    }
+
+    // ===== project_umap_on_delegation =====
+    //
+    // The daemon-delegation path returns early, before the main build's
+    // projection step. These pin that `--umap` still drives the projection on
+    // that path (BUG: it was a silent no-op whenever the daemon was up). A live
+    // daemon is impractical in a unit test, so the testable unit is the
+    // factored helper: the decision to project is purely `umap_flag`.
+
+    /// `--umap` unset on the delegation path must NOT run the projection.
+    #[test]
+    fn project_umap_on_delegation_skips_when_flag_unset() {
+        let (_tmp, cqs_dir) = seed_store(3, 16);
+        let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
+        let updated = project_umap_on_delegation(false, &index_path, true);
+        assert_eq!(
+            updated, None,
+            "umap_flag=false must skip the projection entirely on the delegation path"
+        );
+    }
+
+    /// `--umap` set on the delegation path must REACH the projection against
+    /// the active slot's store — the regression being guarded is that the
+    /// delegation early-return dropped the projection entirely whenever the
+    /// daemon was up. Reaching the projection yields `Some(_)`; a dropped
+    /// projection would be `None` (the unset-flag shape).
+    ///
+    /// PATH is pointed at an empty dir so the projection takes the instant
+    /// graceful no-Python skip (`Ok(0)` → `Some(0)`) rather than shelling out
+    /// to umap-learn — that keeps the test fast and deterministic while still
+    /// proving control reaches `run_umap_projection`. `#[serial]` because it
+    /// mutates the process-global PATH.
+    #[test]
+    #[serial_test::serial]
+    fn project_umap_on_delegation_runs_when_flag_set() {
+        let (_tmp, cqs_dir) = seed_store(3, 16);
+        let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
+
+        let saved_path = std::env::var_os("PATH");
+        let empty_dir = TempDir::new().expect("empty PATH dir");
+        std::env::set_var("PATH", empty_dir.path());
+
+        let updated = project_umap_on_delegation(true, &index_path, true);
+
+        // Restore PATH before asserting so a panic can't leak it into the suite.
+        match saved_path {
+            Some(v) => std::env::set_var("PATH", v),
+            None => std::env::remove_var("PATH"),
+        }
+
+        assert_eq!(
+            updated,
+            Some(0),
+            "umap_flag=true must reach the projection on the delegation path \
+             (here Some(0) via the no-Python graceful skip); None would mean the \
+             projection was dropped before the early return — the silent-no-op regression"
         );
     }
 }

--- a/src/cli/commands/index/umap.rs
+++ b/src/cli/commands/index/umap.rs
@@ -13,6 +13,7 @@
 //! `scripts/run_umap.py`'s module docstring; both sides keep it in sync.
 
 use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use anyhow::{Context, Result};
@@ -41,15 +42,158 @@ fn umap_stream_batch_size(dim: usize) -> usize {
 /// dropped immediately after the subprocess exits.
 const UMAP_SCRIPT: &str = include_str!("../../../../scripts/run_umap.py");
 
+/// Owned `(chunk_id, embedding)` pairs read out of a store for projection.
+type EmbeddingRows = Vec<(String, Vec<f32>)>;
+
+/// Decision on whether the embedding read must be staged through fast local
+/// disk before the projection runs.
+///
+/// `run_umap_projection` reads every embedding from the store via random-page
+/// SQLite IO. On a slow mmap filesystem (WSL `/mnt/c` 9P / NFS / SMB) that
+/// access pattern collapses — measured at hours for a ~17k-chunk slot — while
+/// the same read against a fast-disk snapshot finishes in seconds. Staging
+/// snapshots the live DB onto fast disk, reads embeddings from the snapshot,
+/// and writes coords back to the original (a single bounded transaction —
+/// sequential write IO is fine on v9fs).
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum StagingDecision {
+    /// DB is on a fast fs — read embeddings directly, no snapshot.
+    DirectRead,
+    /// DB is on a slow fs and a fast temp dir was found — snapshot the DB
+    /// into this dir, read from the snapshot.
+    StageVia(PathBuf),
+    /// DB is on a slow fs but no fast temp dir is available — the caller must
+    /// loud-warn and skip rather than silently hang on the slow read.
+    SlowNoFastDisk,
+}
+
+/// Decide how to source the embedding read for `db_path`.
+///
+/// Pure over `db_path` + the chosen fast temp dir, so it is unit-testable
+/// without mounting a filesystem (`is_wsl_drvfs_path` is a path-shape check).
+fn decide_staging(db_path: &Path) -> StagingDecision {
+    if !cqs::config::is_wsl_drvfs_path(db_path) {
+        return StagingDecision::DirectRead;
+    }
+    match pick_fast_temp_dir() {
+        Some(dir) => StagingDecision::StageVia(dir),
+        None => StagingDecision::SlowNoFastDisk,
+    }
+}
+
+/// Pick a fast temp directory to stage the snapshot through.
+///
+/// Prefers `$XDG_RUNTIME_DIR` (typically a tmpfs), falling back to
+/// `std::env::temp_dir()` (`/tmp`, the WSL ext4 rootfs). A candidate is
+/// rejected if it is itself on a slow mmap fs — staging slow→slow would just
+/// move the hang, so we return `None` and let the caller warn-and-skip rather
+/// than copy onto another slow mount.
+fn pick_fast_temp_dir() -> Option<PathBuf> {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if let Some(xdg) = std::env::var_os("XDG_RUNTIME_DIR") {
+        let p = PathBuf::from(xdg);
+        if !p.as_os_str().is_empty() {
+            candidates.push(p);
+        }
+    }
+    candidates.push(std::env::temp_dir());
+
+    candidates.into_iter().find(|dir| {
+        // The directory must exist (a stale XDG_RUNTIME_DIR pointing at a
+        // missing path is useless) and must not itself be slow.
+        dir.is_dir() && !cqs::config::is_wsl_drvfs_path(dir)
+    })
+}
+
+/// Stream every `(id, embedding)` pair out of a store into an owned buffer.
+///
+/// Generic over the store mode so it can read from the original
+/// `Store<ReadWrite>` (direct path) or a `Store<ReadOnly>` snapshot (staged
+/// path). The `dim` drives the streaming batch size only.
+fn collect_embeddings<Mode>(store: &Store<Mode>, dim: usize) -> Result<EmbeddingRows> {
+    let stream_batch = umap_stream_batch_size(dim);
+    let mut buffered: EmbeddingRows = Vec::new();
+    for batch in store.embedding_batches(stream_batch) {
+        let batch = batch.context("read embedding batch for UMAP")?;
+        for (id, emb) in batch {
+            buffered.push((id, emb.as_slice().to_vec()));
+        }
+    }
+    Ok(buffered)
+}
+
+/// Snapshot the live DB onto fast disk and read embeddings from the snapshot.
+///
+/// Returns the buffered embeddings plus the snapshot's `TempPath` — the caller
+/// must keep the `TempPath` alive until the read is consumed, and it cleans up
+/// the snapshot file (and its `-wal`/`-shm` sidecars, if any) on drop. The
+/// snapshot is a `VACUUM INTO` single-file copy, torn-page-safe under a
+/// concurrent daemon writer.
+fn stage_and_read(
+    store: &Store,
+    db_path: &Path,
+    fast_dir: &Path,
+    dim: usize,
+) -> Result<(EmbeddingRows, tempfile::TempPath)> {
+    // Reserve a unique path in the fast dir. `snapshot_to` -> VACUUM INTO
+    // clears any pre-existing file at the target first, so the empty
+    // NamedTempFile placeholder is fine; the TempPath owns cleanup.
+    let placeholder = tempfile::Builder::new()
+        .prefix("cqs-umap-snapshot-")
+        .suffix(".db")
+        .tempfile_in(fast_dir)
+        .with_context(|| {
+            format!(
+                "failed to create UMAP snapshot temp file in {}",
+                fast_dir.display()
+            )
+        })?;
+    let snapshot_path = placeholder.into_temp_path();
+
+    store
+        .snapshot_to(&snapshot_path)
+        .with_context(|| format!("failed to snapshot index DB to {}", snapshot_path.display()))?;
+    tracing::info!(
+        src = %db_path.display(),
+        snapshot = %snapshot_path.display(),
+        "UMAP: staged embedding read through fast-disk snapshot"
+    );
+
+    // Open the snapshot read-write and read embeddings from it. A read-only
+    // open forces WAL journal-mode on connect, which is itself a header write —
+    // and a `VACUUM INTO` output is born in rollback-journal mode, so a
+    // read-only open errors with "attempt to write a readonly database". The
+    // snapshot is a private throwaway on fast disk (unique temp name, no
+    // concurrent reader), so a read-write open is safe and avoids that footgun.
+    // Migrations are a no-op: the snapshot is a copy of the already-current DB.
+    let snapshot_store = Store::open(&snapshot_path).with_context(|| {
+        format!(
+            "failed to open UMAP snapshot at {}",
+            snapshot_path.display()
+        )
+    })?;
+    let rows = collect_embeddings(&snapshot_store, dim)?;
+    // Drop the snapshot store's connections before returning so the TempPath
+    // can be unlinked cleanly (no lingering fds against the snapshot file).
+    drop(snapshot_store);
+    Ok((rows, snapshot_path))
+}
+
 /// Run the UMAP projection pass and write coords back to the store.
 ///
 /// The Python script is embedded into the binary, so this works whether the
 /// caller is running from the source tree or from an installed binary.
 ///
+/// `db_path` is the on-disk path of `store`'s SQLite database. When it lives on
+/// a slow mmap filesystem (WSL 9P / NFS / SMB), the embedding read is staged
+/// through a fast-disk snapshot — see [`decide_staging`] — because reading all
+/// embeddings via random-page SQLite IO over v9fs collapses to hours. Coords
+/// are always written back to the original `store`.
+///
 /// Returns the number of rows successfully updated. Empty corpora and
 /// "no Python" both return `Ok(0)` after logging — the index build is not
 /// considered failed when the optional projection can't run.
-pub(crate) fn run_umap_projection(store: &Store, quiet: bool) -> Result<usize> {
+pub(crate) fn run_umap_projection(store: &Store, db_path: &Path, quiet: bool) -> Result<usize> {
     let _span = tracing::info_span!("umap_projection").entered();
 
     // Materialize the embedded script to a tempfile so the Python interpreter
@@ -95,15 +239,67 @@ pub(crate) fn run_umap_projection(store: &Store, quiet: bool) -> Result<usize> {
 
     // Collect all (id, embedding) pairs into a binary buffer for stdin.
     // Format documented in scripts/run_umap.py; keep both in sync.
+    //
+    // The read of every embedding is random-page SQLite IO. On a slow mmap
+    // filesystem (WSL 9P / NFS / SMB) that pattern collapses — measured at
+    // hours for a ~17k-chunk slot — so stage the read through a fast-disk
+    // snapshot when the live DB is on such a mount. Coords are always written
+    // back to the original `store` below (sequential write IO, fine on v9fs).
     let dim = store.dim();
-    let stream_batch = umap_stream_batch_size(dim);
-    let mut buffered: Vec<(String, Vec<f32>)> = Vec::new();
-    for batch in store.embedding_batches(stream_batch) {
-        let batch = batch.context("read embedding batch for UMAP")?;
-        for (id, emb) in batch {
-            buffered.push((id, emb.as_slice().to_vec()));
+    let _stage_snapshot; // keep the TempPath alive across the read when staging
+    let buffered: EmbeddingRows = match decide_staging(db_path) {
+        StagingDecision::DirectRead => collect_embeddings(store, dim)?,
+        StagingDecision::StageVia(fast_dir) => {
+            // Snapshot the live DB onto fast disk, read embeddings from the
+            // snapshot. A snapshot failure is not fatal: fall back to a
+            // direct (slow) read with a loud warning rather than failing the
+            // whole index — but warn so the operator knows why it may stall.
+            match stage_and_read(store, db_path, &fast_dir, dim) {
+                Ok((rows, snapshot_path)) => {
+                    _stage_snapshot = snapshot_path;
+                    rows
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        db = %db_path.display(),
+                        "UMAP staging snapshot failed; falling back to a direct read \
+                         on the slow filesystem (this may take a very long time)"
+                    );
+                    if !quiet {
+                        eprintln!(
+                            "  UMAP: could not stage to fast disk ({e}); reading directly \
+                             from {} — this may stall for a long time on a slow mount. \
+                             Ctrl-C and re-run from a fast disk if it hangs.",
+                            db_path.display()
+                        );
+                    }
+                    collect_embeddings(store, dim)?
+                }
+            }
         }
-    }
+        StagingDecision::SlowNoFastDisk => {
+            // DB is on a slow mmap fs and no fast temp dir is available. The
+            // direct read would hang for hours (random-page IO over v9fs), so
+            // skip the projection with an actionable hint rather than leave the
+            // operator guessing why `cqs index --umap` never returns.
+            tracing::warn!(
+                db = %db_path.display(),
+                "UMAP projection skipped: DB is on a slow filesystem (WSL 9P / NFS / SMB) \
+                 and no fast temp disk (XDG_RUNTIME_DIR / TMPDIR) is available to stage \
+                 the embedding read; the unstaged read would hang for a very long time"
+            );
+            if !quiet {
+                eprintln!(
+                    "  UMAP: skipped — {} is on a slow filesystem and no fast temp disk \
+                     was found to stage through. Set XDG_RUNTIME_DIR or TMPDIR to a fast \
+                     mount (tmpfs / ext4), or move the index off the slow mount, then re-run.",
+                    db_path.display()
+                );
+            }
+            return Ok(0);
+        }
+    };
 
     let n_rows = buffered.len();
     if n_rows == 0 {
@@ -295,8 +491,9 @@ mod tests {
 
     /// Spin up an empty `Store` whose dim matches a small test profile, just
     /// enough that `run_umap_projection` can hit `embedding_batches` and the
-    /// empty-corpus branch.
-    fn fresh_empty_store(dim: usize) -> (Store, TempDir) {
+    /// empty-corpus branch. Returns the store, its db path, and the owning
+    /// tempdir (kept alive by the caller).
+    fn fresh_empty_store(dim: usize) -> (Store, std::path::PathBuf, TempDir) {
         let dir = TempDir::new().expect("tempdir");
         let path = dir.path().join("test_umap.db");
         let mut store = Store::open(&path).expect("open store");
@@ -304,7 +501,7 @@ mod tests {
             .init(&ModelInfo::new("test/model", dim))
             .expect("init store");
         store.set_dim(dim);
-        (store, dir)
+        (store, path, dir)
     }
 
     /// Pin the documented graceful-skip path on machines without Python. A
@@ -325,8 +522,8 @@ mod tests {
         let empty_dir = TempDir::new().expect("empty PATH dir");
         std::env::set_var("PATH", empty_dir.path());
 
-        let (store, _tmp) = fresh_empty_store(8);
-        let result = run_umap_projection(&store, true);
+        let (store, db_path, _tmp) = fresh_empty_store(8);
+        let result = run_umap_projection(&store, &db_path, true);
 
         // Restore PATH before any assertion so a panic doesn't leak the
         // empty PATH into the rest of the suite.
@@ -339,9 +536,9 @@ mod tests {
             Ok(n) => assert_eq!(n, 0, "Python-missing path must return Ok(0), got Ok({n})"),
             Err(e) => panic!(
                 "Python-missing path must return Ok(0), got Err: {e:#}. \
-                 The graceful-skip path at umap.rs:53-60 is documented \
-                 behavior — promoting it to a hard error breaks `cqs index \
-                 --umap` on every machine without umap-learn installed."
+                 The Python-not-found graceful skip is documented behavior — \
+                 promoting it to a hard error breaks `cqs index --umap` on \
+                 every machine without umap-learn installed."
             ),
         }
     }
@@ -353,15 +550,227 @@ mod tests {
     /// runners that lack umap-learn.
     #[test]
     fn run_umap_projection_returns_zero_for_empty_corpus() {
-        let (store, _tmp) = fresh_empty_store(8);
-        let result = run_umap_projection(&store, true);
+        let (store, db_path, _tmp) = fresh_empty_store(8);
+        let result = run_umap_projection(&store, &db_path, true);
         match result {
             Ok(n) => assert_eq!(n, 0, "empty corpus must return Ok(0), got Ok({n})"),
             Err(e) => panic!(
                 "empty corpus must return Ok(0), got Err: {e:#}. \
                  If this fails on a machine WITH umap-learn, the empty-corpus \
-                 branch at umap.rs:94-100 has regressed."
+                 skip branch has regressed."
             ),
         }
+    }
+
+    /// A fast-fs DB path reads directly (no staging). The decision is pure
+    /// over the path shape, so a real `/tmp` (ext4) path exercises the
+    /// `DirectRead` arm without mounting anything.
+    #[test]
+    fn decide_staging_fast_path_reads_directly() {
+        let dir = TempDir::new().expect("tempdir");
+        let db = dir.path().join("index.db");
+        assert!(
+            !cqs::config::is_wsl_drvfs_path(&db),
+            "test tempdir must be on a fast fs for this assertion to be meaningful: {}",
+            db.display()
+        );
+        assert_eq!(decide_staging(&db), StagingDecision::DirectRead);
+    }
+
+    /// A DB under a simulated WSL `/mnt/<letter>/` mount selects staging.
+    /// `is_wsl_drvfs_path` is a path-shape check (no statfs), so a synthetic
+    /// `/mnt/c/...` path drives the slow-fs branch on any host. With a fast
+    /// temp dir available (the normal case on this workstation) the decision
+    /// is `StageVia`.
+    #[test]
+    fn decide_staging_wsl_mount_selects_staging_when_fast_disk_available() {
+        let slow_db = Path::new("/mnt/c/Projects/cqs/.cqs/slots/gemma/index.db");
+        // Only meaningful when this host actually exposes a fast temp dir
+        // (true on the dev workstation and CI Linux runners). If no fast disk
+        // exists, the decision is SlowNoFastDisk — assert that branch instead
+        // so the test is correct on every host.
+        match decide_staging(slow_db) {
+            StagingDecision::StageVia(dir) => {
+                assert!(
+                    !cqs::config::is_wsl_drvfs_path(&dir),
+                    "staging dir must itself be on a fast fs, got {}",
+                    dir.display()
+                );
+            }
+            StagingDecision::SlowNoFastDisk => {
+                assert!(
+                    pick_fast_temp_dir().is_none(),
+                    "SlowNoFastDisk only valid when no fast temp dir exists"
+                );
+            }
+            StagingDecision::DirectRead => panic!(
+                "a /mnt/<letter>/ path must be classified slow, not DirectRead — \
+                 is_wsl_drvfs_path regressed on the automount-root arm"
+            ),
+        }
+    }
+
+    /// The fast-location selection rejects a slow temp dir. With both
+    /// `XDG_RUNTIME_DIR` and `TMPDIR` pointed at a (simulated) slow WSL mount,
+    /// `pick_fast_temp_dir` must return `None` rather than stage slow→slow.
+    ///
+    /// Mutates process-global env vars, so `#[serial]`.
+    #[test]
+    #[serial]
+    fn pick_fast_temp_dir_rejects_slow_candidates() {
+        let saved_xdg = std::env::var_os("XDG_RUNTIME_DIR");
+        let saved_tmp = std::env::var_os("TMPDIR");
+
+        // Both candidate sources point at a /mnt/<letter>/ shape, which
+        // is_wsl_drvfs_path classifies slow regardless of the real fs. The
+        // path need not exist — pick_fast_temp_dir's is_dir() guard then also
+        // rejects it, but the slow-shape rejection is the property under test
+        // (a real slow dir that DID exist would be rejected for being slow).
+        std::env::set_var("XDG_RUNTIME_DIR", "/mnt/c/slow-xdg");
+        std::env::set_var("TMPDIR", "/mnt/c/slow-tmp");
+
+        let picked = pick_fast_temp_dir();
+
+        // Restore before asserting so a panic can't leak the env into the suite.
+        match saved_xdg {
+            Some(v) => std::env::set_var("XDG_RUNTIME_DIR", v),
+            None => std::env::remove_var("XDG_RUNTIME_DIR"),
+        }
+        match saved_tmp {
+            Some(v) => std::env::set_var("TMPDIR", v),
+            None => std::env::remove_var("TMPDIR"),
+        }
+
+        assert_eq!(
+            picked, None,
+            "every candidate is on a slow mount — must refuse to stage slow→slow"
+        );
+    }
+
+    /// `pick_fast_temp_dir` prefers a fast `XDG_RUNTIME_DIR` when set, and the
+    /// chosen dir is never itself slow.
+    ///
+    /// Mutates `XDG_RUNTIME_DIR`, so `#[serial]`.
+    #[test]
+    #[serial]
+    fn pick_fast_temp_dir_prefers_fast_xdg_runtime_dir() {
+        let saved_xdg = std::env::var_os("XDG_RUNTIME_DIR");
+        let fast = TempDir::new().expect("fast tempdir");
+        std::env::set_var("XDG_RUNTIME_DIR", fast.path());
+
+        let picked = pick_fast_temp_dir();
+
+        match saved_xdg {
+            Some(v) => std::env::set_var("XDG_RUNTIME_DIR", v),
+            None => std::env::remove_var("XDG_RUNTIME_DIR"),
+        }
+
+        let picked = picked.expect("a fast XDG_RUNTIME_DIR must be selected");
+        assert!(
+            !cqs::config::is_wsl_drvfs_path(&picked),
+            "selected dir must be fast"
+        );
+        assert_eq!(
+            picked,
+            fast.path(),
+            "a fast XDG_RUNTIME_DIR must win over the temp_dir() fallback"
+        );
+    }
+
+    /// The staged read produces the same rows as a direct read on the same
+    /// corpus. This pins the snapshot path's correctness without reproducing
+    /// the slow-fs hang: seed N>n_neighbors embeddings, read them directly and
+    /// via a fast-disk snapshot, and assert the two reads are identical.
+    ///
+    /// `stage_and_read` snapshots the live DB and reads from the snapshot;
+    /// `collect_embeddings` is the direct read. Equal output proves the
+    /// snapshot round-trips every embedding faithfully.
+    #[test]
+    fn staged_read_matches_direct_read() {
+        let dim = 8usize;
+        let (store, db_path, _tmp) = fresh_empty_store(dim);
+
+        // Seed a small synthetic corpus. 32 chunks is comfortably above any
+        // umap n_neighbors default and large enough to span multiple
+        // streaming batches at small batch sizes.
+        let mut seeded: Vec<(String, Vec<f32>)> = Vec::new();
+        for i in 0..32u32 {
+            let id = format!("src/f{i}.rs:1:{i:08x}");
+            let emb: Vec<f32> = (0..dim).map(|d| (i as f32) + (d as f32) * 0.25).collect();
+            seeded.push((id, emb));
+        }
+        seed_chunks_with_embeddings(&store, dim, &seeded);
+
+        let direct = collect_embeddings(&store, dim).expect("direct read");
+        assert_eq!(
+            direct.len(),
+            seeded.len(),
+            "direct read must see every seeded chunk"
+        );
+
+        let fast_dir = std::env::temp_dir();
+        assert!(
+            !cqs::config::is_wsl_drvfs_path(&fast_dir),
+            "temp_dir must be fast for this test to stage meaningfully: {}",
+            fast_dir.display()
+        );
+        let (staged, _snapshot) =
+            stage_and_read(&store, &db_path, &fast_dir, dim).expect("staged read");
+
+        // Compare by id (order-independent): both reads are rowid-ascending,
+        // but sort to make the assertion robust to batch boundaries.
+        let mut direct_sorted = direct.clone();
+        let mut staged_sorted = staged.clone();
+        direct_sorted.sort_by(|a, b| a.0.cmp(&b.0));
+        staged_sorted.sort_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(
+            staged_sorted, direct_sorted,
+            "staged snapshot read must yield identical (id, embedding) rows as the direct read"
+        );
+    }
+
+    /// Seed `chunks` rows carrying embeddings so `embedding_batches` returns
+    /// them. Builds a minimal `Chunk` per row and upserts through the store's
+    /// own batch path (the same write path the indexer uses).
+    fn seed_chunks_with_embeddings(store: &Store, dim: usize, rows: &[(String, Vec<f32>)]) {
+        use cqs::parser::{Chunk, ChunkType, Language};
+        use cqs::Embedding;
+        use std::path::PathBuf;
+
+        let batch: Vec<(Chunk, Embedding)> = rows
+            .iter()
+            .enumerate()
+            .map(|(i, (id, emb))| {
+                let content = format!("fn f{i}() {{}}");
+                let content_hash = blake3::hash(content.as_bytes()).to_hex().to_string();
+                let chunk = Chunk {
+                    id: id.clone(),
+                    file: PathBuf::from(format!("src/f{i}.rs")),
+                    language: Language::Rust,
+                    chunk_type: ChunkType::Function,
+                    name: format!("f{i}"),
+                    signature: format!("fn f{i}()"),
+                    content,
+                    doc: None,
+                    line_start: 1,
+                    line_end: 1,
+                    byte_start: 0,
+                    content_hash,
+                    canonical_hash: String::new(),
+                    parent_id: None,
+                    window_idx: None,
+                    parent_type_name: None,
+                    parser_version: 0,
+                };
+                // Pad/truncate the synthetic embedding to the store dim so the
+                // wire bytes match what `embedding_batches` expects.
+                let mut v = emb.clone();
+                v.resize(dim, 0.0);
+                (chunk, Embedding::new(v))
+            })
+            .collect();
+        store
+            .upsert_chunks_batch(&batch, Some(1))
+            .expect("seed chunks with embeddings");
     }
 }

--- a/src/store/backup.rs
+++ b/src/store/backup.rs
@@ -29,6 +29,40 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use sqlx::SqlitePool;
 
 use super::helpers::StoreError;
+use super::Store;
+
+impl<Mode> Store<Mode> {
+    /// Take a transactionally-consistent, single-file snapshot of this store's
+    /// database into `dst`, reusing the same `VACUUM INTO` path the
+    /// migration backup uses (no torn-page window under a concurrent daemon
+    /// writer; no `-wal`/`-shm` sidecars on the output).
+    ///
+    /// Sync wrapper over the async [`vacuum_into`] primitive, driven on the
+    /// store's own runtime. `dst` must be on a filesystem with space for the
+    /// full DB; the caller is responsible for cleaning it up (e.g. via a
+    /// `TempPath`). Used by the UMAP projection to stage the embedding read
+    /// onto fast local disk when the live index sits on a slow mmap fs (WSL
+    /// 9P / NFS / SMB), where random-page SQLite reads collapse.
+    ///
+    /// A `wal_checkpoint(FULL)` runs first to bound WAL growth before the
+    /// snapshot read transaction; snapshot consistency itself comes from
+    /// VACUUM INTO's read transaction, not the checkpoint.
+    pub fn snapshot_to(&self, dst: &Path) -> Result<(), StoreError> {
+        let _span = tracing::info_span!("store_snapshot_to").entered();
+        self.block_on(async {
+            if let Err(e) = sqlx::query("PRAGMA wal_checkpoint(FULL)")
+                .execute(&self.pool)
+                .await
+            {
+                tracing::warn!(
+                    error = %e,
+                    "wal_checkpoint before snapshot failed (non-fatal)"
+                );
+            }
+            vacuum_into(&self.pool, dst).await
+        })
+    }
+}
 
 /// Env var that controls whether a failed migration-time DB backup is a hard
 /// error (default) or a warn-and-continue.
@@ -469,7 +503,40 @@ fn sidecar_path(db: &Path, ext: &str) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::store::ModelInfo;
     use std::assert_matches;
+
+    /// `Store::snapshot_to` produces a single-file, integrity-clean snapshot
+    /// (no `-wal`/`-shm` sidecars) that re-opens as a valid DB carrying the
+    /// source's metadata. Pins the public snapshot primitive the UMAP slow-fs
+    /// staging path relies on, through the `Store` method (the `vacuum_into`
+    /// tests below cover the async primitive directly).
+    #[test]
+    fn store_snapshot_to_produces_consistent_single_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("index.db");
+        let store = Store::open(&db_path).expect("open store");
+        store
+            .init(&ModelInfo::new("test/model", 8))
+            .expect("init store");
+
+        let snapshot = dir.path().join("snapshot.db");
+        store.snapshot_to(&snapshot).expect("snapshot must succeed");
+
+        assert!(snapshot.exists(), "snapshot file must exist");
+        assert!(
+            !sidecar_path(&snapshot, "-wal").exists(),
+            "snapshot must not carry a -wal sidecar"
+        );
+        assert!(
+            !sidecar_path(&snapshot, "-shm").exists(),
+            "snapshot must not carry a -shm sidecar"
+        );
+
+        // The snapshot re-opens and reports the source's model/dim.
+        let reopened = Store::open(&snapshot).expect("snapshot must re-open");
+        assert_eq!(reopened.dim(), 8, "snapshot must preserve the source dim");
+    }
 
     /// `keep_backups()` returns the compiled default when unset, the env
     /// value when set (including `0`, which is a valid "prune all" choice),


### PR DESCRIPTION
## Make `cqs index --umap` actually work on WSL `/mnt/c` — two bugs

Found while standing up the cluster view: on the default WSL `/mnt/c` setup `cqs index --umap` either does nothing (daemon running) or hangs for ~9 hours (daemon stopped).

### BUG 1 — `--umap` silently dropped when a daemon is running
The daemon-delegation branch in `cmd_index` queues a daemon reconcile and returns early, *before* the build's projection step — and the daemon's reconcile never projects. So with the (normally always-on) daemon up, `--umap` was a no-op. Fix: a testable `project_umap_on_delegation(umap_flag, index_path, quiet)` helper runs the projection on the delegation path before the early return (opens the active slot ReadWrite — the daemon holds only a shared HNSW lock, and the UMAP `UPDATE` is WAL-safe concurrent with the reconcile). Adds `umap_projected` to the delegation JSON.

### BUG 2 — ~9h hang on v9fs (`/mnt/c`)
`run_umap_projection` read every embedding via random-page SQLite IO over the v9fs plan9 mount — the hang (the umap-learn fit itself is fast, in-memory). Fix: `decide_staging(db_path)` (via `is_wsl_drvfs_path`) snapshots the live DB to fast local disk through a new `Store::snapshot_to` (a sync wrapper over the existing migration-backup `VACUUM INTO` primitive — torn-page-safe under a concurrent daemon writer, **not** raw `fs::copy`), reads embeddings from the snapshot, and writes coords back to the **original** store (single bounded transaction — sequential write IO is fine on v9fs). `pick_fast_temp_dir()` prefers `XDG_RUNTIME_DIR` then `temp_dir()`, rejecting any candidate that is itself slow. Fallbacks are **loud-warn-and-skip / warn-and-direct-with-Ctrl-C-hint** — never a silent hang.

Measured ground truth (not re-reproduced in-lane): ~17k-chunk slot on v9fs = **9h20m / 0 rows** unstaged vs **~31s** staged through ext4.

### Tests
`umap` 7 pass (staging decisions: fast→direct, `/mnt/<letter>`→stage, slow-temp rejection, XDG preference, **staged==direct byte-equivalence**, + graceful-skip). `build` delegation 2 pass. `backup` `store_snapshot_to` 1 new pass (single-file, no sidecars, dim preserved). clippy `--all-targets`/fmt/provenance clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
