### PR TITLE
docs(agents): fable access restored — revert the export-order opus override

### DIFF
--- a/.claude/agents/adequacy-auditor.md
+++ b/.claude/agents/adequacy-auditor.md
@@ -1,7 +1,7 @@
 ---
 name: adequacy-auditor
 description: Meta adversary - finds where the test suite's own assertions don't bite, via mutation testing. A green suite is consistent with a test that asserts nothing; this is the only auditor that turns the lens on the suite itself. Dispatch after a logic-dense change with tests that LOOK thorough, during audits, or from /idle. Writes the killing test; deliverable is a surviving mutant (a vacuous test) or a hardened assertion. (#1826 family - the meta-null; enumerable, so it gets the Agent tool.)
-# fable is the to-restore reviewer default; this lane writes code, so opus.
+# implementation lane (writes durable guards/tests), so opus; fable is the review/judge seat
 model: opus
 tools: Bash, Read, Write, Edit, Glob, Grep, Agent
 ---

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,8 +1,7 @@
 ---
 name: code-reviewer
 description: "Review current diff for risk, impact, and correctness before commit/PR"
-# fable is the to-restore default; disabled 2026-06-12 by US export order, opus until it returns
-model: opus
+model: fable
 tools:
   - Bash
   - Read

--- a/.claude/agents/interleaving-auditor.md
+++ b/.claude/agents/interleaving-auditor.md
@@ -1,7 +1,7 @@
 ---
 name: interleaving-auditor
 description: Concurrency adversary - finds an interleaving where two individually-correct operations, run concurrently, leave a shared invariant broken. Orthogonal to the house happy/sad-path signature (which runs everything single-threaded); dispatch after a change to the daemon caches / epochs / watch loop, during audits, or from the idle loop. Writes loom models and stress harnesses; the deliverable is a reproducing interleaving (a race) or a durable concurrency test. (#1826)
-# fable is the to-restore reviewer default; this lane writes code + judges, so opus.
+# implementation lane (writes loom models + stress harnesses), so opus; fable is the review/judge seat
 model: opus
 tools: Bash, Read, Write, Edit, Glob, Grep
 ---

--- a/.claude/agents/legacy-state-auditor.md
+++ b/.claude/agents/legacy-state-auditor.md
@@ -1,7 +1,7 @@
 ---
 name: legacy-state-auditor
 description: Version adversary - finds where current code mishandles persisted state that only a PAST version (or external mutation) could have written. The per-unit suite is structurally blind to it because every fixture is born at the current version, so a shape the current code cannot itself produce is unreachable. Dispatch after a schema migration, a PARSER_VERSION / format / wire-version bump, a sidecar-header change, or a new-field-with-default. Writes a frozen-artifact guard; the deliverable is a mishandled old shape (a bug) or a durable old-format fixture test. (#1826 family - the fifth orthogonal shape.)
-# fable is the to-restore reviewer default; this lane writes code, so opus.
+# implementation lane (writes frozen-artifact guards), so opus; fable is the review/judge seat
 model: opus
 tools: Bash, Read, Write, Edit, Glob, Grep
 ---

--- a/.claude/agents/property-auditor.md
+++ b/.claude/agents/property-auditor.md
@@ -1,7 +1,7 @@
 ---
 name: property-auditor
 description: Property-based testing lane (proptest) - lives in the null between hand-written examples by generating valid inputs and asserting an algebraic invariant over ALL of them. Orthogonal to the house happy/sad-path signature; dispatch during audits, after a codec/round-trip/equivalence-shaped change, or from the idle loop. Writes proptest generators + properties; the deliverable is a falsifying input (a bug) or a durable property test. (#1826)
-# fable is the to-restore reviewer default; this lane writes code, so opus.
+# implementation lane (writes proptest generators + properties), so opus; fable is the review/judge seat
 model: opus
 tools: Bash, Read, Write, Edit, Glob, Grep
 ---

--- a/.claude/agents/seam-auditor.md
+++ b/.claude/agents/seam-auditor.md
@@ -1,8 +1,7 @@
 ---
 name: seam-auditor
-description: Composition adversary - finds two correct units whose join lies. Orthogonal to the house happy/sad-path signature; dispatch during audits, after multi-lane merges, or from the idle loop. Fable-seated (pure judgment work) — but fable is disabled 2026-06-12 by US export order, so opus-seated until it returns.
-# fable is the to-restore default; disabled 2026-06-12 by US export order, opus until it returns
-model: opus
+description: Composition adversary - finds two correct units whose join lies. Orthogonal to the house happy/sad-path signature; dispatch during audits, after multi-lane merges, or from the idle loop. Fable-seated (pure judgment work).
+model: fable
 tools: Bash, Read, Glob, Grep
 ---
 

--- a/.claude/agents/spec-fidelity-auditor.md
+++ b/.claude/agents/spec-fidelity-auditor.md
@@ -1,8 +1,7 @@
 ---
 name: spec-fidelity-auditor
 description: Oracle adversary - finds a green, mutation-killing test whose ASSERTION contradicts an authoritative external contract. Covers the adequacy/meta-null's own null: mutation testing proves a test BITES, never that it asserts the RIGHT thing. Dispatch after a spec/contract change (SECURITY.md/PRIVACY.md/README/a stated invariant), during audits, or whenever a doc and a test could have drifted apart. Read-only; the find is the deliverable.
-# fable is the to-restore default; disabled 2026-06-12 by US export order, opus until it returns
-model: opus
+model: fable
 tools: Bash, Read, Glob, Grep
 ---
 

--- a/.claude/agents/sweep-auditor.md
+++ b/.claude/agents/sweep-auditor.md
@@ -1,7 +1,7 @@
 ---
 name: sweep-auditor
 description: Completeness adversary - finds the member of a should-be-uniform set that diverged (the incomplete sweep: a change applied to N-1 of N sites). Orthogonal to the house happy/sad-path signature AND to the seam/property/interleaving trio - their nulls are joins, input spaces, and schedules; this null is the relation across a SET of peers. Dispatch after a migration / rename / new-variant / dual-surface change, during audits, or from the idle loop. Writes a completeness guard; the deliverable is a straggler (a bug) or a durable exhaustiveness test. (#1826 family - the fourth orthogonal shape.)
-# fable is the to-restore reviewer default; this lane writes code, so opus.
+# implementation lane (writes completeness guards), so opus; fable is the review/judge seat
 model: opus
 tools: Bash, Read, Write, Edit, Glob, Grep
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,8 +185,7 @@ Use teams when dispatching 2+ agents that need coordination. Teams provide task 
 
 **Conventions:**
 - Name teams by purpose: `audit-batch-1`, `feat-streaming`, `refactor-errors`
-- ⚠️ **FABLE DISABLED 2026-06-12 by US export order (temporary, no timeline).** Until access is restored, **every `fable` below is overridden to `opus`** — wherever this file, a skill, or an agent def says to dispatch fable (reviews, seam-audits, audit finders, orchestration/judge passes), use opus instead. Dispatching fable now fails mid-run and wastes the lane. Revert to the split below when an announcement or a successful fable dispatch confirms it's back; don't assume restoration from silence.
-- Model split: `opus` implements, `fable` orchestrates/reviews/audits. EXCEPTION: security lanes (audit Security category, /red-team, security reviews) stay `opus`. Sonnet only for mechanical test-only tasks; haiku for doc-only edits.
+- Model split: `opus` implements, `fable` orchestrates/reviews/audits. EXCEPTION: security lanes (audit Security category, /red-team, security reviews) stay `opus`. Sonnet only for mechanical test-only tasks; haiku for doc-only edits. (Fable was disabled 2026-06-12–2026-07-01 by a US export order, since lifted; this split is the restored default.)
 - Always clean up teams when done (`Teammate cleanup`)
 - Teammates can't see your text output — use `SendMessage` to communicate
 


### PR DESCRIPTION
## Fable access restored — revert the export-order override

The US export-control order on Fable 5 + Mythos was lifted 2026-07-01. Restoration confirmed by the override's own stated criterion: a successful Fable dispatch (this session runs on Fable 5), not silence.

Reverts b2bda86e (#1852):
- **CLAUDE.md** — the ⚠️ FABLE DISABLED banner removed; the model split (`opus` implements, `fable` orchestrates/reviews/audits, security lanes stay `opus`) is the standing default again, with a one-line historical note.
- **code-reviewer / seam-auditor / spec-fidelity-auditor** — `model:` back to `fable` (spec-fidelity was born during the block carrying the same to-restore marker).

The four skills (audit/idle/archeo/red-team) were never rewritten — the banner overrode them — so they resolve back to fable with no edit. The red-team/security opus-always exception predates the block and stands. Memory (MEMORY.md + reference_fable_disabled) updated in parallel outside the repo.

Docs-only.
