### PR TITLE
chore: Release v1.51.0 (SPLADE viz Stage 2b + 4 red-team security fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.51.0] - 2026-06-28
+
+The SPLADE-viz Stage 2b feature plus four security fixes from a post-v1.50.1 red-team pass (4 confirmed findings / 0 false positives across serve / MCP / relay / parse / path). The scoring path is byte-identical to v1.50.1 (the diff touches only the injection scanner, the read/serve relay surfaces, and docs) — retrieval is unchanged (47.2 / 70.7 / 86.7 R@1/R@5/R@20).
+
 ### Added
 
-- **SPLADE-viz Stage 2b — eval-gold "where hybrid wins" tour + R@K-delta panel.** Builds on the Stage 1 `search_legs` backend and the Stage 2a mechanism step-through. A new `GET /api/eval_gold` route serves the v3.v2 eval set (218 golds) resolved to current chunk ids (by `(origin, name)`, the eval harness's match key), and the cluster-3d view gains a **gold-tour mode**: a stratified walk — one anchor per category, *including* the zero/negative-uplift ones (conceptual_search, multi_step) — that fetches the legs per gold and renders the dense-leg→fused-leg rank movement as text on a dimmed base (`gold: dense #121 → fused #2 + rescued`), plus an **R@K-delta panel** showing the per-category net (rescued − hurt) @K=5. The standalone legs analysis it visualizes: SPLADE fusion nets **+9 queries @5** (21 rescued / 12 hurt) over dense-alone, winning on literal/structural/type queries (type_filtered +4) and losing on conceptual ones (conceptual_search −4) — and a per-category α sweep confirmed that tax does **not** survive the full production pipeline (FTS/RRF + MMR + boosts), so no retune is warranted; the viz teaches the mechanism, orthogonal to tuning.
+- **SPLADE-viz Stage 2b — eval-gold "where hybrid wins" tour + R@K-delta panel.** Builds on the Stage 1 `search_legs` backend and the Stage 2a mechanism step-through. A new `GET /api/eval_gold` route serves the v3.v2 eval set (218 golds) resolved to current chunk ids (by `(origin, name)`, the eval harness's match key), and the cluster-3d view gains a **gold-tour mode**: a stratified walk — one anchor per category, *including* the zero/negative-uplift ones (conceptual_search, multi_step) — that fetches the legs per gold and renders the dense-leg→fused-leg rank movement as text on a dimmed base (`gold: dense #121 → fused #2 + rescued`), plus an **R@K-delta panel** showing the per-category net (rescued − hurt) @K=5. The standalone legs analysis it visualizes: SPLADE fusion nets **+9 queries @5** (21 rescued / 12 hurt) over dense-alone, winning on literal/structural/type queries (type_filtered +4) and losing on conceptual ones (conceptual_search −4) — and a per-category α sweep confirmed that tax does **not** survive the full production pipeline (FTS/RRF + MMR + boosts), so no retune is warranted; the viz teaches the mechanism, orthogonal to tuning. Builds on the Stage 1 `search_legs` backend and the Stage 2a mechanism step-through. A new `GET /api/eval_gold` route serves the v3.v2 eval set (218 golds) resolved to current chunk ids (by `(origin, name)`, the eval harness's match key), and the cluster-3d view gains a **gold-tour mode**: a stratified walk — one anchor per category, *including* the zero/negative-uplift ones (conceptual_search, multi_step) — that fetches the legs per gold and renders the dense-leg→fused-leg rank movement as text on a dimmed base (`gold: dense #121 → fused #2 + rescued`), plus an **R@K-delta panel** showing the per-category net (rescued − hurt) @K=5. The standalone legs analysis it visualizes: SPLADE fusion nets **+9 queries @5** (21 rescued / 12 hurt) over dense-alone, winning on literal/structural/type queries (type_filtered +4) and losing on conceptual ones (conceptual_search −4) — and a per-category α sweep confirmed that tax does **not** survive the full production pipeline (FTS/RRF + MMR + boosts), so no retune is warranted; the viz teaches the mechanism, orthogonal to tuning.
 
 ### Security
 
@@ -3928,6 +3932,7 @@ Second 14-category audit completed (117 findings). 107 of 109 actionable finding
 - CLI commands: init, doctor, index, stats, serve
 - Filter by language (`-l`) and path pattern (`-p`)
 
+[1.51.0]: https://github.com/jamie8johnson/cqs/compare/v1.50.1...v1.51.0
 [1.50.1]: https://github.com/jamie8johnson/cqs/compare/v1.50.0...v1.50.1
 [1.50.0]: https://github.com/jamie8johnson/cqs/compare/v1.49.0...v1.50.0
 [1.49.0]: https://github.com/jamie8johnson/cqs/compare/v1.48.0...v1.49.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -451,7 +451,7 @@ src/
     query.rs    - Query normalization for training pairs
   serve/        - `cqs serve` web UI (gated on `serve` feature; axum + tower)
     mod.rs      - run_server, build_router, server wiring
-    handlers.rs - axum route handlers (search, search_legs, graph, hierarchy, cluster, chunk detail); each emits a tracing event and wraps sync Store calls in spawn_blocking
+    handlers.rs - axum route handlers (search, search_legs, eval_gold, graph, hierarchy, cluster, chunk detail); each emits a tracing event and wraps sync Store calls in spawn_blocking
     daemon_client.rs - Synchronous client of the retrieval daemon socket; `/api/search_legs` (SPLADE-fusion inspector) forwards to the daemon rather than loading the embedder/index into the web process
     data.rs     - Wire-format types + builders for `/api/*` (Node/Edge shapes matching Cytoscape.js element-data convention); wire-shaping only — SQL lives in store/serve_queries.rs
     error.rs    - HTTP-side error type wrapping StoreError → 4xx/5xx responses (incl. 503 ServiceUnavailable for daemon-down mechanism mode)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "1.50.1"
+version = "1.51.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,10 @@ members = ["cqs-macros"]
 
 [package]
 name = "cqs"
-version = "1.50.1"
+version = "1.51.0"
 edition = "2021"
 rust-version = "1.96"
-description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 54 languages + L5X/L5K PLC exports. 70.7% R@5 / 47.2% R@1 / 86.7% R@20 on v3.v2 dual-judge code-search (218 queries, EmbeddingGemma-300m default with per-category SPLADE α; 2026-06-26 snapshot, scoring unchanged through v1.50.1). Daemon mode (3-19ms queries). MCP server (`cqs mcp`, 30 read tools). Local-first, GPU-accelerated."
+description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 54 languages + L5X/L5K PLC exports. 70.7% R@5 / 47.2% R@1 / 86.7% R@20 on v3.v2 dual-judge code-search (218 queries, EmbeddingGemma-300m default with per-category SPLADE α; 2026-06-26 snapshot, scoring unchanged through v1.51.0). Daemon mode (3-19ms queries). MCP server (`cqs mcp`, 30 read tools). Local-first, GPU-accelerated."
 license = "MIT"
 repository = "https://github.com/jamie8johnson/cqs"
 homepage = "https://github.com/jamie8johnson/cqs"


### PR DESCRIPTION
## Release v1.51.0

The **SPLADE-viz Stage 2b** feature + **four security fixes** from a post-v1.50.1 red-team pass.

### Stage 2b (Added)
The eval-gold "where hybrid wins" stratified tour + R@K-delta panel: a new `/api/eval_gold` route + a cluster-3d gold-tour mode that shows, per gold query, the dense-leg→fused-leg rank movement (rescued vs hurt), stratified across all 8 categories including the zero/negative-uplift ones. Live-verified: the showcase deltas (121→2, 69→4, 4→24, 2→8) reproduce the standalone legs analysis exactly.

### Security (4 red-team findings, all confirmed / 0 false-positive)
- Leading-directive heuristic missed the canonical `ignore all previous instructions` (filler "all" defeated the exact-prefix match) — now a normalized kill-verb family.
- Comment-marker strip-set omitted `/*` `/**` `--` `%` `;` — a directive behind them was relayed unflagged.
- Full-file `cqs read` relayed the whole file verbatim with no scan — now scans the exact relayed bytes.
- `/api/search_legs` forwarded the client query with no `--` separator (flag-injection) — now flags-first + `--` + query.

The heuristic widening was empirically proven inert: **0 newly-flagged chunks** on the real 17.5k-chunk corpus. SECURITY.md updated.

### Recall — carries unchanged
The scoring path is **byte-identical to v1.50.1** (the diff touches only the injection scanner, the read/serve relay surfaces, and docs — the `src/search/scoring` / embedder / `query.rs` / fusion diff is empty). So **47.2 / 70.7 / 86.7** (R@1/R@5/R@20) carries — no recall A/B needed (the empty diff is stronger proof than an eval run with HNSW noise).

### Gates
Full suite **841 passed, 0 failed**; `clippy --all-targets --features cuda-index` clean; `fmt --check` clean; provenance clean. A `release.yml` **cross-build dry-run** (all 3 targets) runs before tagging — the v1.50.0 lesson.

After merge: dry-run-green → tag `v1.51.0` → release.yml binaries + GitHub release → `cargo publish` → deploy (security fixes + viz to the daemon).
