### PR TITLE
chore: Release v1.50.1 (Windows cross-build fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.50.1] - 2026-06-26
+
+### Fixed
+
+- **Windows release build (`x86_64-pc-windows-msvc`) — daemon-socket-path cfg gate.** v1.50.0's SPLADE-leg viz wired `/api/search_legs` to the retrieval daemon, computing the daemon socket path in the `serve` command. `daemon_socket_path` is unix-only (the socket is a Unix domain socket; the resolver uses `libc::getuid` for the XDG-unset fallback), but `serve` compiles on all targets, so the ungated call broke the Windows release build (E0425) — invisible in PR CI (Linux-only), caught only on the v1.50.0 tag's cross-build (and it broke `cargo install cqs` on Windows). A sibling of the #2068 daemon-client cfg-gating that this missed: the socket *path* computation is now gated too. On non-unix the `serve` process passes no daemon socket, so `/api/search_legs` degrades to the same clean 503 the cfg-gated client already returns; the rest of the read-only web UI is unaffected. No behavior change on unix; scoring untouched (recall carried from v1.50.0). v1.50.0 is yanked from crates.io in favor of this.
+
 ## [1.50.0] - 2026-06-26
 
 Completes the MCP read-tool campaign (#2021): the unconditional read-tool surface grows from 19 to 30 (34 with `CQS_MCP_ENABLE_MUTATIONS`), every tool riding the existing command cores with no per-tool reimplementation. Also adds the SPLADE↔dense fusion mechanism visualization (Stages 1 + 2a), formalizes the spec-fidelity-auditor, and lands a cluster of daemon / serve / index correctness and security fixes — notably `cqs index --umap` on WSL `/mnt/c`. The scoring path is byte-identical to v1.49.0 — a same-corpus binary A/B (v1.49.0 vs current on the same index) returned identical R@K, so the recall shift vs the prior snapshot is corpus growth, not a scoring change.
@@ -3913,6 +3919,7 @@ Second 14-category audit completed (117 findings). 107 of 109 actionable finding
 - CLI commands: init, doctor, index, stats, serve
 - Filter by language (`-l`) and path pattern (`-p`)
 
+[1.50.1]: https://github.com/jamie8johnson/cqs/compare/v1.50.0...v1.50.1
 [1.50.0]: https://github.com/jamie8johnson/cqs/compare/v1.49.0...v1.50.0
 [1.49.0]: https://github.com/jamie8johnson/cqs/compare/v1.48.0...v1.49.0
 [1.48.0]: https://github.com/jamie8johnson/cqs/compare/v1.47.0...v1.48.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "1.50.0"
+version = "1.50.1"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,10 @@ members = ["cqs-macros"]
 
 [package]
 name = "cqs"
-version = "1.50.0"
+version = "1.50.1"
 edition = "2021"
 rust-version = "1.96"
-description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 54 languages + L5X/L5K PLC exports. 70.7% R@5 / 47.2% R@1 / 86.7% R@20 on v3.v2 dual-judge code-search (218 queries, EmbeddingGemma-300m default with per-category SPLADE α; 2026-06-26 snapshot, scoring unchanged through v1.50.0). Daemon mode (3-19ms queries). MCP server (`cqs mcp`, 30 read tools). Local-first, GPU-accelerated."
+description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 54 languages + L5X/L5K PLC exports. 70.7% R@5 / 47.2% R@1 / 86.7% R@20 on v3.v2 dual-judge code-search (218 queries, EmbeddingGemma-300m default with per-category SPLADE α; 2026-06-26 snapshot, scoring unchanged through v1.50.1). Daemon mode (3-19ms queries). MCP server (`cqs mcp`, 30 read tools). Local-first, GPU-accelerated."
 license = "MIT"
 repository = "https://github.com/jamie8johnson/cqs"
 homepage = "https://github.com/jamie8johnson/cqs"

--- a/src/cli/commands/serve.rs
+++ b/src/cli/commands/serve.rs
@@ -109,10 +109,17 @@ pub(crate) fn cmd_serve(port: u16, bind: String, open: bool, no_auth: bool) -> R
 
     // The retrieval daemon's socket — `/api/search_legs` forwards to it (the
     // serve process holds no embedder/index, so mechanism mode requires
-    // `cqs watch --serve`). Same path resolution the CLI client uses.
-    let daemon_socket = cqs::daemon_translate::daemon_socket_path(&cqs_dir);
+    // `cqs watch --serve`). Same path resolution the CLI client uses. The
+    // socket is a Unix domain socket and `daemon_socket_path` is unix-only; on
+    // non-unix targets the daemon-client transport is unavailable, so no socket
+    // is passed and `/api/search_legs` degrades to a clean 503 (mirrors the
+    // cfg-gated daemon client). The rest of the read-only web UI is unaffected.
+    #[cfg(unix)]
+    let daemon_socket = Some(cqs::daemon_translate::daemon_socket_path(&cqs_dir));
+    #[cfg(not(unix))]
+    let daemon_socket: Option<std::path::PathBuf> = None;
 
-    cqs::serve::run_server(store, bind_addr, false, auth, Some(daemon_socket))
+    cqs::serve::run_server(store, bind_addr, false, auth, daemon_socket)
 }
 
 /// Reject URLs containing shell metacharacters before handing them to


### PR DESCRIPTION
## Release v1.50.1 — Windows cross-build fix

Patch release fixing a **release-blocking Windows break in v1.50.0**.

### The break

v1.50.0's SPLADE-leg viz wired `/api/search_legs` to forward to the retrieval daemon, computing the daemon socket path in the `serve` command (`serve.rs:113`). `daemon_socket_path` is unix-only (Unix domain socket; the resolver uses `libc::getuid` for the XDG-unset fallback), but `serve` compiles on all targets — so the ungated call failed the `x86_64-pc-windows-msvc` release build (E0425). Invisible in PR CI (Linux-only); surfaced only on the v1.50.0 **tag's** cross-build, where it skipped "Create GitHub Release" (gated on all 3 builds) — and it also breaks `cargo install cqs` on Windows. A sibling of the #2068 daemon-client cfg-gating that this one missed.

### The fix

cfg-gate the socket-**path** computation too. On non-unix the `serve` process passes no daemon socket, so `/api/search_legs` degrades to the same clean 503 the cfg-gated client already returns. The rest of the read-only web UI is unaffected; unix behavior is unchanged.

### Validation

A `release.yml` cross-build **dry-run on this branch before tagging** (`workflow_dispatch`) built all three targets — **`x86_64-unknown-linux-gnu`, `aarch64-apple-darwin`, AND `x86_64-pc-windows-msvc` — all success** ("Create GitHub Release" correctly skipped on a non-tag ref). Local unix build + clippy + fmt + provenance clean.

Scoring is untouched (serve-cfg only) — recall carries from v1.50.0 (47.2/70.7/86.7, same-corpus binary A/B confirmed byte-identical to v1.49.0), so no re-gate.

After merge: tag `v1.50.1` → release.yml builds all 3 + the GitHub release → `cargo publish -p cqs` → **yank v1.50.0** (Windows-broken).
