### PR TITLE
fix(serve): cfg-gate unix-only SPLADE-leg daemon-client for the Windows release build

### DIFF
--- a/src/serve/handlers.rs
+++ b/src/serve/handlers.rs
@@ -318,6 +318,21 @@ pub(crate) async fn search_legs(
         }
     };
 
+    search_legs_dispatch(state, socket, params).await
+}
+
+/// The daemon round-trip half of [`search_legs`], split out so the unix-only
+/// daemon-client path can be cfg-gated independently of the request validation
+/// above. The daemon client speaks a Unix domain socket (`std::os::unix::net`),
+/// so on non-unix this whole path compiles out and returns the same 503 the
+/// daemon-down path returns — there is no daemon to reach until the named-pipe
+/// Windows transport exists.
+#[cfg(unix)]
+async fn search_legs_dispatch(
+    state: AppState,
+    socket: std::sync::Arc<std::path::PathBuf>,
+    params: SearchLegsQuery,
+) -> Result<Json<serde_json::Value>, ServeError> {
     // Build the daemon argv: the verb is supplied by the client; these are the
     // tokens after it. Clamp `k` to the same bound the name-search handler uses.
     let k = params.k.clamp(1, 200);
@@ -347,6 +362,22 @@ pub(crate) async fn search_legs(
 
     tracing::info!("serve::search_legs forwarded to daemon");
     Ok(Json(output))
+}
+
+/// Non-unix stand-in for [`search_legs_dispatch`]: the retrieval daemon is
+/// reached over a Unix domain socket, which does not exist on this platform, so
+/// mechanism mode is structurally unavailable and the endpoint returns a clean
+/// 503 rather than failing to compile.
+#[cfg(not(unix))]
+async fn search_legs_dispatch(
+    _state: AppState,
+    _socket: std::sync::Arc<std::path::PathBuf>,
+    _params: SearchLegsQuery,
+) -> Result<Json<serde_json::Value>, ServeError> {
+    Err(ServeError::ServiceUnavailable(
+        "mechanism mode requires the retrieval daemon over a unix socket; not available on this platform"
+            .to_string(),
+    ))
 }
 
 /// `GET /api/hierarchy/{id}?direction={callers|callees}&depth=N`

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -40,6 +40,10 @@ use crate::store::{ReadOnly, Store};
 
 mod assets;
 mod auth;
+// The daemon client speaks a Unix domain socket (`std::os::unix::net`); the
+// Windows named-pipe transport for the retrieval daemon is not yet implemented,
+// so this module compiles out on non-unix and `/api/search_legs` 503s there.
+#[cfg(unix)]
 mod daemon_client;
 mod data;
 mod error;

--- a/src/serve/tests.rs
+++ b/src/serve/tests.rs
@@ -1617,8 +1617,13 @@ async fn host_allowlist_rejects_missing_host_header() {
 // client of the retrieval daemon socket. These pin: (1) a clean 503 with the
 // "requires `cqs watch --serve`" hint when the daemon is absent, and (2) that
 // a present daemon's three-leg response is forwarded verbatim.
+//
+// The fake daemon is a Unix domain socket (`std::os::unix::net`), so this whole
+// block is unix-only — the daemon client compiles out on non-unix, where the
+// endpoint 503s instead of forwarding.
 
 /// A `Fixture` whose `AppState.daemon_socket` points at `socket`.
+#[cfg(unix)]
 fn fixture_state_with_socket(socket: std::path::PathBuf) -> Fixture {
     let mut fixture = fixture_state();
     let mut state = fixture.state.take().expect("fixture state");
@@ -1630,6 +1635,7 @@ fn fixture_state_with_socket(socket: std::path::PathBuf) -> Fixture {
 /// Spawn a one-shot fake daemon on `socket`: accept a single connection, read
 /// the request line, hand it to `responder`, and write the response line back.
 /// Returns the join handle (carrying the parsed request for assertions).
+#[cfg(unix)]
 fn spawn_fake_daemon(
     socket: std::path::PathBuf,
     response: serde_json::Value,
@@ -1651,6 +1657,7 @@ fn spawn_fake_daemon(
     })
 }
 
+#[cfg(unix)]
 #[tokio::test(flavor = "multi_thread")]
 async fn search_legs_503_when_no_daemon_socket() {
     let fixture = fixture_state(); // daemon_socket: None
@@ -1677,6 +1684,7 @@ async fn search_legs_503_when_no_daemon_socket() {
     );
 }
 
+#[cfg(unix)]
 #[tokio::test(flavor = "multi_thread")]
 async fn search_legs_503_when_socket_path_absent() {
     let dir = TempDir::new().expect("tempdir");
@@ -1699,6 +1707,7 @@ async fn search_legs_503_when_socket_path_absent() {
     assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
 }
 
+#[cfg(unix)]
 #[tokio::test(flavor = "multi_thread")]
 async fn search_legs_forwards_daemon_legs_response() {
     let dir = TempDir::new().expect("tempdir");
@@ -1783,6 +1792,7 @@ async fn search_legs_forwards_daemon_legs_response() {
     assert!(args.contains(&"--splade-alpha".to_string()) && args.contains(&"0.4".to_string()));
 }
 
+#[cfg(unix)]
 #[tokio::test(flavor = "multi_thread")]
 async fn search_legs_envelope_error_surfaces_as_500() {
     // A daemon that ran the verb but whose handler failed returns


### PR DESCRIPTION
## cfg-gate the unix-only SPLADE-leg daemon-client so the Windows release build compiles

Latent release-blocker introduced by #2060 (viz Stage 1). `serve` is a default feature, but its `/api/search_legs` daemon-client path (`src/serve/daemon_client.rs`) uses `std::os::unix::net` with **no `#[cfg(unix)]` gating** — a hard **E0432** compile error on `x86_64-pc-windows-msvc`, which is exactly what `release.yml` builds (default features). PR CI is Linux-only, so it went uncaught; no release has been cut since #2060, so it hasn't bitten yet. This is the v1.46.0-class "all-3-targets gate skips a binary" risk (distinct from #1992, which is dead_code *warnings* that still compile).

### Fix
- `#[cfg(unix)] mod daemon_client;` — the `UnixStream` use compiles out on non-unix.
- `search_legs` handler split into a cfg-gated `search_legs_dispatch`: `#[cfg(unix)]` keeps the existing `spawn_blocking(query_search_legs)` round-trip; `#[cfg(not(unix))]` returns the same `ServiceUnavailable` 503 (the unix domain socket is unix-only until the #1512 named-pipe transport exists). Route stays registered → Windows 503s, not 404s. Identical signatures so the call type-checks on both platforms.
- Gated the unix-socket serve test helpers + the four `search_legs_*` tests `#[cfg(unix)]`.

### Verification
A real `cargo check --target x86_64-pc-windows-msvc` is blocked locally (C build-deps — ring/onig_sys/tree-sitter/libsqlite3-sys/aws-lc-sys — need the MSVC C toolchain WSL lacks; it never reaches `Compiling cqs`). Verified instead by: (1) **cfg-flip simulation** — swapped the real `cfg(unix)` gates to a never-set flag so the non-unix arms activate on the Linux toolchain, then `cargo check --all-targets` → clean, zero unused warnings (gating structure is complete, both dispatch arms' signatures match); (2) **negative control** — re-exposing the gated module under the flip → `E0433`, proving the simulation has bite; (3) **exhaustive reference audit** — the only `UnixStream` use is the now-gated module, the only production `daemon_client::` reference is in the `#[cfg(unix)]` arm, every test caller is inside a `#[cfg(unix)]` fn.

Linux gates (real code): build green, clippy `--all-targets` clean, `test --lib serve` **141 passed** (Linux behavior byte-identical), fmt/provenance clean.

Follow-up (separate issue): PR CI should gain a Windows `cargo check`/build gate so this class regresses loudly — gated on clearing the #1992 dead_code backlog + needing an MSVC runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
