### PR TITLE
fix(test): de-flake daemon over-cap response test (EPIPE in mock server)

### DIFF
--- a/src/daemon_translate.rs
+++ b/src/daemon_translate.rs
@@ -2648,8 +2648,13 @@ mod tests {
             // Write WELL over the 64-byte cap with NO terminating newline before
             // the cap, so `read_line` fills the buffer and stops at the cap.
             let big = "x".repeat(4096);
-            write!(stream, "{{\"status\":\"ok\",\"output\":\"{big}\"}}").unwrap();
-            stream.flush().unwrap();
+            // The client reads only `cap + 1` bytes, returns `ResponseTooLarge`,
+            // and drops the stream by design — so this write can hit a broken
+            // pipe. That is the expected shape, not a harness fault: the assertion
+            // under test is the CLIENT's classification, not a clean server write.
+            // Ignore write/flush errors (matching the boundary proptest sibling).
+            let _ = write!(stream, "{{\"status\":\"ok\",\"output\":\"{big}\"}}");
+            let _ = stream.flush();
             // Hold the connection open briefly so the reader hits the cap rather
             // than EOF.
             std::thread::sleep(std::time::Duration::from_millis(50));


### PR DESCRIPTION
## What

De-flakes `daemon_translate::tests::json_args_response_over_cap_is_distinct_too_large_error`, which failed CI on the latest main (run 28210950913) with a panic in the **mock server thread** — unrelated to the merge that surfaced it.

## Root cause

The over-cap test's mock server wrote its 4 KiB payload with `write!(...).unwrap()` / `flush().unwrap()`. The client under test *correctly* hits the 64-byte response read cap, returns `ResponseTooLarge`, and **drops the stream** — exactly the production behavior the test asserts. When the client closes the read end, the server's write can hit a broken pipe (EPIPE); the `.unwrap()` then panicked the server thread, and `handle.join().unwrap()` propagated that into the test as a failure. The race only loses under CI scheduling/load, which is why it passed locally and on adjacent commits.

This is an **incomplete sweep**: the boundary proptest sibling `prop_cap_accepts_iff_len_le_cap` already ignores write/flush errors for precisely this reason (with a comment explaining the by-design early close), but the single-example test was left with `.unwrap()`.

## Fix

Ignore the mock server's write/flush errors in the over-cap example test, matching the proptest sibling. The assertion under test is the **client's** classification, not a clean server-side write.

The `under_cap` and `exactly_at_cap` tests keep `.unwrap()` deliberately — there the client reads the complete line and never closes early, so a write failure there genuinely *is* a harness fault.

## Verification

- `json_args_response_over_cap_*` run 25× consecutively: 25/25 pass (stresses the EPIPE race the fix removes).
- Full cap cluster (`under` / `exactly` / `over` + boundary proptest): green.
- `cargo clippy --all-targets --features cuda-index`: clean. `cargo fmt --check`: clean. Provenance lint: clean.

Test-only change; no production code touched.
