### PR TITLE
feat(serve): SPLADE viz Stage 2b — eval-gold where-hybrid-wins tour + R@K-delta panel

### DIFF
--- a/src/cli/commands/serve.rs
+++ b/src/cli/commands/serve.rs
@@ -119,7 +119,11 @@ pub(crate) fn cmd_serve(port: u16, bind: String, open: bool, no_auth: bool) -> R
     #[cfg(not(unix))]
     let daemon_socket: Option<std::path::PathBuf> = None;
 
-    cqs::serve::run_server(store, bind_addr, false, auth, daemon_socket)
+    // The eval-gold tour (`/api/eval_gold`) reads `evals/queries/*.json` relative
+    // to the project root so the fixtures stay fresh with the checkout. Pass the
+    // same root the index was resolved from; the route 503s cleanly when the
+    // fixtures aren't present there.
+    cqs::serve::run_server(store, bind_addr, false, auth, daemon_socket, Some(root))
 }
 
 /// Reject URLs containing shell metacharacters before handing them to

--- a/src/serve/assets/app.css
+++ b/src/serve/assets/app.css
@@ -260,3 +260,44 @@ main {
 
 .mech-status { color: #9aa6bf; font-size: 12px; padding: 4px 0; line-height: 1.4; }
 .mech-status.error { color: #ff9a9a; }
+
+/* Stage-2b eval-gold tour. Reuses the .mech-panel shell; these add the
+   per-anchor text win and the R@K-delta table. The win rides TEXT, never a
+   per-chunk color — the panel is where the honest signal is read. */
+.tour-cat { color: #ffd34d; font-weight: 600; }
+.tour-split { font-size: 10px; color: #8591ab; border: 1px solid #3a4870; border-radius: 3px; padding: 0 4px; }
+.tour-query { font-size: 12px; margin: 6px 0 4px; color: #cdd6e6; }
+.tour-gold { font-size: 11.5px; color: #b8c2d8; margin-bottom: 6px; }
+.tour-gold strong { color: #e8edf5; }
+.tour-ok { font-size: 10px; color: #7fd6a0; border: 1px solid #2f6a47; border-radius: 3px; padding: 0 4px; }
+.tour-dead { font-size: 10px; color: #d8995a; border: 1px solid #6b5a2a; border-radius: 3px; padding: 0 4px; }
+.tour-win {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  border: 1px solid #3a4870;
+  border-left-width: 4px;
+  border-radius: 4px;
+  padding: 6px 8px;
+  margin: 6px 0;
+  background: rgba(255, 255, 255, 0.04);
+}
+.tour-win-num { font-size: 12.5px; font-weight: 600; color: #e8edf5; font-variant-numeric: tabular-nums; }
+.tour-win-tag { font-size: 12px; font-weight: 700; white-space: nowrap; }
+
+.rk-table { width: 100%; border-collapse: collapse; margin: 8px 0; font-size: 11.5px; }
+.rk-table th {
+  text-align: right;
+  color: #9aa6bf;
+  font-weight: 600;
+  padding: 2px 4px;
+  border-bottom: 1px solid #2a3550;
+}
+.rk-table th:first-child { text-align: left; }
+.rk-table td { padding: 2px 4px; border-bottom: 1px solid rgba(42, 53, 80, 0.5); }
+.rk-cat { color: #cdd6e6; }
+.rk-num { text-align: right; color: #b8c2d8; font-variant-numeric: tabular-nums; }
+.rk-net { text-align: right; font-weight: 700; font-variant-numeric: tabular-nums; }
+.rk-total td { border-top: 1px solid #3a4870; border-bottom: none; font-weight: 700; color: #e8edf5; padding-top: 4px; }
+.rk-total td:first-child { color: #9aa6bf; }

--- a/src/serve/assets/app.js
+++ b/src/serve/assets/app.js
@@ -26,6 +26,7 @@
   const $colorGroup = document.getElementById("cluster-color");
   const $mechQuery = document.getElementById("mech-query");
   const $mechRun = document.getElementById("mech-run");
+  const $goldTour = document.getElementById("gold-tour");
 
   // --- View registry ---
   const VIEWS = {
@@ -319,6 +320,15 @@
     }
   }
 
+  // Drive the cluster view's eval-gold "where hybrid wins" tour. Only the
+  // cluster view implements `runGoldTour`; a no-op for any other view.
+  function runGoldTour() {
+    if (currentView && typeof currentView.runGoldTour === "function") {
+      setStatus("gold tour");
+      currentView.runGoldTour();
+    }
+  }
+
   async function loadChunkDetail(id) {
     $sidebar.innerHTML = `<p class="hint">loading…</p>`;
     try {
@@ -478,6 +488,10 @@
         runMechanism();
       }
     });
+  }
+  // Cluster eval-gold tour: a single button enters the stratified walk.
+  if ($goldTour) {
+    $goldTour.addEventListener("click", () => runGoldTour());
   }
   $search.addEventListener("input", onSearchInput);
 

--- a/src/serve/assets/index.html
+++ b/src/serve/assets/index.html
@@ -27,6 +27,7 @@
         <input id="mech-query" type="text" placeholder="query → dense→+SPLADE→fused" autocomplete="off"
                title="Step through how SPLADE fusion changes the ranking, overlaid on the dense-cosine UMAP plane">
         <button type="button" id="mech-run" title="run the dense / +SPLADE / fused step-through">trace</button>
+        <button type="button" id="gold-tour" title="Eval-gold 'where hybrid wins' tour — stratified per-category walk + R@K-delta panel">gold tour</button>
       </div>
     </div>
     <div id="hierarchy-controls" class="hierarchy-controls" style="display:none;" aria-label="hierarchy controls">

--- a/src/serve/assets/views/cluster-3d.js
+++ b/src/serve/assets/views/cluster-3d.js
@@ -74,11 +74,29 @@
     dense: "#4a86e8", // blue    — dense leg
     splade: "#e0529c", // magenta — SPLADE-only / dense-low pulls
     fused: "#f5a623", // amber   — fusion elevated over dense-alone
+    gold: "#ffd34d", // bright   — the eval-gold chunk (Stage-2b tour)
     dimmed: "rgba(120,130,150,0.16)", // dimmed base layer
   };
 
   // Number of top entries per leg used to drive the step-through highlight.
   const MECH_TOP_K = 20;
+
+  // The R@K window for the honest "where hybrid wins" signal. A win/loss is a
+  // top-K presence FLIP of the gold between the dense-alone leg and the fused
+  // leg: rescued = gold absent from dense top-K but present in fused top-K;
+  // hurt = present in dense top-K but absent from fused top-K. K=5 matches the
+  // ground-truth reference the tour is validated against.
+  const TOUR_K = 5;
+
+  // Per-category anchors the tour prefers when a matching query is present, so
+  // the stratified walk reliably surfaces the canonical showcases — including
+  // the honest NEGATIVE (conceptual_search, where fusion hurts the gold). Match
+  // is case-insensitive prefix; any category without a pin falls back to its
+  // first gold-resolved query.
+  const TOUR_SHOWCASE = {
+    type_filtered: "method implementations on the store struct",
+    conceptual_search: "reciprocal rank fusion",
+  };
 
   function colorByType(kind) {
     return TYPE_COLORS[kind] || "#999";
@@ -127,6 +145,32 @@
     mechStep: 0,
     mechRole: new Map(),
     mechPanel: null,
+
+    // ── Stage-2b eval-gold tour ───────────────────────────────────────────
+    // The "where hybrid wins" stratified walk + R@K-delta panel. Shares the
+    // dimmed-base renderer with mechanism mode but is a SEPARATE mode (the two
+    // are mutually exclusive; entering one clears the other).
+    // `tourActive` gates the tour's dimmed-base highlight + text-win panel.
+    // `tourQueries` is the full `/api/eval_gold` set (every gold for the sweep).
+    // `tourAnchors` is the stratified one-per-category walk (the step-through).
+    // `tourStep` indexes `tourAnchors`.
+    // `tourRole` maps chunk_id → role ("gold"|"dense"|"fused") for the active
+    //   anchor only; recomputed per step.
+    // `tourLegsCache` memoizes `/api/search_legs` by query string so stepping
+    //   back and the R@K sweep don't refetch.
+    // `tourPanelMode` is "walk" (per-anchor text win) or "rk" (the per-category
+    //   R@K-delta table).
+    // `rkRows` holds the per-category aggregates; `rkGen` cancels a stale sweep.
+    tourActive: false,
+    tourQueries: [],
+    tourAnchors: [],
+    tourStep: 0,
+    tourRole: new Map(),
+    tourLegsCache: new Map(),
+    tourPanelMode: "walk",
+    rkRows: null,
+    rkGen: 0,
+    rkSweeping: false,
 
     async init(container, options) {
       this.container = container;
@@ -208,12 +252,12 @@
         .backgroundColor("#0d1117")
         .nodeLabel((n) => this.nodeLabelText(n))
         .nodeColor((n) => {
-          // Mechanism mode overrides the base palette: dimmed base layer with
-          // the active step's role chunks lit. Selection still wins so a
-          // clicked chunk stays findable.
-          if (this.mechActive) {
+          // Mechanism mode and the eval-gold tour both override the base
+          // palette: dimmed base layer with the active step's role chunks lit.
+          // Selection still wins so a clicked chunk stays findable.
+          if (this.mechActive || this.tourActive) {
             if (this.selected === n.id) return "#fff";
-            const role = this.mechRole.get(n.id);
+            const role = this.dimRole().get(n.id);
             if (role) return MECH_COLORS[role] || MECH_COLORS.dense;
             return MECH_COLORS.dimmed;
           }
@@ -225,11 +269,11 @@
             : colorByType(n.kind);
         })
         .nodeVal((n) => {
-          // In mech mode, inflate role chunks so the lit set reads against the
-          // dimmed base; base nodes shrink so the highlight carries.
-          if (this.mechActive) {
+          // In a dimmed-base mode, inflate role chunks so the lit set reads
+          // against the dimmed base; base nodes shrink so the highlight carries.
+          if (this.mechActive || this.tourActive) {
             const base = Math.pow(nodeRadius(n.callers), 2);
-            return this.mechRole.has(n.id) ? base * 3.5 : base * 0.5;
+            return this.dimRole().has(n.id) ? base * 3.5 : base * 0.5;
           }
           return Math.pow(nodeRadius(n.callers), 2);
         })
@@ -274,12 +318,18 @@
       if (this.graph) this.graph.refresh();
     },
 
-    // Hover/label text. In mechanism mode, append the per-leg roles so the
+    // The role map the dimmed-base renderer reads — mechanism mode and the
+    // eval-gold tour each own one, and they're mutually exclusive.
+    dimRole() {
+      return this.tourActive ? this.tourRole : this.mechRole;
+    },
+
+    // Hover/label text. In a dimmed-base mode, append the active role so the
     // tooltip carries the mechanism even before the panel is read.
     nodeLabelText(n) {
       const base = `${n.name} · ${n.kind} · ${n.language} · ${n.callers} callers`;
-      if (!this.mechActive) return base;
-      const role = this.mechRole.get(n.id);
+      if (!this.mechActive && !this.tourActive) return base;
+      const role = this.dimRole().get(n.id);
       const roleTag = role ? ` · [${role}]` : "";
       return base + roleTag;
     },
@@ -292,6 +342,9 @@
     // 503 and the "fusion did not run" (legs:null) cases without crashing.
     async runMechanism(query) {
       if (!this.graph) return;
+      // Mechanism mode and the eval-gold tour are mutually exclusive dimmed-base
+      // modes — leave the tour before entering the query-anchored step-through.
+      if (this.tourActive) this.clearTour();
       const q = (query || "").trim();
       if (q.length < 2) {
         this.clearMechanism();
@@ -628,6 +681,580 @@
       });
     },
 
+    // ── Stage-2b eval-gold tour ───────────────────────────────────────────
+    // The honest "where hybrid wins" walk. For each gold query it reads the
+    // gold chunk's rank in the FUSED leg vs the DENSE-alone leg (per-query,
+    // @K=TOUR_K, attributable to fusion — NOT a per-chunk +/- color). The
+    // default walk is stratified (one anchor per category, ALL categories
+    // including the zero/negative ones), and the R@K-delta panel aggregates the
+    // net fused-vs-dense flips per category over the full gold set.
+
+    // Entry point: load the eval-gold set, build the stratified anchors, and
+    // show anchor 1. Degrades cleanly on 503 (no eval set / daemon down) and on
+    // an empty set — no crash.
+    async runGoldTour() {
+      if (!this.graph) return;
+      // Mutually exclusive with mechanism mode.
+      if (this.mechActive) this.clearMechanism();
+      this.ensureMechPanel();
+      this.mechSetPanelHtml(
+        `<div class="mech-status">loading eval-gold set…</div>`,
+      );
+
+      let resp;
+      try {
+        resp = await fetch("/api/eval_gold");
+      } catch (e) {
+        this.mechSetPanelHtml(
+          `<div class="mech-status error">eval-gold fetch error: ${escapeHtml(e.message)}</div>`,
+        );
+        return;
+      }
+      if (resp.status === 503) {
+        let msg = "no eval-gold set at the served root";
+        try {
+          const b = await resp.text();
+          if (b) {
+            try {
+              msg = JSON.parse(b).detail || msg;
+            } catch (_e) {
+              msg = b.slice(0, 240);
+            }
+          }
+        } catch (_e) {
+          /* keep default */
+        }
+        this.mechSetPanelHtml(
+          `<div class="mech-status error">gold tour unavailable (503): ${escapeHtml(msg)}</div>`,
+        );
+        return;
+      }
+      if (!resp.ok) {
+        let b = "";
+        try {
+          b = await resp.text();
+        } catch (_e) {
+          /* ignore */
+        }
+        this.mechSetPanelHtml(
+          `<div class="mech-status error">eval-gold HTTP ${resp.status}: ${escapeHtml(b.slice(0, 200))}</div>`,
+        );
+        return;
+      }
+      let data;
+      try {
+        data = await resp.json();
+      } catch (e) {
+        this.mechSetPanelHtml(
+          `<div class="mech-status error">eval-gold parse error: ${escapeHtml(e.message)}</div>`,
+        );
+        return;
+      }
+
+      this.tourQueries = Array.isArray(data.queries) ? data.queries : [];
+      this.tourCategories = Array.isArray(data.categories)
+        ? data.categories
+        : [];
+      this.tourResolved = data.resolved || 0;
+      this.tourTotal = data.total || this.tourQueries.length;
+      if (!this.tourQueries.length) {
+        this.mechSetPanelHtml(
+          `<div class="mech-status">eval-gold set is empty (no usable golds at the served root).</div>`,
+        );
+        return;
+      }
+
+      this.tourAnchors = this.buildTourAnchors();
+      this.tourLegsCache = new Map();
+      this.rkRows = null;
+      this.rkProgress = null;
+      this.rkSweeping = false;
+      this.rkGen += 1; // strand any sweep left running from a prior tour session
+      this.tourActive = true;
+      this.tourPanelMode = "walk";
+      this.tourStep = 0;
+      await this.tourSetStep(0);
+    },
+
+    // One anchor per category, in the payload's canonical order, preferring a
+    // showcase query when present so the walk reliably surfaces the canonical
+    // wins AND the honest negative (conceptual_search). Falls back to the first
+    // gold-resolved query in the category, then the first query.
+    buildTourAnchors() {
+      const byCat = new Map();
+      for (const q of this.tourQueries) {
+        if (!byCat.has(q.category)) byCat.set(q.category, []);
+        byCat.get(q.category).push(q);
+      }
+      const order =
+        this.tourCategories && this.tourCategories.length
+          ? this.tourCategories
+          : Array.from(byCat.keys());
+      const anchors = [];
+      for (const cat of order) {
+        const list = byCat.get(cat);
+        if (!list || !list.length) continue;
+        const showcase = TOUR_SHOWCASE[cat];
+        let pick = null;
+        if (showcase) {
+          pick = list.find((q) =>
+            (q.query || "").toLowerCase().startsWith(showcase),
+          );
+        }
+        if (!pick)
+          pick = list.find((q) => (q.gold_chunk_ids || []).length > 0);
+        if (!pick) pick = list[0];
+        anchors.push(pick);
+      }
+      return anchors;
+    },
+
+    // Fetch the three legs for one query. Returns a tagged result the panel
+    // renders without throwing: ok / no-fusion / daemon-down / http-error /
+    // parse-error / error. Shares the daemon envelope-peel with mechanism mode.
+    async fetchSearchLegs(query) {
+      const q = (query || "").trim();
+      if (q.length < 2) return { state: "empty" };
+      let resp;
+      try {
+        resp = await fetch(
+          `/api/search_legs?q=${encodeURIComponent(q)}&k=${TOUR_K}`,
+        );
+      } catch (e) {
+        return { state: "error", message: e.message };
+      }
+      if (resp.status === 503) {
+        let msg = "retrieval daemon required (cqs watch --serve)";
+        try {
+          const b = await resp.text();
+          if (b) msg = b.slice(0, 240);
+        } catch (_e) {
+          /* keep default */
+        }
+        return { state: "daemon-down", message: msg };
+      }
+      if (!resp.ok) {
+        let b = "";
+        try {
+          b = await resp.text();
+        } catch (_e) {
+          /* ignore */
+        }
+        return {
+          state: "http-error",
+          message: `HTTP ${resp.status}: ${b.slice(0, 160)}`,
+        };
+      }
+      let body;
+      try {
+        body = await resp.json();
+      } catch (e) {
+        return { state: "parse-error", message: e.message };
+      }
+      const d = body && body.data ? body.data : body;
+      const results = Array.isArray(d.results) ? d.results : [];
+      if (!d.legs) return { state: "no-fusion", query: d.query || q, results };
+      const legs = {
+        dense: Array.isArray(d.legs.dense) ? d.legs.dense : [],
+        sparse: Array.isArray(d.legs.sparse) ? d.legs.sparse : [],
+        fused: Array.isArray(d.legs.fused) ? d.legs.fused : [],
+      };
+      return { state: "ok", query: d.query || q, legs, results };
+    },
+
+    // Memoizing legs fetch — the walk (step back/forth) and the R@K sweep share
+    // it so a query is never sent twice. Only terminal states cache; a network
+    // blip stays retryable.
+    async cachedLegs(query) {
+      if (this.tourLegsCache.has(query)) return this.tourLegsCache.get(query);
+      const fetched = await this.fetchSearchLegs(query);
+      if (fetched.state === "ok" || fetched.state === "no-fusion") {
+        this.tourLegsCache.set(query, fetched);
+      }
+      return fetched;
+    },
+
+    // Move the walk to anchor `s`: dim the base, fetch its legs, recompute the
+    // gold roles, pan to the gold, render the text win. Guards against a step
+    // change while awaiting (the late response is dropped).
+    async tourSetStep(s) {
+      if (!this.tourActive || !this.tourAnchors.length) return;
+      this.tourStep = Math.max(0, Math.min(this.tourAnchors.length - 1, s));
+      this.tourPanelMode = "walk";
+      const anchor = this.tourAnchors[this.tourStep];
+
+      this.tourRole = this.computeTourRoles(null, anchor.gold_chunk_ids);
+      if (this.graph) this.graph.refresh();
+      this.renderTourWalk({ state: "loading" }, anchor);
+
+      const fetched = await this.cachedLegs(anchor.query);
+      if (!this.tourActive || this.tourAnchors[this.tourStep] !== anchor) return;
+
+      if (fetched.state === "ok") {
+        this.tourRole = this.computeTourRoles(
+          fetched.legs,
+          anchor.gold_chunk_ids,
+        );
+        if (this.graph) this.graph.refresh();
+        this.focusGold(anchor.gold_chunk_ids);
+      } else {
+        this.tourRole = this.computeTourRoles(null, anchor.gold_chunk_ids);
+        if (this.graph) this.graph.refresh();
+      }
+      this.renderTourWalk(fetched, anchor);
+    },
+
+    // Pan the camera to the first resolved gold that's loaded in the cluster.
+    focusGold(goldIds) {
+      for (const id of goldIds || []) {
+        if (this.nodeIds.has(id)) {
+          this.onNodeFocus(id);
+          return;
+        }
+      }
+    },
+
+    // The honest per-query metric: the gold's rank in the dense-alone leg vs the
+    // fused leg, classified by a top-TOUR_K presence FLIP.
+    //   rescued = gold below TOUR_K in dense, inside top-TOUR_K after fusion
+    //   hurt    = gold inside top-TOUR_K in dense, below TOUR_K after fusion
+    //   neutral = no flip across the TOUR_K boundary
+    //   unresolved = the gold (origin,name) didn't resolve in the served index
+    // `rank == 0` means absent from the leg; the best (lowest) rank across the
+    // resolved ids wins when an (origin,name) maps to more than one chunk.
+    computeGoldDelta(legs, goldIds) {
+      const idSet = new Set(goldIds || []);
+      if (idSet.size === 0) {
+        return { denseRank: 0, fusedRank: 0, classification: "unresolved" };
+      }
+      let denseRank = 0;
+      for (const e of legs.dense) {
+        if (idSet.has(e.chunk_id) && e.present_in_pool && e.rank > 0) {
+          if (denseRank === 0 || e.rank < denseRank) denseRank = e.rank;
+        }
+      }
+      let fusedRank = 0;
+      for (const e of legs.fused) {
+        if (idSet.has(e.chunk_id) && e.rank > 0) {
+          if (fusedRank === 0 || e.rank < fusedRank) fusedRank = e.rank;
+        }
+      }
+      const denseTop = denseRank >= 1 && denseRank <= TOUR_K;
+      const fusedTop = fusedRank >= 1 && fusedRank <= TOUR_K;
+      let classification;
+      if (!denseTop && fusedTop) classification = "rescued";
+      else if (denseTop && !fusedTop) classification = "hurt";
+      else classification = "neutral";
+      return { denseRank, fusedRank, classification };
+    },
+
+    // Role map for the dimmed-base highlight on one anchor: the gold (always
+    // lit, top priority), the dense top neighborhood, and the fused-elevated
+    // neighborhood. Pure highlight context — the win itself rides the text.
+    computeTourRoles(legs, goldIds) {
+      const roles = new Map();
+      if (legs) {
+        const denseTop = legs.dense
+          .filter((e) => e.present_in_pool && e.rank > 0)
+          .slice(0, MECH_TOP_K);
+        for (const e of denseTop) roles.set(e.chunk_id, "dense");
+
+        const denseRankById = new Map();
+        for (const e of legs.dense) denseRankById.set(e.chunk_id, e.rank || 0);
+        const fusedTop = legs.fused
+          .filter((e) => e.rank > 0)
+          .slice(0, MECH_TOP_K);
+        for (const e of fusedTop) {
+          const dr = denseRankById.get(e.chunk_id) || 0;
+          const elevated = dr === 0 || e.rank < dr;
+          if (elevated) roles.set(e.chunk_id, "fused");
+          else if (!roles.has(e.chunk_id)) roles.set(e.chunk_id, "dense");
+        }
+      }
+      for (const id of goldIds || []) roles.set(id, "gold");
+      return roles;
+    },
+
+    // Switch the panel to the R@K-delta table; kick off the sweep on first view.
+    showRkPanel() {
+      if (!this.tourActive) return;
+      this.tourPanelMode = "rk";
+      if (this.rkRows === null && !this.rkSweeping) {
+        this.runRkSweep();
+      } else {
+        this.renderRkPanel();
+      }
+    },
+
+    // Sweep the full gold set through the daemon, aggregating the net
+    // fused-vs-dense flips per category @K=TOUR_K. Sequential (one daemon
+    // round-trip at a time) and incremental (re-renders as it goes). A
+    // generation counter cancels a stale sweep when the user clears or restarts.
+    // Aborts cleanly the moment the daemon is unreachable.
+    async runRkSweep() {
+      const gen = ++this.rkGen;
+      this.rkSweeping = true;
+      const rows = new Map();
+      const ensureRow = (c) => {
+        if (!rows.has(c)) {
+          rows.set(c, {
+            rescued: 0,
+            hurt: 0,
+            neutral: 0,
+            unresolved: 0,
+            noFusion: 0,
+            error: 0,
+            total: 0,
+          });
+        }
+        return rows.get(c);
+      };
+      for (const c of this.tourCategories) ensureRow(c);
+      this.rkRows = rows;
+      this.rkProgress = {
+        done: 0,
+        total: this.tourQueries.length,
+        daemonDown: false,
+      };
+      this.renderRkPanel();
+
+      for (const q of this.tourQueries) {
+        if (gen !== this.rkGen || !this.tourActive) return; // cancelled
+        const row = ensureRow(q.category || "—");
+        row.total += 1;
+        const ids = q.gold_chunk_ids || [];
+        if (ids.length === 0) {
+          row.unresolved += 1;
+        } else {
+          const fetched = await this.cachedLegs(q.query);
+          if (gen !== this.rkGen || !this.tourActive) return;
+          if (fetched.state === "ok") {
+            const d = this.computeGoldDelta(fetched.legs, ids);
+            if (d.classification === "rescued") row.rescued += 1;
+            else if (d.classification === "hurt") row.hurt += 1;
+            else row.neutral += 1;
+          } else if (fetched.state === "no-fusion") {
+            row.noFusion += 1;
+          } else if (fetched.state === "daemon-down") {
+            this.rkProgress.daemonDown = true;
+            this.rkSweeping = false;
+            this.renderRkPanel();
+            return; // no daemon — stop, keep partial counts
+          } else {
+            row.error += 1;
+          }
+        }
+        this.rkProgress.done += 1;
+        if (
+          this.rkProgress.done % 5 === 0 ||
+          this.rkProgress.done === this.rkProgress.total
+        ) {
+          this.renderRkPanel();
+        }
+      }
+      this.rkSweeping = false;
+      this.renderRkPanel();
+    },
+
+    // Re-bind the tour panel buttons after an innerHTML replace.
+    wireTourButtons() {
+      if (!this.mechPanel) return;
+      this.mechPanel.querySelectorAll("[data-tour]").forEach((btn) => {
+        btn.addEventListener("click", (ev) => {
+          ev.stopPropagation();
+          const action = btn.getAttribute("data-tour");
+          if (action === "next") this.tourSetStep(this.tourStep + 1);
+          else if (action === "prev") this.tourSetStep(this.tourStep - 1);
+          else if (action === "clear") this.clearTour();
+          else if (action === "rk") this.showRkPanel();
+          else if (action === "walk") this.tourSetStep(this.tourStep);
+        });
+      });
+    },
+
+    // The per-anchor "walk" panel: the gold identity + the text win
+    // (dense rank → fused rank, rescued/hurt/neutral), step nav, and the link to
+    // the R@K-delta panel. The win is TEXT, never a per-chunk color.
+    renderTourWalk(fetched, anchor) {
+      this.ensureMechPanel();
+      if (!this.mechPanel) return;
+      const n = this.tourAnchors.length;
+      const stepLabel = `anchor ${this.tourStep + 1}/${n}`;
+      const cat = anchor.category || "—";
+      const split = anchor.split || "";
+      const ids = anchor.gold_chunk_ids || [];
+      const goldName = anchor.gold_name || "?";
+      const goldLoc = anchor.gold_origin || "?";
+
+      const CLASS_LABEL = {
+        rescued: { text: "rescued", sign: "+", color: MECH_COLORS.fused },
+        hurt: { text: "hurt", sign: "−", color: MECH_COLORS.splade },
+        neutral: { text: "no change @K", sign: "·", color: "#8591ab" },
+        unresolved: { text: "gold not in index", sign: "?", color: "#8591ab" },
+      };
+
+      let winHtml;
+      if (fetched.state === "loading") {
+        winHtml = `<div class="mech-status">querying legs for this gold…</div>`;
+      } else if (fetched.state === "daemon-down") {
+        winHtml = `<div class="mech-status error">retrieval daemon required for legs (cqs watch --serve): ${escapeHtml(fetched.message || "")}</div>`;
+      } else if (fetched.state === "no-fusion") {
+        winHtml = `<div class="mech-status">no SPLADE fusion ran for this query — the dense↔fused win is only defined when fusion runs.</div>`;
+      } else if (fetched.state !== "ok") {
+        winHtml = `<div class="mech-status error">legs unavailable (${escapeHtml(fetched.state)}): ${escapeHtml(fetched.message || "")}</div>`;
+      } else {
+        const d = this.computeGoldDelta(fetched.legs, ids);
+        const meta = CLASS_LABEL[d.classification] || CLASS_LABEL.neutral;
+        winHtml =
+          `<div class="tour-win" style="border-color:${meta.color}">` +
+          `<span class="tour-win-num">gold: dense ${fmtRank(d.denseRank)} → fused ${fmtRank(d.fusedRank)}</span>` +
+          `<span class="tour-win-tag" style="color:${meta.color}">${meta.sign} ${escapeHtml(meta.text)}</span>` +
+          `</div>`;
+      }
+
+      const resolvedTag = ids.length
+        ? `<span class="tour-ok">${ids.length} chunk id${ids.length > 1 ? "s" : ""}</span>`
+        : `<span class="tour-dead" title="gold (origin,name) not in the served index">dead gold</span>`;
+
+      const html =
+        `<div class="mech-panel-head">` +
+        `<div class="mech-title">gold tour · <span class="tour-cat">${escapeHtml(cat)}</span>${split ? ` <span class="tour-split">${escapeHtml(split)}</span>` : ""}</div>` +
+        `<div class="mech-steptabs">` +
+        `<button type="button" class="mech-btn" data-tour="prev"${this.tourStep === 0 ? " disabled" : ""}>‹ prev</button>` +
+        `<span class="mech-stepname">${escapeHtml(stepLabel)}</span>` +
+        `<button type="button" class="mech-btn" data-tour="next"${this.tourStep === n - 1 ? " disabled" : ""}>next ›</button>` +
+        `<button type="button" class="mech-btn mech-clear" data-tour="clear">clear</button>` +
+        `</div>` +
+        `<div class="tour-query"><code>${escapeHtml(anchor.query)}</code></div>` +
+        `<div class="tour-gold">gold: <strong>${escapeHtml(goldName)}</strong> <span class="mech-loc"><code>${escapeHtml(goldLoc)}</code></span> ${resolvedTag}</div>` +
+        winHtml +
+        `<div class="mech-legend">` +
+        `<span><span class="mech-dot" style="background:${MECH_COLORS.gold}"></span>gold</span>` +
+        `<span><span class="mech-dot" style="background:${MECH_COLORS.dense}"></span>dense top</span>` +
+        `<span><span class="mech-dot" style="background:${MECH_COLORS.fused}"></span>fused-elevated</span>` +
+        `</div>` +
+        `<div class="mech-steptabs"><button type="button" class="mech-btn" data-tour="rk">R@K-delta panel ▸</button></div>` +
+        `<div class="mech-note">Win = the gold's rank in the FUSED leg vs the DENSE-alone leg (per-query, @K=${TOUR_K}, attributable to fusion — not a per-chunk color). Plane = dense-cosine UMAP (locally faithful, globally distorted; NOT a metric). The walk steps through ALL categories, including where hybrid does NOT help.</div>` +
+        `</div>`;
+
+      this.mechPanel.style.display = "block";
+      this.mechPanel.innerHTML = html;
+      this.wireTourButtons();
+    },
+
+    // The R@K-delta panel: per-category net (rescued − hurt) @K=TOUR_K over the
+    // FULL gold set — the honest "where hybrid earns its keep", explicitly
+    // including the ~0 and negative categories (conceptual_search is the
+    // negative one; it's in the table on purpose).
+    renderRkPanel() {
+      this.ensureMechPanel();
+      if (!this.mechPanel) return;
+      const order =
+        this.tourCategories && this.tourCategories.length
+          ? this.tourCategories
+          : this.rkRows
+            ? Array.from(this.rkRows.keys())
+            : [];
+
+      let totRes = 0;
+      let totHurt = 0;
+      let totUnres = 0;
+      let totNoFus = 0;
+      const bodyRows = order
+        .map((cat) => {
+          const r = (this.rkRows && this.rkRows.get(cat)) || {
+            rescued: 0,
+            hurt: 0,
+            unresolved: 0,
+            noFusion: 0,
+          };
+          totRes += r.rescued;
+          totHurt += r.hurt;
+          totUnres += r.unresolved;
+          totNoFus += r.noFusion;
+          const net = r.rescued - r.hurt;
+          const netColor =
+            net > 0
+              ? MECH_COLORS.fused
+              : net < 0
+                ? MECH_COLORS.splade
+                : "#8591ab";
+          return (
+            `<tr>` +
+            `<td class="rk-cat">${escapeHtml(cat)}</td>` +
+            `<td class="rk-num">${r.rescued}</td>` +
+            `<td class="rk-num">${r.hurt}</td>` +
+            `<td class="rk-net" style="color:${netColor}">${net > 0 ? "+" : ""}${net}</td>` +
+            `</tr>`
+          );
+        })
+        .join("");
+      const totNet = totRes - totHurt;
+      const totColor =
+        totNet > 0
+          ? MECH_COLORS.fused
+          : totNet < 0
+            ? MECH_COLORS.splade
+            : "#8591ab";
+
+      const prog = this.rkProgress || {
+        done: 0,
+        total: this.tourQueries.length,
+        daemonDown: false,
+      };
+      let progLine = "";
+      if (this.rkSweeping) {
+        progLine = `<div class="mech-status">sweeping ${prog.done}/${prog.total} golds through the daemon…</div>`;
+      } else if (prog.daemonDown) {
+        progLine = `<div class="mech-status error">aborted: retrieval daemon required (cqs watch --serve). Partial counts below.</div>`;
+      }
+
+      const excl =
+        totUnres || totNoFus
+          ? ` (${totUnres} dead gold${totUnres === 1 ? "" : "s"}, ${totNoFus} no-fusion excluded)`
+          : "";
+
+      const html =
+        `<div class="mech-panel-head">` +
+        `<div class="mech-title">R@K-delta · net fused vs dense-alone @K=${TOUR_K}</div>` +
+        `<div class="mech-steptabs">` +
+        `<button type="button" class="mech-btn" data-tour="walk">‹ back to walk</button>` +
+        `<button type="button" class="mech-btn mech-clear" data-tour="clear">clear</button>` +
+        `</div>` +
+        progLine +
+        `<table class="rk-table"><thead><tr><th>category</th><th>resc</th><th>hurt</th><th>net</th></tr></thead><tbody>` +
+        bodyRows +
+        `<tr class="rk-total"><td>TOTAL</td><td class="rk-num">${totRes}</td><td class="rk-num">${totHurt}</td><td class="rk-net" style="color:${totColor}">${totNet > 0 ? "+" : ""}${totNet}</td></tr>` +
+        `</tbody></table>` +
+        `<div class="mech-note">net = rescued − hurt @K=${TOUR_K}. Rescue: gold below rank ${TOUR_K} in the dense-alone leg, inside top-${TOUR_K} after fusion. Hurt: the reverse. conceptual_search is the honest negative — fusion tends to hurt its gold; it's in the table on purpose.${excl}</div>` +
+        `</div>`;
+
+      this.mechPanel.style.display = "block";
+      this.mechPanel.innerHTML = html;
+      this.wireTourButtons();
+    },
+
+    // Leave the tour: restore the base palette, clear the panel, cancel any
+    // in-flight R@K sweep (the generation bump strands it).
+    clearTour() {
+      this.tourActive = false;
+      this.tourQueries = [];
+      this.tourAnchors = [];
+      this.tourStep = 0;
+      this.tourRole = new Map();
+      this.tourLegsCache = new Map();
+      this.tourPanelMode = "walk";
+      this.rkRows = null;
+      this.rkProgress = null;
+      this.rkSweeping = false;
+      this.rkGen += 1;
+      if (this.graph) this.graph.refresh();
+      if (this.mechPanel) {
+        this.mechPanel.style.display = "none";
+        this.mechPanel.innerHTML = "";
+      }
+    },
+
     onSearchHighlight(matchedIds) {
       if (!this.graph) return 0;
       this.highlighted = new Set();
@@ -709,6 +1336,18 @@
       this.mechStep = 0;
       this.mechRole = new Map();
       this.mechPanel = null;
+      // Stage-2b tour state. The generation bump strands any in-flight R@K sweep.
+      this.tourActive = false;
+      this.tourQueries = [];
+      this.tourAnchors = [];
+      this.tourStep = 0;
+      this.tourRole = new Map();
+      this.tourLegsCache = new Map();
+      this.tourPanelMode = "walk";
+      this.rkRows = null;
+      this.rkProgress = null;
+      this.rkSweeping = false;
+      this.rkGen += 1;
       if (this.container) {
         this.container.innerHTML = "";
       }

--- a/src/serve/data.rs
+++ b/src/serve/data.rs
@@ -5,9 +5,11 @@
 //! pass the rows through without transformation.
 
 use std::collections::HashMap;
+use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
+use super::error::ServeError;
 use crate::store::serve_queries::NeighborRow;
 use crate::store::{ReadOnly, Store, StoreError};
 
@@ -893,5 +895,246 @@ pub(crate) fn build_stats(store: &Store<ReadOnly>) -> Result<StatsResponse, Stor
         total_files: row.total_files.max(0) as u64,
         call_edges: row.call_edges.max(0) as u64,
         type_edges: row.type_edges.max(0) as u64,
+    })
+}
+
+// ─── Eval-gold tour (the "where hybrid wins" driver) ─────────────────────────
+//
+// `GET /api/eval_gold` serves the eval query set so the frontend tour can,
+// per gold query, fetch its three search legs (`/api/search_legs`) and read the
+// honest win signal: the gold chunk's rank in the FUSED leg vs its rank in the
+// DENSE-alone leg. The win is per-query and attributable to fusion — NOT a
+// per-chunk +/- color. The gold is pinned by `(origin, name)` in the eval files;
+// chunk ids drift across reindexes, so each gold is resolved to current ids by
+// (origin, name) against the *served* index here, never by trusting the pinned id.
+
+/// One eval-gold query surfaced to the Stage-2b tour.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct EvalGoldQuery {
+    /// The natural-language query string fed to `/api/search_legs`.
+    pub query: String,
+    /// Eval category (`type_filtered`, `conceptual_search`, ...). Drives the
+    /// stratified per-category tour and the R@K-delta panel grouping.
+    pub category: String,
+    /// Source fixture split: `test` or `dev`.
+    pub split: String,
+    /// Gold chunk's source file (the `(origin, name)` match key).
+    pub gold_origin: String,
+    /// Gold chunk's symbol name (the `(origin, name)` match key).
+    pub gold_name: String,
+    /// Current-index chunk ids whose `(origin, name)` match this gold. Empty
+    /// when the gold no longer resolves in the served index (a dead gold after a
+    /// file move/split) — the tour reports it unresolved rather than faking a rank.
+    pub gold_chunk_ids: Vec<String>,
+}
+
+/// `GET /api/eval_gold` response: the eval query set plus resolution stats.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct EvalGoldResponse {
+    /// Every eval query that carries a usable `(origin, name)` gold, test then dev.
+    pub queries: Vec<EvalGoldQuery>,
+    /// Distinct categories present, in a stable canonical display order.
+    pub categories: Vec<String>,
+    /// Total queries returned.
+    pub total: usize,
+    /// How many of `total` resolved to at least one current chunk id. A large
+    /// `total - resolved` gap means the served index drifted from the eval pins
+    /// (dead golds) and tour ranks will read as unresolved for those.
+    pub resolved: usize,
+}
+
+/// Minimal projection of an eval fixture file — only the fields the tour needs.
+/// `#[serde(default)]` everywhere so a schema change in the fixture (extra keys,
+/// renamed siblings) never fails the parse; missing pieces just drop the query.
+#[derive(Deserialize)]
+struct EvalFileRaw {
+    #[serde(default)]
+    queries: Vec<EvalQueryRaw>,
+}
+
+#[derive(Deserialize)]
+struct EvalQueryRaw {
+    #[serde(default)]
+    query: String,
+    #[serde(default)]
+    category: String,
+    /// Consensus gold (top-level `gold_chunk`, `gold_chunk_source: consensus`).
+    #[serde(default)]
+    gold_chunk: Option<GoldChunkRaw>,
+}
+
+#[derive(Deserialize)]
+struct GoldChunkRaw {
+    #[serde(default)]
+    origin: String,
+    #[serde(default)]
+    name: String,
+}
+
+/// Canonical category display order for the tour. The two zero/negative-uplift
+/// categories (`conceptual_search`, `multi_step`) are kept in the set on
+/// purpose: the tour is honest about where hybrid does NOT help, so they must
+/// be tourable, not hidden. Categories present but not listed here are appended
+/// after, in first-seen order.
+const CANON_CATEGORIES: [&str; 8] = [
+    "type_filtered",
+    "conceptual_search",
+    "cross_language",
+    "identifier_lookup",
+    "negation",
+    "behavioral_search",
+    "structural_search",
+    "multi_step",
+];
+
+fn order_categories(present: Vec<String>) -> Vec<String> {
+    let mut ordered: Vec<String> = Vec::new();
+    for c in CANON_CATEGORIES {
+        if present.iter().any(|p| p == c) {
+            ordered.push(c.to_string());
+        }
+    }
+    for p in present {
+        if !ordered.contains(&p) {
+            ordered.push(p);
+        }
+    }
+    ordered
+}
+
+/// Build the `GET /api/eval_gold` payload from the eval fixtures under
+/// `<root>/evals/queries/` and the served index.
+///
+/// Reads `v3_test.v2.json` and `v3_dev.v2.json` (merged, each tagged with its
+/// split), keeps only queries that carry a usable `(origin, name)` gold, and
+/// resolves every gold to current chunk ids by `(origin, name)` against the
+/// served index — robust to id drift, the same match key the eval harness uses.
+///
+/// Returns `503 ServiceUnavailable` when NEITHER fixture file is present, so the
+/// tour degrades to a clean "no eval set here" rather than an empty success that
+/// reads as "no wins". A present-but-unparseable file is logged and skipped (the
+/// other split may still drive the tour).
+pub(crate) fn build_eval_gold(
+    store: &Store<ReadOnly>,
+    root: &Path,
+) -> Result<EvalGoldResponse, ServeError> {
+    let _span = tracing::info_span!("build_eval_gold").entered();
+
+    let dir = root.join("evals").join("queries");
+    let files = [("test", "v3_test.v2.json"), ("dev", "v3_dev.v2.json")];
+
+    let mut raw: Vec<(&'static str, EvalQueryRaw)> = Vec::new();
+    let mut found_any = false;
+    for (split, fname) in files {
+        let path = dir.join(fname);
+        match std::fs::read_to_string(&path) {
+            Ok(text) => {
+                found_any = true;
+                match serde_json::from_str::<EvalFileRaw>(&text) {
+                    Ok(parsed) => {
+                        for q in parsed.queries {
+                            raw.push((split, q));
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            file = %path.display(),
+                            "eval-gold: failed to parse eval fixture; skipping this split"
+                        );
+                    }
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                tracing::debug!(file = %path.display(), "eval-gold: fixture not present");
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    file = %path.display(),
+                    "eval-gold: failed to read eval fixture; skipping this split"
+                );
+            }
+        }
+    }
+
+    if !found_any {
+        return Err(ServeError::ServiceUnavailable(format!(
+            "eval-gold tour unavailable: no eval query fixtures at {} \
+             (expected v3_test.v2.json / v3_dev.v2.json)",
+            dir.display()
+        )));
+    }
+
+    // Keep only queries with a usable (origin, name) gold.
+    struct Pending {
+        query: String,
+        category: String,
+        split: &'static str,
+        origin: String,
+        name: String,
+    }
+    let mut pending: Vec<Pending> = Vec::with_capacity(raw.len());
+    for (split, q) in raw {
+        let Some(gc) = q.gold_chunk else { continue };
+        if q.query.is_empty() || gc.origin.is_empty() || gc.name.is_empty() {
+            continue;
+        }
+        pending.push(Pending {
+            query: q.query,
+            category: q.category,
+            split,
+            origin: gc.origin,
+            name: gc.name,
+        });
+    }
+
+    // Resolve golds to current chunk ids by (origin, name) against the served
+    // index. Query only the gold names (a bounded set), then disambiguate by
+    // origin in Rust — the chunk id encodes origin as a prefix, but we map via
+    // the index rather than parse it.
+    let mut name_set: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for p in &pending {
+        name_set.insert(p.name.as_str());
+    }
+    let names: Vec<&str> = name_set.into_iter().collect();
+    let rows = store.serve_resolve_origin_names(&names)?;
+    let mut by_origin_name: HashMap<(String, String), Vec<String>> = HashMap::new();
+    for (id, origin, name) in rows {
+        by_origin_name.entry((origin, name)).or_default().push(id);
+    }
+
+    let mut queries: Vec<EvalGoldQuery> = Vec::with_capacity(pending.len());
+    let mut resolved = 0usize;
+    let mut seen_categories: Vec<String> = Vec::new();
+    for p in pending {
+        let ids = by_origin_name
+            .get(&(p.origin.clone(), p.name.clone()))
+            .cloned()
+            .unwrap_or_default();
+        if !ids.is_empty() {
+            resolved += 1;
+        }
+        if !p.category.is_empty() && !seen_categories.iter().any(|c| c == &p.category) {
+            seen_categories.push(p.category.clone());
+        }
+        queries.push(EvalGoldQuery {
+            query: p.query,
+            category: p.category,
+            split: p.split.to_string(),
+            gold_origin: p.origin,
+            gold_name: p.name,
+            gold_chunk_ids: ids,
+        });
+    }
+
+    let categories = order_categories(seen_categories);
+    let total = queries.len();
+    tracing::info!(total, resolved, "build_eval_gold");
+    Ok(EvalGoldResponse {
+        queries,
+        categories,
+        total,
+        resolved,
     })
 }

--- a/src/serve/handlers.rs
+++ b/src/serve/handlers.rs
@@ -15,8 +15,8 @@ use axum::{
 use serde::Deserialize;
 
 use super::data::{
-    ChunkDetail, ClusterResponse, GraphResponse, HierarchyDirection, HierarchyResponse, NodeRef,
-    SearchResponse, StatsResponse,
+    ChunkDetail, ClusterResponse, EvalGoldResponse, GraphResponse, HierarchyDirection,
+    HierarchyResponse, NodeRef, SearchResponse, StatsResponse,
 };
 use super::error::ServeError;
 use super::AppState;
@@ -378,6 +378,40 @@ async fn search_legs_dispatch(
         "mechanism mode requires the retrieval daemon over a unix socket; not available on this platform"
             .to_string(),
     ))
+}
+
+/// `GET /api/eval_gold` — the eval query set that drives the Stage-2b
+/// "where hybrid wins" tour. Returns each eval query with its category, split,
+/// and gold `(origin, name)` resolved to current chunk ids against the served
+/// index, so the frontend can fetch `/api/search_legs` per query and read the
+/// honest per-query R@K delta (gold's fused-leg rank vs dense-alone rank).
+///
+/// Reads the fixtures from the project root passed at launch (`state.eval_root`).
+/// Returns a clean 503 when no root was resolved (the route is structurally
+/// unavailable) or when the fixtures are absent at that root — the tour degrades
+/// to "no eval set here", never a fake empty success.
+pub(crate) async fn eval_gold(
+    State(state): State<AppState>,
+) -> Result<Json<EvalGoldResponse>, ServeError> {
+    tracing::info!("serve::eval_gold");
+
+    let root = match &state.eval_root {
+        Some(r) => r.clone(),
+        None => {
+            return Err(ServeError::ServiceUnavailable(
+                "eval-gold tour unavailable: cqs serve was not launched from a project root \
+                 (no path resolved for evals/queries/)"
+                    .to_string(),
+            ));
+        }
+    };
+
+    let response = with_blocking(&state, "eval_gold", move |store| {
+        super::data::build_eval_gold(store, root.as_ref())
+    })
+    .await?;
+
+    Ok(Json(response))
 }
 
 /// `GET /api/hierarchy/{id}?direction={callers|callees}&depth=N`

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -82,6 +82,11 @@ pub(crate) struct AppState {
     /// mode forwards the query to the daemon and returns its three legs. `None`
     /// when no socket path was resolved (legs mode then always 503s).
     pub(crate) daemon_socket: Option<Arc<std::path::PathBuf>>,
+    /// Project root used to locate the eval fixtures (`evals/queries/*.json`)
+    /// that drive the Stage-2b "where hybrid wins" tour (`/api/eval_gold`).
+    /// `None` disables the tour route — it then returns a clean 503 instead of
+    /// reading from an unknown root.
+    pub(crate) eval_root: Option<Arc<std::path::PathBuf>>,
 }
 
 /// Allowed `Host` header values, built at router-build time from the
@@ -121,6 +126,7 @@ pub fn run_server(
     quiet: bool,
     auth: AuthMode,
     daemon_socket: Option<std::path::PathBuf>,
+    eval_root: Option<std::path::PathBuf>,
 ) -> Result<()> {
     let _span = tracing::info_span!("serve", addr = %bind_addr).entered();
 
@@ -136,6 +142,7 @@ pub fn run_server(
         blocking_permits: Arc::new(tokio::sync::Semaphore::new(permits)),
         last_request_epoch: Arc::clone(&last_request_epoch),
         daemon_socket: daemon_socket.map(Arc::new),
+        eval_root: eval_root.map(Arc::new),
     };
     let allowed_hosts = allowed_host_set(&bind_addr);
     let idle_minutes = crate::limits::serve_idle_minutes();
@@ -385,6 +392,7 @@ pub(crate) fn build_router(state: AppState, allowed_hosts: AllowedHosts, auth: A
         .route("/api/embed/2d", get(handlers::cluster_2d))
         .route("/api/search", get(handlers::search))
         .route("/api/search_legs", get(handlers::search_legs))
+        .route("/api/eval_gold", get(handlers::eval_gold))
         .route("/", get(assets::index_html))
         .route("/static/{*path}", get(assets::static_asset))
         .with_state(state);

--- a/src/serve/tests.rs
+++ b/src/serve/tests.rs
@@ -98,6 +98,10 @@ fn fixture_state() -> Fixture {
             // No daemon socket in the handler-shape tests — mechanism mode
             // (`/api/search_legs`) is exercised by its own dedicated tests.
             daemon_socket: None,
+            // The eval-gold tour route has its own dedicated tests that supply
+            // a temp `eval_root`; the handler-shape fixtures leave it unset so
+            // `/api/eval_gold` 503s (its structurally-unavailable path).
+            eval_root: None,
         }),
         _dir: Some(dir),
     }
@@ -240,6 +244,10 @@ fn populated_fixture(n_chunks: usize, with_umap: bool) -> Fixture {
             // No daemon socket in the handler-shape tests — mechanism mode
             // (`/api/search_legs`) is exercised by its own dedicated tests.
             daemon_socket: None,
+            // The eval-gold tour route has its own dedicated tests that supply
+            // a temp `eval_root`; the handler-shape fixtures leave it unset so
+            // `/api/eval_gold` 503s (its structurally-unavailable path).
+            eval_root: None,
         }),
         _dir: Some(dir),
     }
@@ -324,6 +332,10 @@ fn single_chunk_fixture(content: &str, vendored: bool) -> (Fixture, String) {
             // No daemon socket in the handler-shape tests — mechanism mode
             // (`/api/search_legs`) is exercised by its own dedicated tests.
             daemon_socket: None,
+            // The eval-gold tour route has its own dedicated tests that supply
+            // a temp `eval_root`; the handler-shape fixtures leave it unset so
+            // `/api/eval_gold` 503s (its structurally-unavailable path).
+            eval_root: None,
         }),
         _dir: Some(dir),
     };
@@ -656,6 +668,7 @@ async fn index_html_loads_view_modules() {
         "hierarchy-depth",
         "cluster-controls",
         "cluster-color",
+        "gold-tour",
     ] {
         assert!(
             body.contains(needle),
@@ -2570,4 +2583,212 @@ fn auth_banner_non_tty_omits_token_and_hints() {
         joined.contains("per-launch") && joined.contains("terminal"),
         "non-TTY banner must hint that the token is per-launch and terminal-only: {joined}"
     );
+}
+
+// ─── /api/eval_gold (Stage-2b tour driver) ───────────────────────────────────
+
+/// Build a fixture whose store carries chunks at the given `(origin, name)`
+/// pairs and whose `eval_root` points at a temp dir holding `eval_json` as
+/// `evals/queries/v3_test.v2.json`. Returns the `Fixture` (owns the store dir +
+/// drop discipline) and the eval-root `TempDir` (caller keeps it alive for the
+/// request). Separate dirs because `Fixture` holds only one.
+fn eval_gold_fixture(chunks: &[(&str, &str)], eval_json: &str) -> (Fixture, TempDir) {
+    let store_dir = TempDir::new().expect("store tempdir");
+    let db_path = store_dir.path().join(crate::INDEX_DB_FILENAME);
+    let path_for_setup = db_path.clone();
+    let chunks_owned: Vec<(String, String)> = chunks
+        .iter()
+        .map(|(o, n)| (o.to_string(), n.to_string()))
+        .collect();
+    let ro = std::thread::spawn(move || {
+        let store = Store::open(&path_for_setup).expect("open RW");
+        store.init(&ModelInfo::default()).expect("init");
+        let dim = store.dim();
+        for (i, (origin, name)) in chunks_owned.iter().enumerate() {
+            let content = format!("fn {name}() {{ /* body */ }}");
+            let hash = blake3::hash(content.as_bytes()).to_hex().to_string();
+            let chunk = Chunk {
+                id: format!("{origin}:1:{}:{i}", &hash[..8]),
+                file: PathBuf::from(origin),
+                language: Language::Rust,
+                chunk_type: ChunkType::Function,
+                name: name.clone(),
+                signature: format!("fn {name}()"),
+                content,
+                doc: None,
+                line_start: 1,
+                line_end: 5,
+                byte_start: 0,
+                content_hash: hash,
+                canonical_hash: String::new(),
+                parent_id: None,
+                window_idx: None,
+                parent_type_name: None,
+                parser_version: 0,
+            };
+            let mut v = vec![0.0f32; dim];
+            if !v.is_empty() {
+                v[i % dim] = 1.0;
+            }
+            store
+                .upsert_chunk(&chunk, &Embedding::new(v), Some(100))
+                .unwrap();
+        }
+        drop(store);
+        Store::open_readonly(&path_for_setup).expect("open RO")
+    })
+    .join()
+    .expect("OS thread join");
+
+    let eval_dir = TempDir::new().expect("eval tempdir");
+    let queries_dir = eval_dir.path().join("evals").join("queries");
+    std::fs::create_dir_all(&queries_dir).expect("mkdir evals/queries");
+    std::fs::write(queries_dir.join("v3_test.v2.json"), eval_json).expect("write eval json");
+
+    let fixture = Fixture {
+        state: Some(AppState {
+            store: Arc::new(ro),
+            blocking_permits: Arc::new(tokio::sync::Semaphore::new(
+                crate::limits::serve_blocking_permits(),
+            )),
+            last_request_epoch: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            daemon_socket: None,
+            eval_root: Some(Arc::new(eval_dir.path().to_path_buf())),
+        }),
+        _dir: Some(store_dir),
+    };
+    (fixture, eval_dir)
+}
+
+async fn get_json(app: axum::Router, uri: &str) -> (StatusCode, serde_json::Value) {
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(uri)
+                .header("host", "127.0.0.1:8080")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("oneshot");
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+    (status, json)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn eval_gold_resolves_golds_and_drops_unusable() {
+    // Two resolvable golds (chunks inserted), one dead gold (origin/name absent
+    // from the index), one query with no gold_chunk, one with an empty origin.
+    // Expect: 3 queries kept (the two no-gold/empty-origin dropped), 2 resolved,
+    // canonical category order, dead gold present with empty ids.
+    let eval_json = r#"{"queries":[
+        {"query":"method implementations on the Store struct","category":"type_filtered","gold_chunk":{"origin":"src/store/query.rs","name":"search_filtered"}},
+        {"query":"reciprocal rank fusion","category":"conceptual_search","gold_chunk":{"origin":"src/search/fusion.rs","name":"rrf_fuse"}},
+        {"query":"two step vanished gold","category":"multi_step","gold_chunk":{"origin":"src/gone.rs","name":"vanished"}},
+        {"query":"no gold here","category":"negation"},
+        {"query":"empty origin gold","category":"negation","gold_chunk":{"origin":"","name":"x"}}
+    ]}"#;
+    let (fixture, _eval_dir) = eval_gold_fixture(
+        &[
+            ("src/store/query.rs", "search_filtered"),
+            ("src/search/fusion.rs", "rrf_fuse"),
+        ],
+        eval_json,
+    );
+    let app = test_router(fixture.state());
+    let (status, json) = get_json(app, "/api/eval_gold").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        json["total"].as_u64(),
+        Some(3),
+        "two unusable queries dropped"
+    );
+    assert_eq!(json["resolved"].as_u64(), Some(2), "dead gold not resolved");
+
+    let cats: Vec<&str> = json["categories"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert_eq!(
+        cats,
+        vec!["type_filtered", "conceptual_search", "multi_step"],
+        "categories must be in canonical order, negation dropped (its queries were unusable)"
+    );
+
+    let queries = json["queries"].as_array().unwrap();
+    assert_eq!(queries.len(), 3);
+
+    // Resolvable gold: at least one id, prefixed by its origin.
+    let store_q = queries
+        .iter()
+        .find(|q| q["gold_name"] == "search_filtered")
+        .expect("search_filtered query present");
+    let ids = store_q["gold_chunk_ids"].as_array().unwrap();
+    assert_eq!(ids.len(), 1, "exactly one chunk matches the gold");
+    assert!(
+        ids[0].as_str().unwrap().starts_with("src/store/query.rs:"),
+        "resolved id must belong to the gold origin: {:?}",
+        ids[0]
+    );
+
+    // Dead gold: kept but unresolved (empty ids), not faked.
+    let dead = queries
+        .iter()
+        .find(|q| q["gold_name"] == "vanished")
+        .expect("dead gold query present");
+    assert_eq!(
+        dead["gold_chunk_ids"].as_array().unwrap().len(),
+        0,
+        "dead gold must resolve to no ids, not a fabricated rank"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn eval_gold_503_when_no_root() {
+    // The default handler-shape fixture leaves eval_root unset → structurally
+    // unavailable → clean 503, never a 500 or an empty 200.
+    let fixture = fixture_state();
+    let app = test_router(fixture.state());
+    let (status, _json) = get_json(app, "/api/eval_gold").await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn eval_gold_503_when_fixtures_absent() {
+    // eval_root is set but the dir holds no evals/queries fixtures → 503, so the
+    // tour degrades to "no eval set here" rather than a misleading empty success.
+    let store_dir = TempDir::new().expect("store tempdir");
+    let db_path = store_dir.path().join(crate::INDEX_DB_FILENAME);
+    let path_for_setup = db_path.clone();
+    let ro = std::thread::spawn(move || {
+        let store = Store::open(&path_for_setup).expect("open RW");
+        store.init(&ModelInfo::default()).expect("init");
+        drop(store);
+        Store::open_readonly(&path_for_setup).expect("open RO")
+    })
+    .join()
+    .expect("OS thread join");
+    let empty_root = TempDir::new().expect("empty eval root");
+    let fixture = Fixture {
+        state: Some(AppState {
+            store: Arc::new(ro),
+            blocking_permits: Arc::new(tokio::sync::Semaphore::new(
+                crate::limits::serve_blocking_permits(),
+            )),
+            last_request_epoch: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            daemon_socket: None,
+            eval_root: Some(Arc::new(empty_root.path().to_path_buf())),
+        }),
+        _dir: Some(store_dir),
+    };
+    let app = test_router(fixture.state());
+    let (status, _json) = get_json(app, "/api/eval_gold").await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
 }

--- a/src/store/serve_queries.rs
+++ b/src/store/serve_queries.rs
@@ -579,6 +579,52 @@ impl<Mode> Store<Mode> {
         })
     }
 
+    /// Resolve a set of chunk names to `(id, origin, name)` rows in the current
+    /// index. Backs the eval-gold tour's gold→chunk_id mapping
+    /// (`GET /api/eval_gold`): the eval files pin a gold by `(origin, name)`, but
+    /// chunk ids drift across reindexes (line numbers, content hashes), so the
+    /// pinned `gold_chunk.id` cannot be trusted. The caller filters the returned
+    /// rows by `origin` to build a robust `(origin, name) -> [id]` map against the
+    /// *served* index — the same (origin, name) match key the eval harness uses.
+    ///
+    /// Scoped to the gold names (a bounded ~hundreds set), not the whole corpus,
+    /// and IN-list chunked so a name set larger than SQLite's bind-variable cap
+    /// can't overflow the cursor. Duplicate names across chunks return one row
+    /// each (overloads / same-named chunks in different files); the caller keeps
+    /// all and disambiguates by origin.
+    pub(crate) fn serve_resolve_origin_names(
+        &self,
+        names: &[&str],
+    ) -> Result<Vec<(String, String, String)>, StoreError> {
+        let _span = tracing::info_span!("serve_resolve_origin_names").entered();
+        if names.is_empty() {
+            return Ok(Vec::new());
+        }
+        self.rt.block_on(async {
+            use crate::store::helpers::sql::max_rows_per_statement;
+            // One bind per name in the IN-list.
+            const NAME_CHUNK: usize = max_rows_per_statement(1);
+            let mut out: Vec<(String, String, String)> = Vec::new();
+            for chunk in names.chunks(NAME_CHUNK) {
+                let placeholders = vec!["?"; chunk.len()].join(",");
+                let sql =
+                    format!("SELECT id, origin, name FROM chunks WHERE name IN ({placeholders})");
+                let mut q = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()));
+                for n in chunk {
+                    q = q.bind(*n);
+                }
+                let rows = q.fetch_all(&self.pool).await?;
+                for row in rows {
+                    let id: String = row.get("id");
+                    let origin: String = row.get("origin");
+                    let name: String = row.get("name");
+                    out.push((id, origin, name));
+                }
+            }
+            Ok(out)
+        })
+    }
+
     /// Fetch the four corpus counts for `GET /api/stats` in one round-trip.
     pub(crate) fn serve_stats(&self) -> Result<StatsRow, StoreError> {
         let _span = tracing::info_span!("serve_stats").entered();


### PR DESCRIPTION
## SPLADE viz Stage 2b — eval-gold "where hybrid wins" stratified tour + R@K-delta panel

Builds on Stage 1 (the `search_legs` backend, #2060) and Stage 2a (query-anchored mechanism step-through, #2065). This is the payoff: drive the cluster-3d view from the eval gold to *show* where SPLADE fusion rescues a dense-alone miss vs where it hurts.

### Backend
- **`GET /api/eval_gold`** — serves the v3.v2 eval set (218 golds, both splits) as `{query, category, split, gold_origin, gold_name, gold_chunk_ids}`. Gold is pinned by `(origin, name)` and resolved to **current** chunk ids against the served index (the same match key the eval harness uses — robust to id drift, never trusts the fixture's stale id). Degrades to a clean 503 when no root resolved / fixtures absent.
- `Store::serve_resolve_origin_names` — batched `(origin,name)→[id]` resolution.
- `run_server` threads the served project root for the fixture read.

### Frontend (`cluster-3d.js`, additive)
- **Gold-tour mode** beside the Stage 2a mechanism mode (mutually exclusive). Stratified walk: one anchor per category across **all 8 including the zero/negative-uplift ones** (conceptual_search, multi_step) — the honest negatives the design mandates. Per anchor it fetches `/api/search_legs`, finds the gold's dense-leg vs fused-leg rank, and renders the win as **TEXT** (`gold: dense #121 → fused #2  + rescued`) on a dimmed base, never a per-chunk color.
- **R@K-delta panel** — sweeps the full gold set and shows the per-category net (rescued − hurt) @K=5, explicitly including the negative category. Incremental, cancellable, aborts on daemon-down.
- Daemon-down (503) and "fusion did not run" render gracefully; existing color-by-type/language, name-search, and Stage 2a mode unchanged.

### Live verification (against the real daemon)
`/api/eval_gold` → **218/218 resolved**, all 8 categories. The showcase deltas reproduce the measured ground truth exactly:

| query | dense → fused |
|---|---|
| method implementations on the Store struct | 121 → 2 (rescue) |
| Display trait implementation | 69 → 4 (rescue) |
| reciprocal rank fusion | 4 → 24 (hurt) |
| content based fingerprinting | 2 → 8 (hurt) |

These match the standalone legs analysis (net +21 rescued / −12 hurt @5; type_filtered +4, conceptual_search −4). The legs analysis also confirmed the SPLADE "conceptual tax" does NOT survive the full production pipeline (per-category α sweep flat) — so the router needs no retune; the viz teaches the mechanism, orthogonal to tuning.

### Gates
Serve suite 105/105 (incl. 3 new `eval_gold` route tests: resolution + dead-gold + 503 paths). `clippy --all-targets --features cuda-index` clean, `fmt --check` clean, provenance clean. Live-smoked end-to-end on the real index.
