### PR TITLE
chore(deps): batch 6 Dependabot patch bumps + de-flake umap tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -134,14 +134,14 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arrayref"
@@ -661,7 +661,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -830,7 +830,7 @@ dependencies = [
  "hnsw_rs",
  "httpmock",
  "ignore",
- "indicatif 0.18.4",
+ "indicatif 0.18.5",
  "insta",
  "libc",
  "log",
@@ -1217,7 +1217,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1354,7 +1354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2209,9 +2209,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.18.4"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+checksum = "993f007684f2e9727160da8b960ec161264703bfd1af084fd2e34d040c9a0dd4"
 dependencies = [
  "console 0.16.2",
  "portable-atomic",
@@ -2541,9 +2541,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -2755,7 +2755,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3606,7 +3606,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3665,7 +3665,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3706,9 +3706,9 @@ dependencies = [
 
 [[package]]
 name = "rustyline"
-version = "18.0.0"
+version = "18.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a990b25f351b25139ddc7f21ee3f6f56f86d6846b74ac8fad3a719a287cd4a0"
+checksum = "53f6a737db68eb1a8ccff86b584b2fc13eca6a7bb6f78ebc7c529547e3ab9684"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
@@ -4079,7 +4079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4336,10 +4336,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4436,7 +4436,7 @@ dependencies = [
  "esaxx-rs",
  "getrandom 0.3.4",
  "hf-hub",
- "indicatif 0.18.4",
+ "indicatif 0.18.5",
  "itertools",
  "log",
  "macro_rules_attribute",
@@ -4698,9 +4698,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.9"
+version = "0.26.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dab76d0b724ba557954125188cf0633a1ca43199ced82d95c7b9c32cc3de1f3"
+checksum = "3c343ed63e3f5c64d1acdecb5d2c13d4e169cb5fde0052106ebaa6c6f27f9e55"
 dependencies = [
  "cc",
  "regex",
@@ -5378,9 +5378,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -5647,7 +5647,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/src/cli/commands/index/umap.rs
+++ b/src/cli/commands/index/umap.rs
@@ -769,6 +769,7 @@ mod tests {
     /// paths so the test is portable across the dev workstation and CI
     /// runners that lack umap-learn.
     #[test]
+    #[serial]
     fn run_umap_projection_returns_zero_for_empty_corpus() {
         let (store, db_path, _tmp) = fresh_empty_store(8);
         let result = run_umap_projection(&store, &db_path, true);
@@ -803,6 +804,7 @@ mod tests {
     /// temp dir available (the normal case on this workstation) the decision
     /// is `StageVia`.
     #[test]
+    #[serial]
     fn decide_staging_wsl_mount_selects_staging_when_fast_disk_available() {
         let slow_db = Path::new("/mnt/c/Projects/cqs/.cqs/slots/gemma/index.db");
         // Only meaningful when this host actually exposes a fast temp dir
@@ -908,6 +910,7 @@ mod tests {
     /// — including data still resident in the WAL at copy time, which the
     /// copy's read-only open replays.
     #[test]
+    #[serial]
     fn staged_read_matches_direct_read() {
         let dim = 8usize;
         let (store, db_path, _tmp) = fresh_empty_store(dim);
@@ -956,6 +959,7 @@ mod tests {
     /// eagerly (the `TempPath` only owns the main `.db`); a regression there
     /// would silently accumulate files across repeated `--umap` runs.
     #[test]
+    #[serial]
     fn staged_copy_cleans_up_sidecars() {
         let dim = 8usize;
         let (store, db_path, _tmp) = fresh_empty_store(dim);


### PR DESCRIPTION
## Batch 6 Dependabot patch bumps + de-flake umap tests

Supersedes Dependabot PRs **#2092–#2097** (combined into one branch → one CI run; they auto-close on merge). All six are range-spec'd in `Cargo.toml`, so this is `Cargo.lock`-only:

| crate | bump |
|---|---|
| tree-sitter | 0.26.9 → 0.26.10 |
| uuid | 1.23.3 → 1.23.4 |
| rustyline | 18.0.0 → 18.0.1 |
| anyhow | 1.0.102 → 1.0.103 |
| indicatif | 0.18.4 → 0.18.5 |
| memmap2 | 0.9.10 → 0.9.11 |

tree-sitter is the only behaviorally-sensitive one (parser runtime); the full test suite (parser extraction tests) gates it — green.

## Bonus: de-flake pre-existing umap test-isolation bug

The full-suite verification surfaced a flake (2 umap tests failed under parallel load, passed 3/3 in isolation). Root cause: four umap tests read `XDG_RUNTIME_DIR`/`TMPDIR` (via `decide_staging`/`run_umap_projection` → `pick_fast_temp_dir`) without `#[serial]`, so they raced the serial tests that *set* those vars to `/mnt/c/slow-*` and intermittently read the polluted value. Added `#[serial]` to the four readers — the umap module now passes **4/4 parallel runs**. Pre-existing (the umap tests are from v1.50.0's #2067/#2069), unrelated to the dep bumps; fixed here since this verification surfaced it.

## Gates
`cargo build` + `clippy --all-targets --features cuda-index` clean; full suite green (the 2 failures were the flake, now fixed); provenance clean.
